### PR TITLE
feat: Bitbucket auth improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@
 
 # Claude Code
 .claude/
+
+# Local todo tracking
+docs/todo.md

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -121,7 +121,7 @@ dependencies = [
 
 [[package]]
 name = "atlassian-cli"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "anyhow",
  "atlassian-cli-api",
@@ -145,7 +145,7 @@ dependencies = [
 
 [[package]]
 name = "atlassian-cli-api"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -164,7 +164,7 @@ dependencies = [
 
 [[package]]
 name = "atlassian-cli-auth"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "anyhow",
  "base64",
@@ -177,7 +177,7 @@ dependencies = [
 
 [[package]]
 name = "atlassian-cli-bulk"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "anyhow",
  "futures",
@@ -189,7 +189,7 @@ dependencies = [
 
 [[package]]
 name = "atlassian-cli-config"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "anyhow",
  "dirs",
@@ -197,11 +197,12 @@ dependencies = [
  "serde_yaml",
  "tempfile",
  "thiserror",
+ "tracing",
 ]
 
 [[package]]
 name = "atlassian-cli-output"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.2"
+version = "0.1.3"
 edition = "2021"
 authors = ["atlassian-cli contributors"]
 license = "MIT"

--- a/configs/config.example.yaml
+++ b/configs/config.example.yaml
@@ -6,4 +6,4 @@ profiles:
   personal:
     base_url: https://example.atlassian.net
     email: you@example.com
-    # API tokens are stored securely in the system keyring via `atlcli auth login`
+    # API tokens are stored securely in the system keyring via `atlassian-cli auth login`

--- a/crates/cli/src/commands/bitbucket/utils.rs
+++ b/crates/cli/src/commands/bitbucket/utils.rs
@@ -1,7 +1,63 @@
 use atlassian_cli_api::ApiClient;
 use atlassian_cli_output::OutputRenderer;
+use url::Url;
 
 pub struct BitbucketContext<'a> {
     pub client: ApiClient,
     pub renderer: &'a OutputRenderer,
+}
+
+/// Extract Bitbucket workspace from a URL.
+/// Supports:
+/// - https://bitbucket.org/{workspace}
+/// - https://bitbucket.org/{workspace}/...
+pub fn extract_workspace_from_url(url: &str) -> Option<String> {
+    let parsed = Url::parse(url).ok()?;
+    if parsed.host_str() == Some("bitbucket.org") {
+        let path = parsed.path().trim_start_matches('/');
+        let workspace = path.split('/').next()?;
+        if !workspace.is_empty() {
+            return Some(workspace.to_string());
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_extract_workspace_from_bitbucket_url() {
+        assert_eq!(
+            extract_workspace_from_url("https://bitbucket.org/myworkspace"),
+            Some("myworkspace".to_string())
+        );
+    }
+
+    #[test]
+    fn test_extract_workspace_from_bitbucket_url_with_path() {
+        assert_eq!(
+            extract_workspace_from_url("https://bitbucket.org/myworkspace/some/repo"),
+            Some("myworkspace".to_string())
+        );
+    }
+
+    #[test]
+    fn test_extract_workspace_from_non_bitbucket_url() {
+        assert_eq!(
+            extract_workspace_from_url("https://example.atlassian.net"),
+            None
+        );
+    }
+
+    #[test]
+    fn test_extract_workspace_from_root_url() {
+        assert_eq!(extract_workspace_from_url("https://bitbucket.org/"), None);
+    }
+
+    #[test]
+    fn test_extract_workspace_from_empty_path() {
+        assert_eq!(extract_workspace_from_url("https://bitbucket.org"), None);
+    }
 }

--- a/crates/cli/tests/cli_integration.rs
+++ b/crates/cli/tests/cli_integration.rs
@@ -10,7 +10,7 @@ fn test_cli_version() {
     assert!(output.status.success());
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(stdout.contains("atlassian-cli"));
-    assert!(stdout.contains("0.1.1"));
+    assert!(stdout.contains("0.1.3"));
 }
 
 #[test]

--- a/crates/config/Cargo.toml
+++ b/crates/config/Cargo.toml
@@ -11,6 +11,7 @@ serde_yaml.workspace = true
 anyhow.workspace = true
 thiserror.workspace = true
 dirs.workspace = true
+tracing.workspace = true
 
 [dev-dependencies]
 tempfile = "3.13"

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -1,5 +1,15 @@
 # atlassian-cli TODO
 
+## Recent Changes (2025-11-25)
+- [x] Fix `--workspace` flag to work at any position (`global = true`)
+- [x] Replace all `atlcli` references with `atlassian-cli`
+- [x] Change config directory from `~/.atlcli/` to `~/.atlassian-cli/`
+- [x] Add auto-migration from old config directory
+- [x] Add workspace inference from profile's base_url (bitbucket.org/{workspace})
+- [x] Add `workspace` field to Profile struct
+- [x] Add separate Bitbucket token support (`ATLASSIAN_CLI_BITBUCKET_TOKEN_{PROFILE}`)
+- [x] Document Bitbucket scoped API token requirements in README
+
 ## 0. Research & Validation
 - [ ] Interview 3–5 Jira/Confluence/Opsgenie admins to confirm must-have workflows.
 - [ ] Collect sample API payloads for each Atlassian product (Confluence, Bitbucket, JSM, Opsgenie, Bamboo, Jira admin).

--- a/docs/vision.md
+++ b/docs/vision.md
@@ -41,7 +41,7 @@ atlassian-cli/
 │   │   └── src/commands/     # jira, confluence, bitbucket, jsm, opsgenie, bamboo
 │   ├── api/                  # REST clients per product (reqwest + serde)
 │   ├── auth/                 # API token/keyring helpers
-│   ├── config/               # Profiles (~/.atlcli/config.yaml)
+│   ├── config/               # Profiles (~/.atlassian-cli/config.yaml)
 │   ├── output/               # Table/JSON/CSV/YAML renderers (tabled/serde)
 │   └── bulk/                 # Worker pools, dry-run, logs (tokio + rayon)
 ├── internal/utils/           # Shared utilities/macros
@@ -85,7 +85,7 @@ Milestones: Week 3 foundation complete; Week 6 Jira ready; Week 9 Confluence rea
 
 ## Technical Guardrails
 - Rust (stable 1.79+), Clap 4 CLI framework, Tokio + Reqwest HTTP stack, cargo-make/just-driven tooling, GitHub Actions CI.
-- Config stored at `~/.atlcli/config.yaml` with multiple profiles and keyring-backed credentials.
+- Config stored at `~/.atlassian-cli/config.yaml` with multiple profiles and keyring-backed credentials.
 - HTTP client middleware handles retries, pagination, Atlassian rate limits, and structured logging.
 - Output modes: table (default), JSON, CSV, YAML, quiet (IDs) to support scripting.
 - Bulk engine provides worker pools, dry-run mode, progress bars, and transaction logs for recovery.


### PR DESCRIPTION
## Summary
- Add `ATLASSIAN_CLI_BITBUCKET_TOKEN_{PROFILE}` env var for Bitbucket-specific tokens
- Fix `--workspace` flag to work at any position (`global = true`)
- Change config directory from `~/.atlcli/` to `~/.atlassian-cli/`
- Add auto-migration from old config directory
- Add workspace inference from profile base_url
- Document Bitbucket scoped API token requirements

## Changes
- `crates/cli/src/main.rs` - Bitbucket token lookup, migration, workspace resolution
- `crates/cli/src/commands/bitbucket/mod.rs` - Global workspace flag
- `crates/cli/src/commands/bitbucket/utils.rs` - Workspace extraction helper
- `crates/config/src/lib.rs` - Migration logic, workspace field in Profile
- `README.md` - Bitbucket auth documentation

## Test Plan
- [x] All 121 tests pass
- [x] Verified Bitbucket token env var works
- [x] Verified workspace flag works at any position