### PR TITLE
feat: remove keychain, use file-only storage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -121,7 +121,7 @@ dependencies = [
 
 [[package]]
 name = "atlassian-cli"
-version = "0.1.5"
+version = "0.1.7"
 dependencies = [
  "anyhow",
  "atlassian-cli-api",
@@ -146,7 +146,7 @@ dependencies = [
 
 [[package]]
 name = "atlassian-cli-api"
-version = "0.1.5"
+version = "0.1.7"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -165,12 +165,11 @@ dependencies = [
 
 [[package]]
 name = "atlassian-cli-auth"
-version = "0.1.5"
+version = "0.1.7"
 dependencies = [
  "anyhow",
  "base64",
  "dirs",
- "keyring",
  "serde",
  "serde_json",
  "thiserror",
@@ -179,7 +178,7 @@ dependencies = [
 
 [[package]]
 name = "atlassian-cli-bulk"
-version = "0.1.5"
+version = "0.1.7"
 dependencies = [
  "anyhow",
  "futures",
@@ -191,7 +190,7 @@ dependencies = [
 
 [[package]]
 name = "atlassian-cli-config"
-version = "0.1.5"
+version = "0.1.7"
 dependencies = [
  "anyhow",
  "dirs",
@@ -204,7 +203,7 @@ dependencies = [
 
 [[package]]
 name = "atlassian-cli-output"
-version = "0.1.5"
+version = "0.1.7"
 dependencies = [
  "anyhow",
  "clap",
@@ -264,12 +263,6 @@ name = "bytecount"
 version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "175812e0be2bccb6abe50bb8d566126198344f707e304f45c648fd8f2cc0365e"
-
-[[package]]
-name = "byteorder"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
@@ -382,16 +375,6 @@ name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
-
-[[package]]
-name = "core-foundation"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -1026,21 +1009,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "keyring"
-version = "3.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eebcc3aff044e5944a8fbaf69eb277d11986064cba30c468730e8b9909fb551c"
-dependencies = [
- "byteorder",
- "linux-keyutils",
- "log",
- "security-framework 2.11.1",
- "security-framework 3.5.1",
- "windows-sys 0.60.2",
- "zeroize",
-]
-
-[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1057,16 +1025,6 @@ name = "libredox"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "416f7e718bdb06000964960ffa43b4335ad4012ae8b99060261aa4a8088d5ccb"
-dependencies = [
- "bitflags",
- "libc",
-]
-
-[[package]]
-name = "linux-keyutils"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "761e49ec5fd8a5a463f9b84e877c373d888935b71c6be78f3767fe2ae6bed18e"
 dependencies = [
  "bitflags",
  "libc",
@@ -1153,7 +1111,7 @@ dependencies = [
  "openssl-probe",
  "openssl-sys",
  "schannel",
- "security-framework 2.11.1",
+ "security-framework",
  "security-framework-sys",
  "tempfile",
 ]
@@ -1632,20 +1590,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
 dependencies = [
  "bitflags",
- "core-foundation 0.9.4",
- "core-foundation-sys",
- "libc",
- "security-framework-sys",
-]
-
-[[package]]
-name = "security-framework"
-version = "3.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3297343eaf830f66ede390ea39da1d462b6b0c1b000f420d0a83f898bbbe6ef"
-dependencies = [
- "bitflags",
- "core-foundation 0.10.1",
+ "core-foundation",
  "core-foundation-sys",
  "libc",
  "security-framework-sys",
@@ -1842,7 +1787,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
 dependencies = [
  "bitflags",
- "core-foundation 0.9.4",
+ "core-foundation",
  "system-configuration-sys",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.6"
+version = "0.1.7"
 edition = "2021"
 authors = ["atlassian-cli contributors"]
 license = "MIT"
@@ -38,7 +38,6 @@ anyhow = "1.0"
 thiserror = "1.0"
 
 # Auth & Config
-keyring = { version = "3.6", features = ["apple-native", "windows-native", "linux-native"] }
 base64 = "0.22"
 
 # Logging

--- a/crates/auth/Cargo.toml
+++ b/crates/auth/Cargo.toml
@@ -6,7 +6,6 @@ authors.workspace = true
 license.workspace = true
 
 [dependencies]
-keyring.workspace = true
 base64.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/crates/auth/src/lib.rs
+++ b/crates/auth/src/lib.rs
@@ -1,5 +1,4 @@
 use anyhow::{Context, Result};
-use keyring::{Entry, Error as KeyringError};
 use std::collections::HashMap;
 use std::fs::{self, OpenOptions};
 use std::path::PathBuf;
@@ -7,58 +6,17 @@ use std::path::PathBuf;
 #[cfg(unix)]
 use std::os::unix::fs::OpenOptionsExt;
 
-/// Wrapper around the system keyring to store secrets per profile.
-pub struct CredentialStore {
-    service_name: String,
-}
-
-impl CredentialStore {
-    pub fn new(service_name: impl Into<String>) -> Self {
-        Self {
-            service_name: service_name.into(),
-        }
-    }
-
-    pub fn set_secret(&self, account: &str, secret: &str) -> Result<()> {
-        Entry::new(&self.service_name, account)
-            .with_context(|| format!("Unable to access keyring entry {account}"))?
-            .set_password(secret)
-            .with_context(|| format!("Unable to store secret for {account}"))
-    }
-
-    pub fn get_secret(&self, account: &str) -> Result<Option<String>> {
-        let entry = Entry::new(&self.service_name, account)
-            .with_context(|| format!("Unable to access keyring entry {account}"))?;
-        match entry.get_password() {
-            Ok(secret) => Ok(Some(secret)),
-            Err(KeyringError::NoEntry) => Ok(None),
-            Err(err) => Err(err).with_context(|| format!("Unable to read secret for {account}")),
-        }
-    }
-
-    pub fn delete_secret(&self, account: &str) -> Result<()> {
-        let entry = Entry::new(&self.service_name, account)
-            .with_context(|| format!("Unable to access keyring entry {account}"))?;
-        match entry.delete_credential() {
-            Ok(()) | Err(KeyringError::NoEntry) => Ok(()),
-            Err(err) => Err(err).with_context(|| format!("Unable to delete secret for {account}")),
-        }
-    }
-}
-
 /// Helper to construct a key for profile secrets.
 pub fn token_key(profile: &str) -> String {
     profile.to_string()
 }
-
-// File-based credential storage
 
 fn credentials_path() -> Option<PathBuf> {
     dirs::home_dir().map(|h| h.join(".atlassian-cli").join("credentials"))
 }
 
 /// Store a secret in the credentials file with 600 permissions.
-pub fn set_file_secret(account: &str, secret: &str) -> Result<()> {
+pub fn set_secret(account: &str, secret: &str) -> Result<()> {
     let path = credentials_path().context("Cannot determine home directory")?;
     if let Some(parent) = path.parent() {
         fs::create_dir_all(parent)?;
@@ -100,7 +58,7 @@ pub fn set_file_secret(account: &str, secret: &str) -> Result<()> {
 }
 
 /// Get a secret from the credentials file.
-pub fn get_file_secret(account: &str) -> Result<Option<String>> {
+pub fn get_secret(account: &str) -> Result<Option<String>> {
     let path = credentials_path().context("Cannot determine home directory")?;
     if !path.exists() {
         return Ok(None);
@@ -111,7 +69,7 @@ pub fn get_file_secret(account: &str) -> Result<Option<String>> {
 }
 
 /// Delete a secret from the credentials file.
-pub fn delete_file_secret(account: &str) -> Result<()> {
+pub fn delete_secret(account: &str) -> Result<()> {
     let path = credentials_path().context("Cannot determine home directory")?;
     if !path.exists() {
         return Ok(());

--- a/todo.md
+++ b/todo.md
@@ -1,6 +1,10 @@
 # Changes Made
 
 ## 2025-11-26
+- Fixed `auth whoami` runtime panic (same nested runtime issue)
+  - Made `whoami` async in `crates/cli/src/commands/auth.rs:222`
+  - Removed nested tokio runtime, now uses existing runtime via `.await`
+
 - Added API token URL hint to `auth login` flow
   - File: `crates/cli/src/commands/auth.rs:228`
   - Now shows "You can get the API token from: https://id.atlassian.com/manage-profile/security/api-tokens" before prompting for token
@@ -16,8 +20,9 @@
   - Added `whoami()` function calling `/2.0/user` endpoint in `crates/cli/src/commands/bitbucket/workspaces.rs:312`
   - Displays username, display name, account ID, UUID
 
-- Added hidden password input + file-based credential storage
-  - Token input now hidden via `rpassword` crate (`crates/cli/src/commands/auth.rs:232`)
-  - Added file-based storage at `~/.atlassian-cli/credentials` with 600 permissions (`crates/auth/src/lib.rs:54-147`)
-  - Token lookup: env var → keychain → credentials file
-  - Login stores in both keychain and file; logout deletes from both
+- Added hidden password input + file-based credential storage (removed keychain)
+  - Token input now hidden via `rpassword` crate
+  - Removed `keyring` dependency entirely
+  - Tokens stored only in `~/.atlassian-cli/credentials` with 600 permissions
+  - Token lookup: env var → credentials file
+  - Removed `CredentialStore` struct, simplified auth code


### PR DESCRIPTION
## Summary
- Remove keyring dependency entirely
- Store tokens in ~/.atlassian-cli/credentials with 600 permissions
- Fix auth whoami nested runtime panic
- Bump version to 0.1.7

## Test plan
- [x] auth login stores token in file
- [x] auth test verifies authentication
- [x] auth whoami shows user info
- [x] All 134 tests pass