### PR TITLE
feat: multi-tier token lookup with env var fallback

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1203,6 +1203,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
 
 [[package]]
+name = "openssl-src"
+version = "300.5.4+3.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a507b3792995dae9b0df8a1c1e3771e8418b7c2d9f0baeba32e6fe8b06c7cb72"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "openssl-sys"
 version = "0.9.111"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1210,6 +1219,7 @@ checksum = "82cab2d520aa75e3c58898289429321eb788c3106963d0dc886ec7a5f4adc321"
 dependencies = [
  "cc",
  "libc",
+ "openssl-src",
  "pkg-config",
  "vcpkg",
 ]

--- a/crates/auth/src/lib.rs
+++ b/crates/auth/src/lib.rs
@@ -40,7 +40,7 @@ impl CredentialStore {
     }
 }
 
-/// Helper to construct a key for per-instance secrets.
-pub fn token_key(instance: &str, profile: &str) -> String {
-    format!("{instance}:{profile}")
+/// Helper to construct a key for profile secrets.
+pub fn token_key(profile: &str) -> String {
+    profile.to_string()
 }

--- a/crates/cli/src/commands/confluence/search.rs
+++ b/crates/cli/src/commands/confluence/search.rs
@@ -16,11 +16,6 @@ pub async fn search_cql(
 
     #[derive(Deserialize)]
     struct SearchResult {
-        content: Content,
-    }
-
-    #[derive(Deserialize)]
-    struct Content {
         id: String,
         title: String,
         #[serde(rename = "type")]
@@ -52,9 +47,9 @@ pub async fn search_cql(
         .results
         .iter()
         .map(|r| Row {
-            id: r.content.id.as_str(),
-            title: r.content.title.as_str(),
-            content_type: r.content.content_type.as_str(),
+            id: r.id.as_str(),
+            title: r.title.as_str(),
+            content_type: r.content_type.as_str(),
         })
         .collect();
 


### PR DESCRIPTION
## Summary

Adds environment variable token fallback and fixes deprecated API endpoints to resolve macOS Keychain integration issues.

## Changes

### Authentication Improvements
- ✅ **Multi-tier token lookup**: `ATLASSIAN_CLI_TOKEN_{PROFILE}` → `ATLASSIAN_API_TOKEN` → keyring
- ✅ **Keyring optional**: No longer fails when keyring unavailable
- ✅ **Simplified token storage**: Token key changed from `{base_url}:{profile}` to `{profile}`

### API Fixes
- ✅ **Bitbucket Cloud**: Use correct `https://api.bitbucket.org` endpoint
- ✅ **Jira Search**: Migrate from deprecated POST `/rest/api/3/search` to GET `/rest/api/3/search/jql`
- ✅ **Confluence Search**: Fix response structure parsing (removed incorrect `content` wrapper)

## Testing

Successfully tested with environment variable authentication:
- ✅ Jira: Retrieved 50 tickets assigned to user
- ✅ Confluence: Retrieved 32 pages/attachments created by user
- ✅ Auth commands: `auth list`, `auth test` working with env vars

## Usage

```bash
# Set profile-specific token
export ATLASSIAN_CLI_TOKEN_1="your-api-token"

# Or use generic fallback
export ATLASSIAN_API_TOKEN="your-api-token"

# Run commands normally
atlassian-cli --profile 1 jira search --jql "assignee = currentUser()"
atlassian-cli --profile 1 confluence search cql "creator = currentUser()"
```

## Breaking Changes

⚠️ **Users will need to re-authenticate**: Old keyring tokens stored with `{base_url}:{profile}` format are incompatible with new simplified `{profile}` format.

**Migration Options**:
1. Use environment variables (recommended for macOS users)
2. Run `auth login` again to store with new format

## Files Changed

- `crates/auth/src/lib.rs` - Simplified token_key()
- `crates/cli/src/main.rs` - Multi-tier token lookup, Bitbucket endpoint fix
- `crates/cli/src/commands/auth.rs` - Updated auth commands to use env var fallback
- `crates/cli/src/commands/jira/issues.rs` - Jira API migration
- `crates/cli/src/commands/confluence/search.rs` - Confluence response fix
- `Cargo.lock` - Dependencies update