### PR TITLE
Add custom field support to issue create, update, and bulk import

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,10 @@ crates/
    atlassian-cli jira search --jql "project = DEV order by created desc" --limit 5
    atlassian-cli jira get DEV-123
    atlassian-cli jira create --project DEV --issue-type Task --summary "Test task"
+   # Custom fields — discover IDs via `jira fields list`:
+   atlassian-cli jira create --project DEV --issue-type Task --summary "cf test" \
+     --field 'customfield_10010={"value":"Internal"}' \
+     --field 'customfield_10020={"formula":"a=b"}'
    atlassian-cli jira update DEV-123 --summary "Updated summary"
    atlassian-cli jira transition DEV-123 --transition "In Progress"
    atlassian-cli jira assign DEV-123 --assignee user@example.com

--- a/crates/cli/src/commands/jira/bulk.rs
+++ b/crates/cli/src/commands/jira/bulk.rs
@@ -1,9 +1,11 @@
+use std::collections::HashMap;
+use std::fs;
+use std::path::PathBuf;
+
 use anyhow::{Context, Result};
 use atlassian_cli_bulk::BulkExecutor;
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
-use std::fs;
-use std::path::PathBuf;
 
 use super::utils::JiraContext;
 use crate::commands::common::{render_success, MutationResult};
@@ -358,6 +360,12 @@ pub async fn bulk_import(
                     fields["labels"] = json!(issue.labels);
                 }
 
+                if let Some(custom) = issue.custom_fields {
+                    for (key, value) in custom {
+                        fields[key] = value;
+                    }
+                }
+
                 let payload = json!({ "fields": fields });
 
                 let response: CreateResponse = client
@@ -470,9 +478,81 @@ pub struct ImportIssue {
     pub priority: Option<String>,
     #[serde(default)]
     pub labels: Vec<String>,
+    #[serde(default)]
+    pub custom_fields: Option<HashMap<String, Value>>,
 }
 
 #[derive(Deserialize)]
 struct CreateResponse {
     key: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn test_import_issue_deserialize_with_custom_fields() {
+        let json_str = r#"{
+            "summary": "Test ticket",
+            "issue_type": "Task",
+            "custom_fields": {
+                "customfield_10001": {"value": "Alpha"},
+                "customfield_10002": [{"value": "Beta"}]
+            }
+        }"#;
+        let issue: ImportIssue = serde_json::from_str(json_str).unwrap();
+        assert_eq!(issue.summary, "Test ticket");
+        let cf = issue.custom_fields.unwrap();
+        assert_eq!(cf["customfield_10001"], json!({"value": "Alpha"}));
+        assert_eq!(cf["customfield_10002"], json!([{"value": "Beta"}]));
+    }
+
+    #[test]
+    fn test_import_issue_deserialize_without_custom_fields() {
+        let json_str = r#"{
+            "summary": "Basic ticket",
+            "issue_type": "Bug"
+        }"#;
+        let issue: ImportIssue = serde_json::from_str(json_str).unwrap();
+        assert_eq!(issue.summary, "Basic ticket");
+        assert!(issue.custom_fields.is_none());
+    }
+
+    #[test]
+    fn test_import_issue_deserialize_empty_custom_fields() {
+        let json_str = r#"{
+            "summary": "Empty customs",
+            "issue_type": "Story",
+            "custom_fields": {}
+        }"#;
+        let issue: ImportIssue = serde_json::from_str(json_str).unwrap();
+        assert!(issue.custom_fields.unwrap().is_empty());
+    }
+
+    #[test]
+    fn test_import_issue_full_roundtrip() {
+        let json_str = r#"{
+            "summary": "Full ticket",
+            "issue_type": "Task",
+            "description": "Some description",
+            "assignee": "user123",
+            "priority": "High",
+            "labels": ["backend", "urgent"],
+            "custom_fields": {
+                "customfield_10001": "plain string",
+                "customfield_10002": 42
+            }
+        }"#;
+        let issue: ImportIssue = serde_json::from_str(json_str).unwrap();
+        assert_eq!(issue.summary, "Full ticket");
+        assert_eq!(issue.description.as_deref(), Some("Some description"));
+        assert_eq!(issue.assignee.as_deref(), Some("user123"));
+        assert_eq!(issue.priority.as_deref(), Some("High"));
+        assert_eq!(issue.labels, vec!["backend", "urgent"]);
+        let cf = issue.custom_fields.unwrap();
+        assert_eq!(cf["customfield_10001"], json!("plain string"));
+        assert_eq!(cf["customfield_10002"], json!(42));
+    }
 }

--- a/crates/cli/src/commands/jira/bulk.rs
+++ b/crates/cli/src/commands/jira/bulk.rs
@@ -7,8 +7,58 @@ use atlassian_cli_bulk::BulkExecutor;
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 
+use super::issues::{check_field_collisions, plain_text_adf};
 use super::utils::JiraContext;
 use crate::commands::common::{render_success, MutationResult};
