### PR TITLE
Add query parameterization for Jira and Confluence search

### DIFF
--- a/crates/cli/src/commands/confluence/mod.rs
+++ b/crates/cli/src/commands/confluence/mod.rs
@@ -353,6 +353,40 @@ enum SearchCommands {
         #[arg(long)]
         limit: Option<usize>,
     },
+    /// Search using filter parameters
+    Params {
+        /// Filter by space key
+        #[arg(short = 's', long)]
+        space: Option<String>,
+
+        /// Filter by content type (page, blogpost, attachment)
+        #[arg(short = 't', long)]
+        r#type: Option<String>,
+
+        /// Filter by creator (use @me for current user)
+        #[arg(short = 'c', long)]
+        creator: Option<String>,
+
+        /// Filter by label (repeatable)
+        #[arg(short = 'l', long, num_args = 0..)]
+        label: Vec<String>,
+
+        /// Search in title
+        #[arg(long)]
+        title: Option<String>,
+
+        /// Free text search
+        #[arg(long)]
+        text: Option<String>,
+
+        /// Display generated CQL query
+        #[arg(long)]
+        show_query: bool,
+
+        /// Maximum number of results
+        #[arg(long, default_value_t = 50)]
+        limit: usize,
+    },
 }
 
 #[derive(Subcommand, Debug, Clone)]
@@ -558,6 +592,29 @@ pub async fn execute(
                 query,
                 limit,
             } => search::search_in_space(&ctx, &space, &query, limit).await,
