### PR TITLE
feat: auth improvements and bitbucket whoami

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -121,7 +121,7 @@ dependencies = [
 
 [[package]]
 name = "atlassian-cli"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "anyhow",
  "atlassian-cli-api",
@@ -133,6 +133,7 @@ dependencies = [
  "clap",
  "csv",
  "reqwest",
+ "rpassword",
  "serde",
  "serde_json",
  "tokio",
@@ -145,7 +146,7 @@ dependencies = [
 
 [[package]]
 name = "atlassian-cli-api"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -164,10 +165,11 @@ dependencies = [
 
 [[package]]
 name = "atlassian-cli-auth"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "anyhow",
  "base64",
+ "dirs",
  "keyring",
  "serde",
  "serde_json",
@@ -177,7 +179,7 @@ dependencies = [
 
 [[package]]
 name = "atlassian-cli-bulk"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "anyhow",
  "futures",
@@ -189,7 +191,7 @@ dependencies = [
 
 [[package]]
 name = "atlassian-cli-config"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "anyhow",
  "dirs",
@@ -202,7 +204,7 @@ dependencies = [
 
 [[package]]
 name = "atlassian-cli-output"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "anyhow",
  "clap",
@@ -1526,6 +1528,27 @@ dependencies = [
  "getrandom 0.2.16",
  "libc",
  "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rpassword"
+version = "7.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66d4c8b64f049c6721ec8ccec37ddfc3d641c4a7fca57e8f2a89de509c73df39"
+dependencies = [
+ "libc",
+ "rtoolbox",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rtoolbox"
+version = "0.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7cc970b249fbe527d6e02e0a227762c9108b2f49d81094fe357ffc6d14d7f6f"
+dependencies = [
+ "libc",
  "windows-sys 0.52.0",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.5"
+version = "0.1.6"
 edition = "2021"
 authors = ["atlassian-cli contributors"]
 license = "MIT"

--- a/crates/auth/Cargo.toml
+++ b/crates/auth/Cargo.toml
@@ -13,3 +13,4 @@ serde_json.workspace = true
 anyhow.workspace = true
 thiserror.workspace = true
 tokio.workspace = true
+dirs = "5"

--- a/crates/auth/src/lib.rs
+++ b/crates/auth/src/lib.rs
@@ -1,5 +1,11 @@
 use anyhow::{Context, Result};
 use keyring::{Entry, Error as KeyringError};
+use std::collections::HashMap;
+use std::fs::{self, OpenOptions};
+use std::path::PathBuf;
+
+#[cfg(unix)]
+use std::os::unix::fs::OpenOptionsExt;
 
 /// Wrapper around the system keyring to store secrets per profile.
 pub struct CredentialStore {
@@ -43,4 +49,99 @@ impl CredentialStore {
 /// Helper to construct a key for profile secrets.
 pub fn token_key(profile: &str) -> String {
     profile.to_string()
+}
+
+// File-based credential storage
+
+fn credentials_path() -> Option<PathBuf> {
+    dirs::home_dir().map(|h| h.join(".atlassian-cli").join("credentials"))
+}
+
+/// Store a secret in the credentials file with 600 permissions.
+pub fn set_file_secret(account: &str, secret: &str) -> Result<()> {
+    let path = credentials_path().context("Cannot determine home directory")?;
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+
+    let mut creds: HashMap<String, String> = if path.exists() {
+        let content = fs::read_to_string(&path)?;
+        serde_json::from_str(&content).unwrap_or_default()
+    } else {
+        HashMap::new()
+    };
+
+    creds.insert(account.to_string(), secret.to_string());
+
+    #[cfg(unix)]
+    {
+        use std::io::Write;
+        let mut file = OpenOptions::new()
+            .write(true)
+            .create(true)
+            .truncate(true)
+            .mode(0o600)
+            .open(&path)?;
+        let json = serde_json::to_string_pretty(&creds)?;
+        file.write_all(json.as_bytes())?;
+    }
+
+    #[cfg(not(unix))]
+    {
+        let file = OpenOptions::new()
+            .write(true)
+            .create(true)
+            .truncate(true)
+            .open(&path)?;
+        serde_json::to_writer_pretty(file, &creds)?;
+    }
+
+    Ok(())
+}
+
+/// Get a secret from the credentials file.
+pub fn get_file_secret(account: &str) -> Result<Option<String>> {
+    let path = credentials_path().context("Cannot determine home directory")?;
+    if !path.exists() {
+        return Ok(None);
+    }
+    let content = fs::read_to_string(&path)?;
+    let creds: HashMap<String, String> = serde_json::from_str(&content)?;
+    Ok(creds.get(account).cloned())
+}
+
+/// Delete a secret from the credentials file.
+pub fn delete_file_secret(account: &str) -> Result<()> {
+    let path = credentials_path().context("Cannot determine home directory")?;
+    if !path.exists() {
+        return Ok(());
+    }
+    let content = fs::read_to_string(&path)?;
+    let mut creds: HashMap<String, String> = serde_json::from_str(&content).unwrap_or_default();
+    creds.remove(account);
+
+    #[cfg(unix)]
+    {
+        use std::io::Write;
+        let mut file = OpenOptions::new()
+            .write(true)
+            .create(true)
+            .truncate(true)
+            .mode(0o600)
+            .open(&path)?;
+        let json = serde_json::to_string_pretty(&creds)?;
+        file.write_all(json.as_bytes())?;
+    }
+
+    #[cfg(not(unix))]
+    {
+        let file = OpenOptions::new()
+            .write(true)
+            .create(true)
+            .truncate(true)
+            .open(&path)?;
+        serde_json::to_writer_pretty(file, &creds)?;
+    }
+
+    Ok(())
 }

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -34,6 +34,7 @@ csv = "1.4.0"
 urlencoding = "2.1.3"
 reqwest = { workspace = true, features = ["multipart"] }
 chrono.workspace = true
+rpassword = "7"
 
 [dev-dependencies]
 wiremock.workspace = true

--- a/crates/cli/src/commands/auth.rs
+++ b/crates/cli/src/commands/auth.rs
@@ -29,7 +29,9 @@ fn get_token(profile_name: &str, store: &CredentialStore) -> Option<String> {
         .or_else(|| {
             // 4. Try credentials file as fallback
             let secret_key = token_key(profile_name);
-            atlassian_cli_auth::get_file_secret(&secret_key).ok().flatten()
+            atlassian_cli_auth::get_file_secret(&secret_key)
+                .ok()
+                .flatten()
         })
 }
 

--- a/crates/cli/src/commands/bitbucket/mod.rs
+++ b/crates/cli/src/commands/bitbucket/mod.rs
@@ -72,6 +72,9 @@ enum BitbucketCommands {
     /// Bulk operations.
     #[command(subcommand)]
     Bulk(BulkCommands),
+
+    /// Show current authenticated Bitbucket user.
+    Whoami,
 }
 
 #[derive(Subcommand, Debug, Clone)]
@@ -594,6 +597,11 @@ pub async fn execute(
     renderer: &OutputRenderer,
     inferred_workspace: Option<&str>,
 ) -> Result<()> {
+    // Whoami doesn't require workspace
+    if matches!(args.command, BitbucketCommands::Whoami) {
+        return workspaces::whoami(&client).await;
+    }
+
     // CLI flag takes precedence, then inferred from profile
     let workspace = args
         .workspace
@@ -930,5 +938,6 @@ pub async fn execute(
                 dry_run,
             } => bulk::delete_merged_branches(&ctx, &workspace, &repo, exclude, dry_run).await,
         },
+        BitbucketCommands::Whoami => unreachable!("handled above"),
     }
 }

--- a/crates/cli/src/commands/bitbucket/workspaces.rs
+++ b/crates/cli/src/commands/bitbucket/workspaces.rs
@@ -1,4 +1,5 @@
 use anyhow::{Context, Result};
+use atlassian_cli_api::ApiClient;
 use serde::{Deserialize, Serialize};
 use url::form_urlencoded;
 
@@ -297,5 +298,27 @@ pub async fn delete_project(
     tracing::info!(project_key, workspace, "Project deleted successfully");
 
     println!("✓ Project {project_key} deleted from workspace {workspace}");
+    Ok(())
+}
+
+#[derive(Deserialize)]
+struct BitbucketUser {
+    username: String,
+    display_name: String,
+    account_id: String,
+    uuid: String,
+}
+
+pub async fn whoami(client: &ApiClient) -> Result<()> {
+    let user: BitbucketUser = client
+        .get("/2.0/user")
+        .await
+        .context("Failed to fetch current user from Bitbucket API")?;
+
+    println!("Username: {}", user.username);
+    println!("Display Name: {}", user.display_name);
+    println!("Account ID: {}", user.account_id);
+    println!("UUID: {}", user.uuid);
+
     Ok(())
 }

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -119,13 +119,16 @@ async fn main() -> Result<()> {
         }
         AtlassianCommand::Opsgenie(args) => commands::opsgenie::execute(args).await?,
         AtlassianCommand::Bamboo(args) => commands::bamboo::execute(args).await?,
-        AtlassianCommand::Auth(command) => auth::handle(
-            command,
-            &mut config,
-            config_path.as_deref(),
-            &credential_store,
-            &renderer,
-        )?,
+        AtlassianCommand::Auth(command) => {
+            auth::handle(
+                command,
+                &mut config,
+                config_path.as_deref(),
+                &credential_store,
+                &renderer,
+            )
+            .await?
+        }
     }
 
     Ok(())

--- a/todo.md
+++ b/todo.md
@@ -1,0 +1,23 @@
+# Changes Made
+
+## 2025-11-26
+- Added API token URL hint to `auth login` flow
+  - File: `crates/cli/src/commands/auth.rs:228`
+  - Now shows "You can get the API token from: https://id.atlassian.com/manage-profile/security/api-tokens" before prompting for token
+
+- Fixed `auth test` runtime panic ("Cannot start a runtime from within a runtime")
+  - Made `auth::handle` async in `crates/cli/src/commands/auth.rs:88`
+  - Made `test_auth` async in `crates/cli/src/commands/auth.rs:286`
+  - Removed nested tokio runtime, now uses existing runtime via `.await`
+  - Updated `main.rs:122` to await auth::handle
+
+- Added `bitbucket whoami` command to verify Bitbucket authentication
+  - Added `Whoami` variant to `BitbucketCommands` enum in `crates/cli/src/commands/bitbucket/mod.rs:77`
+  - Added `whoami()` function calling `/2.0/user` endpoint in `crates/cli/src/commands/bitbucket/workspaces.rs:312`
+  - Displays username, display name, account ID, UUID
+
+- Added hidden password input + file-based credential storage
+  - Token input now hidden via `rpassword` crate (`crates/cli/src/commands/auth.rs:232`)
+  - Added file-based storage at `~/.atlassian-cli/credentials` with 600 permissions (`crates/auth/src/lib.rs:54-147`)
+  - Token lookup: env var → keychain → credentials file
+  - Login stores in both keychain and file; logout deletes from both


### PR DESCRIPTION
## Summary
- Add API token URL hint before login prompt
- Fix auth test runtime panic (nested tokio runtime)
- Add hidden password input via rpassword
- Add file-based credential storage (~/.atlassian-cli/credentials with 600 permissions)
- Add bitbucket whoami command
- Bump version to 0.1.6

## Changes
- Token input now hidden when typing
- Credentials stored in both keychain and file for fallback
- Token lookup: env var → keychain → credentials file