+
+/// Build the POST body for a single bulk-import row. Pure, testable.
+pub(crate) fn build_bulk_payload(project: &str, issue: &ImportIssue) -> Result<Value> {
+    let empty = HashMap::new();
+    let custom = issue.custom_fields.as_ref().unwrap_or(&empty);
+
+    check_field_collisions(
+        custom,
+        &[
+            ("project", "file project"),
+            ("issuetype", "row.issue_type"),
+            ("summary", "row.summary"),
+        ],
+        &[
+            (
+                "description",
+                "row.description",
+                issue.description.is_some(),
+            ),
+            ("assignee", "row.assignee", issue.assignee.is_some()),
+            ("priority", "row.priority", issue.priority.is_some()),
+            ("labels", "row.labels", !issue.labels.is_empty()),
+        ],
+    )?;
+
+    let mut fields = json!({
+        "project": { "key": project },
+        "issuetype": { "name": issue.issue_type },
+        "summary": issue.summary,
+    });
+
+    if let Some(desc) = &issue.description {
+        fields["description"] = plain_text_adf(desc);
+    }
+    if let Some(assignee) = &issue.assignee {
+        fields["assignee"] = json!({ "id": assignee });
+    }
+    if let Some(priority) = &issue.priority {
+        fields["priority"] = json!({ "name": priority });
+    }
+    if !issue.labels.is_empty() {
+        fields["labels"] = json!(issue.labels);
+    }
+    for (key, value) in custom {
+        fields[key] = value.clone();
+    }
+
+    Ok(json!({ "fields": fields }))
+}
 
 // Bulk transition issues
 pub async fn bulk_transition(
@@ -331,42 +381,7 @@ pub async fn bulk_import(
             let client = client.clone();
             let project = project.clone();
             async move {
-                let mut fields = json!({
-                    "project": { "key": project },
-                    "issuetype": { "name": issue.issue_type },
-                    "summary": issue.summary,
-                });
-
-                if let Some(desc) = issue.description {
-                    fields["description"] = json!({
-                        "type": "doc",
-                        "version": 1,
-                        "content": [{
-                            "type": "paragraph",
-                            "content": [{ "type": "text", "text": desc }]
-                        }]
-                    });
-                }
-
-                if let Some(assignee) = issue.assignee {
-                    fields["assignee"] = json!({ "id": assignee });
-                }
-
-                if let Some(priority) = issue.priority {
-                    fields["priority"] = json!({ "name": priority });
-                }
-
-                if !issue.labels.is_empty() {
-                    fields["labels"] = json!(issue.labels);
-                }
-
-                if let Some(custom) = issue.custom_fields {
-                    for (key, value) in custom {
-                        fields[key] = value;
-                    }
-                }
-
-                let payload = json!({ "fields": fields });
+                let payload = build_bulk_payload(&project, &issue)?;
 
                 let response: CreateResponse = client
                     .post("/rest/api/3/issue", &payload)
@@ -554,5 +569,72 @@ mod tests {
         let cf = issue.custom_fields.unwrap();
         assert_eq!(cf["customfield_10001"], json!("plain string"));
         assert_eq!(cf["customfield_10002"], json!(42));
+    }
+
+    fn minimal_issue() -> ImportIssue {
+        ImportIssue {
+            summary: "s".to_string(),
+            issue_type: "Task".to_string(),
+            description: None,
+            assignee: None,
+            priority: None,
+            labels: vec![],
+            custom_fields: None,
+        }
+    }
+
+    #[test]
+    fn build_bulk_payload_merges_typed_and_custom() {
+        let mut issue = minimal_issue();
+        issue.description = Some("d".into());
+        issue.labels = vec!["backend".into()];
+        issue.custom_fields = Some(
+            [("customfield_10010".to_string(), json!({"value": "x"}))]
+                .into_iter()
+                .collect(),
+        );
+        let payload = build_bulk_payload("PROJ", &issue).unwrap();
+        let fields = &payload["fields"];
+        assert_eq!(fields["project"]["key"], "PROJ");
+        assert_eq!(fields["issuetype"]["name"], "Task");
+        assert_eq!(fields["summary"], "s");
+        assert_eq!(fields["labels"], json!(["backend"]));
+        assert_eq!(fields["customfield_10010"], json!({"value": "x"}));
+        assert_eq!(fields["description"]["type"], "doc");
+    }
+
+    #[test]
+    fn build_bulk_payload_rejects_mandatory_collision() {
+        let mut issue = minimal_issue();
+        issue.custom_fields = Some(
+            [("summary".to_string(), json!("raw"))]
+                .into_iter()
+                .collect(),
+        );
+        let err = build_bulk_payload("PROJ", &issue).unwrap_err().to_string();
+        assert!(err.contains("reserved"), "got: {err}");
+        assert!(err.contains("row.summary"), "got: {err}");
+    }
+
+    #[test]
+    fn build_bulk_payload_rejects_labels_collision_when_both_set() {
+        let mut issue = minimal_issue();
+        issue.labels = vec!["a".into()];
+        issue.custom_fields = Some([("labels".to_string(), json!(["b"]))].into_iter().collect());
+        let err = build_bulk_payload("PROJ", &issue).unwrap_err().to_string();
+        assert!(err.contains("collides"), "got: {err}");
+        assert!(err.contains("row.labels"), "got: {err}");
+    }
+
+    #[test]
+    fn build_bulk_payload_allows_raw_only_labels() {
+        let mut issue = minimal_issue();
+        issue.custom_fields = Some(
+            [("labels".to_string(), json!(["b", "c"]))]
+                .into_iter()
+                .collect(),
+        );
+        let payload = build_bulk_payload("PROJ", &issue).unwrap();
+        assert_eq!(payload["fields"]["labels"], json!(["b", "c"]));
     }
 }

--- a/crates/cli/src/commands/jira/issues.rs
+++ b/crates/cli/src/commands/jira/issues.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use anyhow::{anyhow, Context, Result};
 use atlassian_cli_output::OutputFormat;
 use serde::{Deserialize, Serialize};
@@ -6,6 +8,23 @@ use serde_json::Value;
 use super::utils::JiraContext;
 use crate::commands::common::{render_success, MutationResult};
 use crate::query::JqlBuilder;
+
+/// Parse `--field key=json_value` pairs into a HashMap.
+pub fn parse_custom_fields(raw: &[String]) -> Result<HashMap<String, Value>> {
+    let mut map = HashMap::new();
+    for entry in raw {
+        let (key, val) = entry.split_once('=').ok_or_else(|| {
+            anyhow!(
+                "Invalid --field format '{}': expected key=JSON_VALUE",
+                entry
+            )
+        })?;
+        let parsed: Value = serde_json::from_str(val)
+            .with_context(|| format!("Invalid JSON in --field '{}': {}", key, val))?;
+        map.insert(key.to_string(), parsed);
+    }
+    Ok(map)
+}
 
 // Issue CRUD Operations
 
@@ -242,6 +261,7 @@ pub async fn view_issue(ctx: &JiraContext<'_>, key: &str) -> Result<()> {
     ctx.renderer.render(&view)
 }
 
+#[allow(clippy::too_many_arguments)]
 pub async fn create_issue(
     ctx: &JiraContext<'_>,
     project: &str,
@@ -250,6 +270,7 @@ pub async fn create_issue(
     description: Option<&str>,
     assignee: Option<&str>,
     priority: Option<&str>,
+    custom_fields: &HashMap<String, Value>,
 ) -> Result<()> {
     use serde_json::json;
 
@@ -276,6 +297,10 @@ pub async fn create_issue(
 
     if let Some(pri) = priority {
         fields["priority"] = json!({ "name": pri });
+    }
+
+    for (key, value) in custom_fields {
+        fields[key] = value.clone();
     }
 
     let payload = json!({ "fields": fields });
@@ -306,6 +331,7 @@ pub async fn update_issue(
     summary: Option<&str>,
     description: Option<&str>,
     priority: Option<&str>,
+    custom_fields: &HashMap<String, Value>,
 ) -> Result<()> {
     use serde_json::json;
 
@@ -328,6 +354,10 @@ pub async fn update_issue(
 
     if let Some(pri) = priority {
         fields["priority"] = json!({ "name": pri });
+    }
+
+    for (key, value) in custom_fields {
+        fields[key] = value.clone();
     }
 
     let payload = json!({ "fields": fields });
@@ -1567,5 +1597,73 @@ mod tests {
             }]
         });
         assert_eq!(extract_adf_markdown(&adf), "status: `IN PROGRESS`");
+    }
+
+    // -- Custom field parsing tests --
+
+    #[test]
+    fn test_parse_custom_fields_single() {
+        let input = vec![r#"customfield_10001={"value":"Alpha"}"#.to_string()];
+        let result = parse_custom_fields(&input).unwrap();
+        assert_eq!(result.len(), 1);
+        assert_eq!(result["customfield_10001"], json!({"value": "Alpha"}));
+    }
+
+    #[test]
+    fn test_parse_custom_fields_multiple() {
+        let input = vec![
+            r#"customfield_10001={"value":"Alpha"}"#.to_string(),
+            r#"customfield_10002=[{"value":"Beta"}]"#.to_string(),
+        ];
+        let result = parse_custom_fields(&input).unwrap();
+        assert_eq!(result.len(), 2);
+        assert_eq!(result["customfield_10001"], json!({"value": "Alpha"}));
+        assert_eq!(result["customfield_10002"], json!([{"value": "Beta"}]));
+    }
+
+    #[test]
+    fn test_parse_custom_fields_empty() {
+        let result = parse_custom_fields(&[]).unwrap();
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn test_parse_custom_fields_string_value() {
+        let input = vec![r#"customfield_10001="just a string""#.to_string()];
+        let result = parse_custom_fields(&input).unwrap();
+        assert_eq!(result["customfield_10001"], json!("just a string"));
+    }
+
+    #[test]
+    fn test_parse_custom_fields_numeric_value() {
+        let input = vec!["customfield_10001=42".to_string()];
+        let result = parse_custom_fields(&input).unwrap();
+        assert_eq!(result["customfield_10001"], json!(42));
+    }
+
+    #[test]
+    fn test_parse_custom_fields_missing_equals() {
+        let input = vec!["customfield_10001_no_value".to_string()];
+        let result = parse_custom_fields(&input);
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("expected key=JSON_VALUE"));
+    }
+
+    #[test]
+    fn test_parse_custom_fields_invalid_json() {
+        let input = vec!["customfield_10001={not valid json}".to_string()];
+        let result = parse_custom_fields(&input);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("Invalid JSON"));
+    }
+
+    #[test]
+    fn test_parse_custom_fields_equals_in_json_value() {
+        let input = vec![r#"customfield_10001={"formula":"a=b"}"#.to_string()];
+        let result = parse_custom_fields(&input).unwrap();
+        assert_eq!(result["customfield_10001"], json!({"formula": "a=b"}));
     }
 }

--- a/crates/cli/src/commands/jira/issues.rs
+++ b/crates/cli/src/commands/jira/issues.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use anyhow::{anyhow, Context, Result};
+use anyhow::{anyhow, bail, Context, Result};
 use atlassian_cli_output::OutputFormat;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -9,7 +9,7 @@ use super::utils::JiraContext;
 use crate::commands::common::{render_success, MutationResult};
 use crate::query::JqlBuilder;
 
-/// Parse `--field key=json_value` pairs into a HashMap.
+/// Parse `--field key=json_value` pairs into a HashMap. Rejects duplicate keys.
 pub fn parse_custom_fields(raw: &[String]) -> Result<HashMap<String, Value>> {
     let mut map = HashMap::new();
     for entry in raw {
@@ -21,9 +21,35 @@ pub fn parse_custom_fields(raw: &[String]) -> Result<HashMap<String, Value>> {
         })?;
         let parsed: Value = serde_json::from_str(val)
             .with_context(|| format!("Invalid JSON in --field '{}': {}", key, val))?;
-        map.insert(key.to_string(), parsed);
+        if map.insert(key.to_string(), parsed).is_some() {
+            bail!("--field '{key}' specified more than once");
+        }
     }
     Ok(map)
+}
+
+/// Hard-error if `custom` tries to set reserved or already-set typed fields.
+///
+/// `mandatory`: (jira_payload_key, cli_flag_hint) — always rejected.
+/// `optional_set`: (jira_payload_key, cli_flag_hint, typed_is_set) — rejected
+/// only when both the typed flag and the raw field target the same key.
+pub(crate) fn check_field_collisions(
+    custom: &HashMap<String, Value>,
+    mandatory: &[(&str, &str)],
+    optional_set: &[(&str, &str, bool)],
+) -> Result<()> {
+    for key in custom.keys() {
+        if let Some((_, hint)) = mandatory.iter().find(|(k, _)| *k == key.as_str()) {
+            bail!("--field cannot set reserved key '{key}'; use {hint} instead");
+        }
+        if let Some((_, hint, _)) = optional_set
+            .iter()
+            .find(|(k, _, set)| *k == key.as_str() && *set)
+        {
+            bail!("--field '{key}' collides with {hint} already set; pick one source");
+        }
+    }
+    Ok(())
 }
 
 // Issue CRUD Operations
@@ -261,6 +287,67 @@ pub async fn view_issue(ctx: &JiraContext<'_>, key: &str) -> Result<()> {
     ctx.renderer.render(&view)
 }
 
+/// Wrap a plain string as a minimal single-paragraph ADF doc.
+pub(crate) fn plain_text_adf(text: &str) -> Value {
+    serde_json::json!({
+        "type": "doc",
+        "version": 1,
+        "content": [{
+            "type": "paragraph",
+            "content": [{ "type": "text", "text": text }]
+        }]
+    })
+}
+
+/// Build the POST body for `POST /rest/api/3/issue`. Pure, testable.
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn build_create_payload(
+    project: &str,
+    issue_type: &str,
+    summary: &str,
+    description: Option<&str>,
+    assignee: Option<&str>,
+    priority: Option<&str>,
+    custom: &HashMap<String, Value>,
+) -> Result<Value> {
+    use serde_json::json;
+
+    check_field_collisions(
+        custom,
+        &[
+            ("project", "--project"),
+            ("issuetype", "--issue-type"),
+            ("summary", "--summary"),
+        ],
+        &[
+            ("description", "--description", description.is_some()),
+            ("assignee", "--assignee", assignee.is_some()),
+            ("priority", "--priority", priority.is_some()),
+        ],
+    )?;
+
+    let mut fields = json!({
+        "project": { "key": project },
+        "issuetype": { "name": issue_type },
+        "summary": summary,
+    });
+
+    if let Some(desc) = description {
+        fields["description"] = plain_text_adf(desc);
+    }
+    if let Some(user) = assignee {
+        fields["assignee"] = json!({ "id": user });
+    }
+    if let Some(pri) = priority {
+        fields["priority"] = json!({ "name": pri });
+    }
+    for (key, value) in custom {
+        fields[key] = value.clone();
+    }
+
+    Ok(json!({ "fields": fields }))
+}
+
 #[allow(clippy::too_many_arguments)]
 pub async fn create_issue(
     ctx: &JiraContext<'_>,
@@ -272,38 +359,15 @@ pub async fn create_issue(
     priority: Option<&str>,
     custom_fields: &HashMap<String, Value>,
 ) -> Result<()> {
-    use serde_json::json;
-
-    let mut fields = json!({
-        "project": { "key": project },
-        "issuetype": { "name": issue_type },
-        "summary": summary,
-    });
-
-    if let Some(desc) = description {
-        fields["description"] = json!({
-            "type": "doc",
-            "version": 1,
-            "content": [{
-                "type": "paragraph",
-                "content": [{ "type": "text", "text": desc }]
-            }]
-        });
-    }
-
-    if let Some(user) = assignee {
-        fields["assignee"] = json!({ "id": user });
-    }
-
-    if let Some(pri) = priority {
-        fields["priority"] = json!({ "name": pri });
-    }
-
-    for (key, value) in custom_fields {
-        fields[key] = value.clone();
-    }
-
-    let payload = json!({ "fields": fields });
+    let payload = build_create_payload(
+        project,
+        issue_type,
+        summary,
+        description,
+        assignee,
+        priority,
+        custom_fields,
+    )?;
 
     #[derive(Deserialize)]
     struct CreateResponse {
@@ -325,6 +389,42 @@ pub async fn create_issue(
     )
 }
 
+/// Build the PUT body for `PUT /rest/api/3/issue/{key}`. Pure, testable.
+pub(crate) fn build_update_payload(
+    summary: Option<&str>,
+    description: Option<&str>,
+    priority: Option<&str>,
+    custom: &HashMap<String, Value>,
+) -> Result<Value> {
+    use serde_json::json;
+
+    check_field_collisions(
+        custom,
+        &[],
+        &[
+            ("summary", "--summary", summary.is_some()),
+            ("description", "--description", description.is_some()),
+            ("priority", "--priority", priority.is_some()),
+        ],
+    )?;
+
+    let mut fields = json!({});
+    if let Some(s) = summary {
+        fields["summary"] = json!(s);
+    }
+    if let Some(desc) = description {
+        fields["description"] = plain_text_adf(desc);
+    }
+    if let Some(pri) = priority {
+        fields["priority"] = json!({ "name": pri });
+    }
+    for (key, value) in custom {
+        fields[key] = value.clone();
+    }
+
+    Ok(json!({ "fields": fields }))
+}
+
 pub async fn update_issue(
     ctx: &JiraContext<'_>,
     key: &str,
@@ -333,34 +433,7 @@ pub async fn update_issue(
     priority: Option<&str>,
     custom_fields: &HashMap<String, Value>,
 ) -> Result<()> {
-    use serde_json::json;
-
-    let mut fields = json!({});
-
-    if let Some(s) = summary {
-        fields["summary"] = json!(s);
-    }
-
-    if let Some(desc) = description {
-        fields["description"] = json!({
-            "type": "doc",
-            "version": 1,
-            "content": [{
-                "type": "paragraph",
-                "content": [{ "type": "text", "text": desc }]
-            }]
-        });
-    }
-
-    if let Some(pri) = priority {
-        fields["priority"] = json!({ "name": pri });
-    }
-
-    for (key, value) in custom_fields {
-        fields[key] = value.clone();
-    }
-
-    let payload = json!({ "fields": fields });
+    let payload = build_update_payload(summary, description, priority, custom_fields)?;
 
     let _: Value = ctx
         .client
@@ -1665,5 +1738,95 @@ mod tests {
         let input = vec![r#"customfield_10001={"formula":"a=b"}"#.to_string()];
         let result = parse_custom_fields(&input).unwrap();
         assert_eq!(result["customfield_10001"], json!({"formula": "a=b"}));
+    }
+
+    #[test]
+    fn test_parse_custom_fields_duplicate_key_rejected() {
+        let input = vec![
+            r#"customfield_10001={"value":"first"}"#.to_string(),
+            r#"customfield_10001={"value":"second"}"#.to_string(),
+        ];
+        let err = parse_custom_fields(&input).unwrap_err().to_string();
+        assert!(err.contains("more than once"), "got: {err}");
+        assert!(err.contains("customfield_10001"), "got: {err}");
+    }
+
+    // -- Payload assembly + collision tests --
+
+    fn cf(pairs: &[(&str, Value)]) -> HashMap<String, Value> {
+        pairs
+            .iter()
+            .map(|(k, v)| (k.to_string(), v.clone()))
+            .collect()
+    }
+
+    #[test]
+    fn build_create_payload_merges_typed_and_custom() {
+        let custom = cf(&[("customfield_10010", json!({"value": "x"}))]);
+        let payload = build_create_payload(
+            "PROJ",
+            "Task",
+            "hello",
+            Some("desc"),
+            Some("u1"),
+            Some("High"),
+            &custom,
+        )
+        .unwrap();
+        let fields = &payload["fields"];
+        assert_eq!(fields["project"]["key"], "PROJ");
+        assert_eq!(fields["issuetype"]["name"], "Task");
+        assert_eq!(fields["summary"], "hello");
+        assert_eq!(fields["assignee"]["id"], "u1");
+        assert_eq!(fields["priority"]["name"], "High");
+        assert_eq!(fields["customfield_10010"], json!({"value": "x"}));
+        // description wrapped as ADF
+        assert_eq!(fields["description"]["type"], "doc");
+    }
+
+    #[test]
+    fn build_create_payload_rejects_mandatory_collision() {
+        let custom = cf(&[("summary", json!("x"))]);
+        let err = build_create_payload("PROJ", "Task", "s", None, None, None, &custom)
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("reserved"), "got: {err}");
+        assert!(err.contains("--summary"), "got: {err}");
+    }
+
+    #[test]
+    fn build_create_payload_rejects_optional_when_both_set() {
+        let custom = cf(&[("description", json!({"type": "doc"}))]);
+        let err =
+            build_create_payload("PROJ", "Task", "s", Some("typed desc"), None, None, &custom)
+                .unwrap_err()
+                .to_string();
+        assert!(err.contains("collides"), "got: {err}");
+        assert!(err.contains("--description"), "got: {err}");
+    }
+
+    #[test]
+    fn build_create_payload_allows_raw_only_optional() {
+        let raw_desc = json!({"type": "doc", "version": 1, "content": []});
+        let custom = cf(&[("description", raw_desc.clone())]);
+        let payload = build_create_payload("PROJ", "Task", "s", None, None, None, &custom).unwrap();
+        assert_eq!(payload["fields"]["description"], raw_desc);
+    }
+
+    #[test]
+    fn build_update_payload_rejects_summary_collision() {
+        let custom = cf(&[("summary", json!("raw"))]);
+        let err = build_update_payload(Some("typed"), None, None, &custom)
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("collides"), "got: {err}");
+        assert!(err.contains("--summary"), "got: {err}");
+    }
+
+    #[test]
+    fn build_update_payload_raw_only_priority_ok() {
+        let custom = cf(&[("priority", json!({"name": "Low"}))]);
+        let payload = build_update_payload(None, None, None, &custom).unwrap();
+        assert_eq!(payload["fields"]["priority"], json!({"name": "Low"}));
     }
 }

--- a/crates/cli/src/commands/jira/mod.rs
+++ b/crates/cli/src/commands/jira/mod.rs
@@ -125,7 +125,7 @@ enum IssueCommands {
 
     /// Create a new issue
     #[command(
-        long_about = "Create a new issue.\n\nExamples:\n  jira issue create --project PROJ --issue-type Bug --summary \"Fix login error\"\n  jira issue create --project PROJ --issue-type Story --summary \"Add feature\" --description \"Detailed description\" --assignee user@email.com --priority High"
+        long_about = "Create a new issue.\n\nExamples:\n  jira issue create --project PROJ --issue-type Bug --summary \"Fix login error\"\n  jira issue create --project PROJ --issue-type Story --summary \"Add feature\" --description \"Detailed description\" --assignee user@email.com --priority High\n  jira issue create --project PROJ --issue-type Task --summary \"Test\" --field 'customfield_10001={\"value\":\"Alpha\"}' --field 'customfield_10002=[{\"value\":\"Beta\"}]'"
     )]
     Create {
         /// Project key (e.g., PROJ)
@@ -146,6 +146,9 @@ enum IssueCommands {
         /// Priority name (e.g., High, Medium, Low)
         #[arg(long)]
         priority: Option<String>,
+        /// Custom field as key=value where value is JSON (repeatable)
+        #[arg(long = "field")]
+        fields: Vec<String>,
     },
 
     /// Update an existing issue
@@ -161,6 +164,9 @@ enum IssueCommands {
         /// New priority
         #[arg(long)]
         priority: Option<String>,
+        /// Custom field as key=value where value is JSON (repeatable)
+        #[arg(long = "field")]
+        fields: Vec<String>,
     },
 
     /// Delete an issue
@@ -815,7 +821,9 @@ pub async fn execute(args: JiraArgs, client: ApiClient, renderer: &OutputRendere
                 description,
                 assignee,
                 priority,
+                fields,
             } => {
+                let custom_fields = issues::parse_custom_fields(&fields)?;
                 issues::create_issue(
                     &ctx,
                     &project,
@@ -824,6 +832,7 @@ pub async fn execute(args: JiraArgs, client: ApiClient, renderer: &OutputRendere
                     description.as_deref(),
                     assignee.as_deref(),
                     priority.as_deref(),
+                    &custom_fields,
                 )
                 .await
             }
@@ -832,13 +841,16 @@ pub async fn execute(args: JiraArgs, client: ApiClient, renderer: &OutputRendere
                 summary,
                 description,
                 priority,
+                fields,
             } => {
+                let custom_fields = issues::parse_custom_fields(&fields)?;
                 issues::update_issue(
                     &ctx,
                     &key,
                     summary.as_deref(),
                     description.as_deref(),
                     priority.as_deref(),
+                    &custom_fields,
                 )
                 .await
             }

--- a/crates/cli/src/commands/jira/mod.rs
+++ b/crates/cli/src/commands/jira/mod.rs
@@ -124,9 +124,14 @@ enum IssueCommands {
     },
 
     /// Create a new issue
-    #[command(
-        long_about = "Create a new issue.\n\nExamples:\n  jira issue create --project PROJ --issue-type Bug --summary \"Fix login error\"\n  jira issue create --project PROJ --issue-type Story --summary \"Add feature\" --description \"Detailed description\" --assignee user@email.com --priority High\n  jira issue create --project PROJ --issue-type Task --summary \"Test\" --field 'customfield_10001={\"value\":\"Alpha\"}' --field 'customfield_10002=[{\"value\":\"Beta\"}]'"
-    )]
+    #[command(long_about = "Create a new issue.\n\nExamples:\n  \
+        jira issue create --project PROJ --issue-type Bug --summary \"Fix login error\"\n  \
+        jira issue create --project PROJ --issue-type Story --summary \"Add feature\" --description \"Detailed description\" --assignee user@email.com --priority High\n  \
+        jira issue create --project PROJ --issue-type Task --summary \"Test\" --field 'customfield_10001={\"value\":\"Alpha\"}' --field 'customfield_10002=[{\"value\":\"Beta\"}]'\n  \
+        jira issue create --project PROJ --issue-type Task --summary \"=in value\" --field 'customfield_10020={\"formula\":\"a=b\"}'\n\n\
+        Discover custom field IDs with: `jira fields list` or `jira fields get <id>`.\n\
+        --field cannot overwrite reserved keys (project, issuetype, summary) or \
+        fields already set via a typed flag (--description, --assignee, --priority).")]
     Create {
         /// Project key (e.g., PROJ)
         #[arg(long)]
@@ -137,7 +142,7 @@ enum IssueCommands {
         /// Issue summary
         #[arg(long)]
         summary: String,
-        /// Issue description (Atlassian Document Format or plain text)
+        /// Issue description (plain text; wrapped as a single-paragraph ADF doc)
         #[arg(long)]
         description: Option<String>,
         /// Assignee account ID or email
@@ -146,26 +151,30 @@ enum IssueCommands {
         /// Priority name (e.g., High, Medium, Low)
         #[arg(long)]
         priority: Option<String>,
-        /// Custom field as key=value where value is JSON (repeatable)
-        #[arg(long = "field")]
+        /// Jira custom field (repeatable). Discover IDs via `jira fields list`.
+        #[arg(long = "field", value_name = "KEY=JSON_VALUE")]
         fields: Vec<String>,
     },
 
     /// Update an existing issue
+    #[command(long_about = "Update an existing issue.\n\n\
+        --field (repeatable) lets you set arbitrary fields (including customfield_*); \
+        discover IDs with `jira fields list`. --field cannot collide with \
+        --summary, --description, or --priority when those are also set.")]
     Update {
         /// Issue key
         key: String,
         /// New summary
         #[arg(long)]
         summary: Option<String>,
-        /// New description
+        /// New description (plain text; wrapped as a single-paragraph ADF doc)
         #[arg(long)]
         description: Option<String>,
         /// New priority
         #[arg(long)]
         priority: Option<String>,
-        /// Custom field as key=value where value is JSON (repeatable)
-        #[arg(long = "field")]
+        /// Jira custom field (repeatable). Discover IDs via `jira fields list`.
+        #[arg(long = "field", value_name = "KEY=JSON_VALUE")]
         fields: Vec<String>,
     },
 

--- a/crates/cli/tests/cli_integration.rs
+++ b/crates/cli/tests/cli_integration.rs
@@ -315,3 +315,22 @@ profiles:
         "Jira commands should require base_url. Got: {stderr}"
     );
 }
+
+#[test]
+fn test_jira_issue_create_help_mentions_custom_fields() {
+    let output = Command::new("cargo")
+        .args(["run", "--quiet", "--", "jira", "issue", "create", "--help"])
+        .output()
+        .expect("Failed to execute command");
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("KEY=JSON_VALUE"),
+        "expected --field value_name in help, got: {stdout}"
+    );
+    assert!(
+        stdout.contains("jira fields list"),
+        "expected fields-discovery hint in help, got: {stdout}"
+    );
+}

--- a/docs/14042026_jira_custom_fields.md
+++ b/docs/14042026_jira_custom_fields.md
@@ -1,0 +1,69 @@
+# Jira Custom Fields (`--field`)
+
+Date: 2026-04-14
+
+## Overview
+
+`jira issue create`, `jira issue update`, and `jira bulk import` accept arbitrary Jira fields (including `customfield_*`) via a repeatable `--field` flag or a `custom_fields` map in the bulk-import JSON schema.
+
+## Usage
+
+### Single issue
+
+```bash
+atlassian-cli jira issue create --project PROJ --issue-type Task \
+  --summary "cf test" \
+  --field 'customfield_10010={"value":"Internal"}' \
+  --field 'customfield_12100={"value":"SRE"}'
+
+atlassian-cli jira issue update DEV-42 \
+  --field 'customfield_12100={"value":"Platform"}'
+```
+
+The value after `=` is JSON, so objects, arrays, strings, and numbers all work. `=` inside JSON values is preserved (only the first `=` splits key from value):
+
+```bash
+--field 'customfield_10020={"formula":"a=b"}'
+```
+
+### Bulk import
+
+```json
+[
+  {
+    "summary": "Ticket from import",
+    "issue_type": "Task",
+    "custom_fields": {
+      "customfield_10010": [{"value": "Internal"}],
+      "customfield_12100": {"value": "SRE"}
+    }
+  }
+]
+```
+
+## Discovering field IDs
+
+```bash
+atlassian-cli jira fields list           # all fields in your instance
+atlassian-cli jira fields get customfield_10010
+```
+
+## Collision rules
+
+`--field` (and `custom_fields` in bulk) **cannot silently overwrite** fields that have a dedicated source:
+
+- **Reserved (always rejected)**: `project`, `issuetype`, `summary` on create; same three plus `project`/`issuetype`/`summary` on bulk rows.
+- **Optional (rejected when both sources set)**: `description`, `assignee`, `priority`, and (bulk only) `labels`. Using `--field` is fine as long as the typed flag (`--description`, `--assignee`, `--priority`, or row `labels`) is NOT also provided.
+
+Duplicate `--field` entries targeting the same key are also rejected.
+
+Example rejection:
+
+```text
+$ jira issue create ... --summary "A" --field 'summary="B"'
+Error: --field cannot set reserved key 'summary'; use --summary instead
+```
+
+## Rationale
+
+The silent last-write-wins behavior would have been a real footgun — e.g. a user combining `--summary "typed"` with `--field summary=...` would get whichever path ran last. Hard-erroring forces the user to pick one source and makes the CLI's behavior deterministic.

--- a/todo.md
+++ b/todo.md
@@ -856,3 +856,12 @@ current → draft: error (cannot unpublish)
   - Tokens stored only in `~/.atlassian-cli/credentials` with 600 permissions
   - Token lookup: env var → credentials file
   - Removed `CredentialStore` struct, simplified auth code
+
+## 2026-04-14 — Jira custom field support (`--field`) landed (PR #40)
+
+- Added `--field key=JSON_VALUE` to `jira issue create`/`update` and `custom_fields` map to `bulk import` rows.
+- Duplicate `--field` keys hard-error.
+- Collision check rejects raw keys colliding with reserved (`project`, `issuetype`, `summary`) or already-set typed flags (`--description`, `--assignee`, `--priority`, `--labels` in bulk).
+- Payload assembly extracted to `build_create_payload` / `build_update_payload` / `build_bulk_payload` for unit-testability.
+- New doc: `docs/14042026_jira_custom_fields.md`. README example updated. CLI help integration test added.
+- Co-authored with @thereisnotime (original PR).


### PR DESCRIPTION
## Summary

- Adds a repeatable `--field key=JSON_VALUE` flag to `jira issue create` and `jira issue update` for setting arbitrary Jira custom fields
- Adds an optional `custom_fields` map to the `bulk import` JSON schema, merged into each issue's API payload
- Existing behavior is unchanged when no `--field` flags or `custom_fields` are provided

This unblocks usage with projects that require custom fields (e.g. "Customer/s", "Team") which previously couldn't be targeted by the CLI at all.

### Usage

```bash
# Single issue
jira issue create --project DEVOPS --issue-type Task --summary "Test" \
  --field 'customfield_10105=[{"value":"Internal"}]' \
  --field 'customfield_12100={"value":"SRE"}'

# Update
jira issue update DEVOPS-42 --field 'customfield_12100={"value":"Platform"}'

# Bulk import (JSON file)
[
  {
    "summary": "Ticket from import",
    "issue_type": "Task",
    "custom_fields": {
      "customfield_10105": [{"value": "Internal"}],
      "customfield_12100": {"value": "SRE"}
    }
  }
]
```

## Test plan

- [ ] `jira issue create` with `--field` flags creates issue with custom fields populated
- [ ] `jira issue update` with `--field` flags updates custom fields on existing issue
- [ ] `jira bulk import` with `custom_fields` in JSON creates issues with custom fields
- [ ] All commands work normally when no `--field` / `custom_fields` provided (no regression)
- [ ] Invalid `--field` format (missing `=` or bad JSON) produces clear error message