+            SearchCommands::Params {
+                space,
+                r#type,
+                creator,
+                label,
+                title,
+                text,
+                show_query,
+                limit,
+            } => {
+                search::search_params(
+                    &ctx,
+                    space.as_deref(),
+                    r#type.as_deref(),
+                    creator.as_deref(),
+                    &label,
+                    title.as_deref(),
+                    text.as_deref(),
+                    show_query,
+                    limit,
+                )
+                .await
+            }
         },
         ConfluenceCommands::Bulk(cmd) => match cmd {
             BulkCommands::Delete {

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -1,4 +1,5 @@
 mod commands;
+mod query;
 
 use std::path::PathBuf;
 

--- a/crates/cli/src/query/cql.rs
+++ b/crates/cli/src/query/cql.rs
@@ -1,0 +1,168 @@
+/// Builder for constructing CQL (Confluence Query Language) queries from filter parameters
+pub struct CqlBuilder {
+    conditions: Vec<String>,
+}
+
+impl CqlBuilder {
+    pub fn new() -> Self {
+        Self {
+            conditions: Vec::new(),
+        }
+    }
+
+    /// Add an equality condition (field = value)
+    pub fn eq(mut self, field: &str, value: &str) -> Self {
+        let normalized = Self::normalize_value(field, value);
+        self.conditions.push(format!("{} = {}", field, normalized));
+        self
+    }
+
+    /// Add an IN condition for multiple values (field IN (val1, val2, ...))
+    pub fn in_list(mut self, field: &str, values: &[String]) -> Self {
+        if values.is_empty() {
+            return self;
+        }
+
+        let escaped_values: Vec<String> =
+            values.iter().map(|v| Self::escape_and_quote(v)).collect();
+
+        self.conditions
+            .push(format!("{} IN ({})", field, escaped_values.join(", ")));
+        self
+    }
+
+    /// Add a text search condition (field ~ "value")
+    pub fn contains(mut self, field: &str, value: &str) -> Self {
+        let escaped = Self::escape_and_quote(value);
+        self.conditions.push(format!("{} ~ {}", field, escaped));
+        self
+    }
+
+    /// Build the final CQL query string
+    pub fn finish(self) -> String {
+        if self.conditions.is_empty() {
+            return String::new();
+        }
+        self.conditions.join(" AND ")
+    }
+
+    /// Escape and quote a value
+    fn escape_and_quote(value: &str) -> String {
+        let escaped = value
+            .replace('\\', "\\\\") // Escape backslashes first
+            .replace('"', "\\\""); // Then escape quotes
+        format!("\"{}\"", escaped)
+    }
+
+    /// Normalize special values based on field context
+    fn normalize_value(field: &str, value: &str) -> String {
+        match (field, value) {
+            // Handle @me shorthand for user fields
+            ("creator" | "contributor" | "mention", "@me") => "currentUser()".to_string(),
+            // Default: escape and quote
+            _ => Self::escape_and_quote(value),
+        }
+    }
+}
+
+impl Default for CqlBuilder {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_empty_builder() {
+        let query = CqlBuilder::new().finish();
+        assert_eq!(query, "");
+    }
+
+    #[test]
+    fn test_single_eq() {
+        let query = CqlBuilder::new().eq("space", "ENG").finish();
+        assert_eq!(query, "space = \"ENG\"");
+    }
+
+    #[test]
+    fn test_creator_me_shorthand() {
+        let query = CqlBuilder::new().eq("creator", "@me").finish();
+        assert_eq!(query, "creator = currentUser()");
+    }
+
+    #[test]
+    fn test_multiple_conditions() {
+        let query = CqlBuilder::new()
+            .eq("space", "ENG")
+            .eq("type", "page")
+            .finish();
+        assert_eq!(query, "space = \"ENG\" AND type = \"page\"");
+    }
+
+    #[test]
+    fn test_in_list_single() {
+        let query = CqlBuilder::new()
+            .in_list("type", &[String::from("page")])
+            .finish();
+        assert_eq!(query, "type IN (\"page\")");
+    }
+
+    #[test]
+    fn test_in_list_multiple() {
+        let query = CqlBuilder::new()
+            .in_list("type", &[String::from("page"), String::from("blogpost")])
+            .finish();
+        assert_eq!(query, "type IN (\"page\", \"blogpost\")");
+    }
+
+    #[test]
+    fn test_in_list_empty() {
+        let query = CqlBuilder::new().in_list("type", &[]).finish();
+        assert_eq!(query, "");
+    }
+
+    #[test]
+    fn test_contains_title() {
+        let query = CqlBuilder::new().contains("title", "API").finish();
+        assert_eq!(query, "title ~ \"API\"");
+    }
+
+    #[test]
+    fn test_contains_text() {
+        let query = CqlBuilder::new().contains("text", "documentation").finish();
+        assert_eq!(query, "text ~ \"documentation\"");
+    }
+
+    #[test]
+    fn test_quote_escape() {
+        let query = CqlBuilder::new()
+            .eq("title", "Page \"with quotes\"")
+            .finish();
+        assert_eq!(query, "title = \"Page \\\"with quotes\\\"\"");
+    }
+
+    #[test]
+    fn test_backslash_escape() {
+        let query = CqlBuilder::new().eq("title", "Path\\to\\page").finish();
+        assert_eq!(query, "title = \"Path\\\\to\\\\page\"");
+    }
+
+    #[test]
+    fn test_complex_query() {
+        let query = CqlBuilder::new()
+            .eq("space", "ENG")
+            .eq("type", "page")
+            .eq("creator", "@me")
+            .in_list("label", &[String::from("api"), String::from("backend")])
+            .contains("title", "REST")
+            .finish();
+
+        assert_eq!(
+            query,
+            "space = \"ENG\" AND type = \"page\" AND creator = currentUser() AND label IN (\"api\", \"backend\") AND title ~ \"REST\""
+        );
+    }
+}

--- a/crates/cli/src/query/jql.rs
+++ b/crates/cli/src/query/jql.rs
@@ -1,0 +1,181 @@
+/// Builder for constructing JQL (Jira Query Language) queries from filter parameters
+pub struct JqlBuilder {
+    conditions: Vec<String>,
+}
+
+impl JqlBuilder {
+    pub fn new() -> Self {
+        Self {
+            conditions: Vec::new(),
+        }
+    }
+
+    /// Add an equality condition (field = value)
+    pub fn eq(mut self, field: &str, value: &str) -> Self {
+        let normalized = Self::normalize_value(field, value);
+        self.conditions.push(format!("{} = {}", field, normalized));
+        self
+    }
+
+    /// Add an IN condition for multiple values (field IN (val1, val2, ...))
+    pub fn in_list(mut self, field: &str, values: &[String]) -> Self {
+        if values.is_empty() {
+            return self;
+        }
+
+        let escaped_values: Vec<String> =
+            values.iter().map(|v| Self::escape_and_quote(v)).collect();
+
+        self.conditions
+            .push(format!("{} IN ({})", field, escaped_values.join(", ")));
+        self
+    }
+
+    /// Add a text search condition (field ~ "value")
+    pub fn contains(mut self, field: &str, value: &str) -> Self {
+        let escaped = Self::escape_and_quote(value);
+        self.conditions.push(format!("{} ~ {}", field, escaped));
+        self
+    }
+
+    /// Build the final JQL query string
+    pub fn finish(self) -> String {
+        if self.conditions.is_empty() {
+            return String::new();
+        }
+        self.conditions.join(" AND ")
+    }
+
+    /// Escape and quote a value
+    fn escape_and_quote(value: &str) -> String {
+        let escaped = value
+            .replace('\\', "\\\\") // Escape backslashes first
+            .replace('"', "\\\""); // Then escape quotes
+        format!("\"{}\"", escaped)
+    }
+
+    /// Normalize special values based on field context
+    fn normalize_value(field: &str, value: &str) -> String {
+        match (field, value) {
+            // Handle @me shorthand for user fields
+            ("assignee" | "reporter" | "creator" | "watcher", "@me") => "currentUser()".to_string(),
+            // Handle unassigned/empty shorthand
+            (_, "unassigned" | "none" | "empty") => "EMPTY".to_string(),
+            // Default: escape and quote
+            _ => Self::escape_and_quote(value),
+        }
+    }
+}
+
+impl Default for JqlBuilder {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_empty_builder() {
+        let query = JqlBuilder::new().finish();
+        assert_eq!(query, "");
+    }
+
+    #[test]
+    fn test_single_eq() {
+        let query = JqlBuilder::new().eq("project", "PROJ").finish();
+        assert_eq!(query, "project = \"PROJ\"");
+    }
+
+    #[test]
+    fn test_assignee_me_shorthand() {
+        let query = JqlBuilder::new().eq("assignee", "@me").finish();
+        assert_eq!(query, "assignee = currentUser()");
+    }
+
+    #[test]
+    fn test_reporter_me_shorthand() {
+        let query = JqlBuilder::new().eq("reporter", "@me").finish();
+        assert_eq!(query, "reporter = currentUser()");
+    }
+
+    #[test]
+    fn test_unassigned_shorthand() {
+        let query = JqlBuilder::new().eq("assignee", "unassigned").finish();
+        assert_eq!(query, "assignee = EMPTY");
+    }
+
+    #[test]
+    fn test_multiple_conditions() {
+        let query = JqlBuilder::new()
+            .eq("assignee", "@me")
+            .eq("project", "TEST")
+            .finish();
+        assert_eq!(query, "assignee = currentUser() AND project = \"TEST\"");
+    }
+
+    #[test]
+    fn test_in_list_single() {
+        let query = JqlBuilder::new()
+            .in_list("status", &[String::from("Open")])
+            .finish();
+        assert_eq!(query, "status IN (\"Open\")");
+    }
+
+    #[test]
+    fn test_in_list_multiple() {
+        let query = JqlBuilder::new()
+            .in_list(
+                "status",
+                &[String::from("Open"), String::from("In Progress")],
+            )
+            .finish();
+        assert_eq!(query, "status IN (\"Open\", \"In Progress\")");
+    }
+
+    #[test]
+    fn test_in_list_empty() {
+        let query = JqlBuilder::new().in_list("status", &[]).finish();
+        assert_eq!(query, "");
+    }
+
+    #[test]
+    fn test_contains() {
+        let query = JqlBuilder::new().contains("summary", "bug fix").finish();
+        assert_eq!(query, "summary ~ \"bug fix\"");
+    }
+
+    #[test]
+    fn test_quote_escape() {
+        let query = JqlBuilder::new()
+            .eq("summary", "Fix \"bug\" issue")
+            .finish();
+        assert_eq!(query, "summary = \"Fix \\\"bug\\\" issue\"");
+    }
+
+    #[test]
+    fn test_backslash_escape() {
+        let query = JqlBuilder::new().eq("summary", "Path\\to\\file").finish();
+        assert_eq!(query, "summary = \"Path\\\\to\\\\file\"");
+    }
+
+    #[test]
+    fn test_complex_query() {
+        let query = JqlBuilder::new()
+            .eq("assignee", "@me")
+            .in_list(
+                "status",
+                &[String::from("Open"), String::from("In Progress")],
+            )
+            .eq("priority", "High")
+            .in_list("label", &[String::from("bug"), String::from("backend")])
+            .finish();
+
+        assert_eq!(
+            query,
+            "assignee = currentUser() AND status IN (\"Open\", \"In Progress\") AND priority = \"High\" AND label IN (\"bug\", \"backend\")"
+        );
+    }
+}

--- a/crates/cli/src/query/mod.rs
+++ b/crates/cli/src/query/mod.rs
@@ -1,0 +1,5 @@
+pub mod cql;
+pub mod jql;
+
+pub use cql::CqlBuilder;
+pub use jql::JqlBuilder;

--- a/crates/cli/tests/cli_integration.rs
+++ b/crates/cli/tests/cli_integration.rs
@@ -10,7 +10,7 @@ fn test_cli_version() {
     assert!(output.status.success());
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(stdout.contains("atlassian-cli"));
-    assert!(stdout.contains("0.1.0"));
+    assert!(stdout.contains("0.1.1"));
 }
 
 #[test]


### PR DESCRIPTION
## Summary
Implements query parameterization for Jira and Confluence search commands, enabling users to build queries using semantic filter flags instead of writing raw JQL/CQL.

## Features

### Jira Search
- **Dual-mode support**: Use filter flags OR raw `--jql` (mutually exclusive)
- **8 filter flags**:
  - `-a, --assignee` - Filter by assignee (supports `@me`)
  - `-s, --status` - Filter by status (repeatable)
  - `-y, --priority` - Filter by priority
  - `-l, --label` - Filter by labels (repeatable)
  - `-t, --type` - Filter by issue type
  - `-p, --project` - Filter by project
  - `--text` - Free text search in summary
  - `--show-query` - Display generated JQL

### Confluence Search
- **New `params` subcommand**: Maintains backward compatibility
- **6 filter flags**:
  - `-s, --space` - Filter by space key
  - `-t, --type` - Filter by content type
  - `-c, --creator` - Filter by creator (supports `@me`)
  - `-l, --label` - Filter by labels (repeatable)
  - `--title` - Search in title
  - `--text` - Free text search
  - `--show-query` - Display generated CQL

## Implementation

- **Query builders** (`crates/cli/src/query/`):
  - `JqlBuilder`: Jira Query Language builder with 13 unit tests
  - `CqlBuilder`: Confluence Query Language builder with 11 unit tests
- **Special value expansion**:
  - `@me` → `currentUser()`
  - `unassigned`/`none`/`empty` → `EMPTY` (Jira only)
- **Security**: Comprehensive quote and backslash escaping
- **Conflict groups**: Prevents mixing raw queries with filter flags

## Testing

- ✅ All 116 tests pass (24 new query builder tests)
- ✅ Clippy clean (no warnings)
- ✅ Code formatted
- ✅ Backward compatible (no breaking changes)

## Bug Fixes

- Fixed: Use correct `labels` field instead of `label` for Jira

## Examples

```bash
# Jira: Parameterized search
atlassian-cli jira search --assignee @me --status "In Progress" --priority High

# Jira: Show generated query
atlassian-cli jira search --project ENG --label api --show-query

# Confluence: Parameterized search
atlassian-cli confluence search params --space ENG --type page --creator @me

# Confluence: Original CQL still works
atlassian-cli confluence search cql "space = ENG AND type = page"
```