### PR TITLE
SEO overhaul + independent-OSS positioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,12 @@ Automate your entire Atlassian Cloud stack from the terminal. Bulk operations,
 dry-run mode, multiple output formats (JSON/CSV/YAML/table), and profile-based
 multi-instance support.
 
+> **Independent open-source project.** `atlassian-cli` is not affiliated with,
+> endorsed by, sponsored by, or maintained by Atlassian. Atlassian maintains its
+> own separate official CLI (`acli`). Atlassian, Jira, Confluence, Bitbucket, and
+> Jira Service Management are trademarks of Atlassian Pty Ltd; product names are
+> used here only to identify compatibility.
+
 [![CI](https://github.com/omar16100/atlassian-cli/actions/workflows/ci.yml/badge.svg)](https://github.com/omar16100/atlassian-cli/actions)
 [![crates.io](https://img.shields.io/crates/v/atlassian-cli.svg)](https://crates.io/crates/atlassian-cli)
 [![MIT License](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,34 @@
+# Security Policy
+
+`atlassian-cli` is an independent open-source project. It is not affiliated with,
+endorsed by, sponsored by, or maintained by Atlassian.
+
+## Scope
+
+`atlassian-cli` runs entirely on the user's own machine. API tokens are stored
+locally with AES-256-GCM encryption (`~/.config/atlassian-cli/credentials`). The
+project and the `atlassiancli.com` website never receive, transmit, or process
+user Atlassian credentials.
+
+## Supported versions
+
+Security fixes are applied to the latest released version on
+[crates.io](https://crates.io/crates/atlassian-cli). Please upgrade before
+reporting an issue to confirm it still reproduces.
+
+## Reporting a vulnerability
+
+Please report suspected vulnerabilities **privately** — do not open a public
+issue for security problems.
+
+- Preferred: open a private advisory via
+  [GitHub Security Advisories](https://github.com/omar16100/atlassian-cli/security/advisories/new)
+- Alternative: email **omarshabab55@gmail.com** with subject `atlassian-cli security`
+
+Please include: affected version, reproduction steps, and impact. We aim to
+acknowledge within 7 days and to provide a remediation timeline after triage.
+
+## Disclosure
+
+Coordinated disclosure is preferred. We will credit reporters in the release
+notes unless anonymity is requested.

--- a/crates/cli/src/commands/bitbucket/pipelines.rs
+++ b/crates/cli/src/commands/bitbucket/pipelines.rs
@@ -673,7 +673,7 @@ pub async fn list_pipelines(
     };
     let rows: Vec<PipelineRow> = all_pipelines
         .iter()
-        .zip(step_summaries.into_iter())
+        .zip(step_summaries)
         .map(|(pipeline, steps_summary)| {
             let status = get_pipeline_status(pipeline);
             PipelineRow {

--- a/docs/.well-known/security.txt
+++ b/docs/.well-known/security.txt
@@ -1,0 +1,8 @@
+# Security contact for atlassian-cli (independent open-source project,
+# not affiliated with Atlassian).
+Contact: https://github.com/omar16100/atlassian-cli/security/advisories/new
+Contact: mailto:omarshabab55@gmail.com
+Expires: 2027-05-16T00:00:00.000Z
+Preferred-Languages: en
+Canonical: https://atlassiancli.com/.well-known/security.txt
+Policy: https://github.com/omar16100/atlassian-cli/blob/main/SECURITY.md

--- a/docs/about/index.html
+++ b/docs/about/index.html
@@ -1,0 +1,143 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>About atlassian-cli — Independent Open-Source Project | atlassian-cli</title>
+    <meta name="description" content="atlassian-cli is an independent, MIT-licensed open-source CLI for Jira, Confluence, Bitbucket and JSM Cloud. It is not affiliated with, endorsed by, or maintained by Atlassian.">
+    <meta property="og:site_name" content="atlassian-cli">
+    <meta property="og:title" content="About atlassian-cli — Independent Open-Source Project">
+    <meta property="og:description" content="An independent, MIT-licensed open-source CLI for Atlassian Cloud. Not affiliated with Atlassian.">
+    <meta property="og:type" content="article">
+    <meta property="og:url" content="https://atlassiancli.com/about/">
+    <meta name="twitter:card" content="summary">
+    <meta name="twitter:title" content="About atlassian-cli — Independent Open-Source Project">
+    <meta name="twitter:description" content="An independent, MIT-licensed open-source CLI for Atlassian Cloud. Not affiliated with Atlassian.">
+    <link rel="canonical" href="https://atlassiancli.com/about/" />
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet">
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-SHR43YZK8C"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      gtag('config', 'G-SHR43YZK8C');
+    </script>
+
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "BreadcrumbList",
+      "itemListElement": [
+        {"@type": "ListItem", "position": 1, "name": "atlassian-cli", "item": "https://atlassiancli.com/"},
+        {"@type": "ListItem", "position": 2, "name": "About", "item": "https://atlassiancli.com/about/"}
+      ]
+    }
+    </script>
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "AboutPage",
+      "name": "About atlassian-cli",
+      "url": "https://atlassiancli.com/about/",
+      "description": "atlassian-cli is an independent open-source project, not affiliated with Atlassian.",
+      "mainEntity": {
+        "@type": "SoftwareSourceCode",
+        "name": "atlassian-cli",
+        "codeRepository": "https://github.com/omar16100/atlassian-cli",
+        "programmingLanguage": "Rust",
+        "license": "https://opensource.org/licenses/MIT",
+        "maintainer": {"@type": "Person", "name": "Omar Shabab", "url": "https://omarshabab.com"}
+      }
+    }
+    </script>
+
+    <link rel="stylesheet" href="../styles.css">
+</head>
+<body>
+    <!-- Navigation -->
+    <nav class="nav">
+        <div class="nav-container">
+            <a href="/" class="nav-logo">
+                <img src="../assets/logo.svg" alt="atlassian-cli" height="24">
+            </a>
+            <div class="nav-links">
+                <a href="/jira/" class="nav-link">Jira CLI</a>
+                <a href="/confluence/" class="nav-link">Confluence CLI</a>
+                <a href="/bitbucket/" class="nav-link">Bitbucket CLI</a>
+                <a href="/docs/" class="nav-link">Docs</a>
+                <a href="/blog/" class="nav-link">Blog</a>
+                <a href="https://github.com/omar16100/atlassian-cli" target="_blank" rel="noopener" class="nav-link">
+                    <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor">
+                        <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"/>
+                    </svg>
+                    GitHub
+                </a>
+                <a href="/install/" class="nav-btn">Install</a>
+            </div>
+        </div>
+    </nav>
+
+    <!-- Hero -->
+    <section class="hero" style="padding-top: 6rem;">
+        <div class="hero-container">
+            <div class="hero-badge">About</div>
+            <h1 class="hero-title">About <span class="hero-highlight">atlassian-cli</span></h1>
+            <p class="hero-subtitle">An independent, open-source command-line tool for automating Atlassian Cloud from your terminal.</p>
+            <p class="hero-disclaimer">Independent open-source project — not affiliated with, endorsed by, sponsored by, or maintained by Atlassian.</p>
+        </div>
+    </section>
+
+    <!-- Content -->
+    <section class="install" style="padding-top: 2rem;">
+        <div class="container">
+            <h2 class="section-title">What atlassian-cli is</h2>
+            <p class="section-subtitle">A community tool, not an Atlassian product.</p>
+            <p>atlassian-cli is an independent open-source command-line tool compatible with Jira, Confluence, Bitbucket, and Jira Service Management Cloud. It is not affiliated with, endorsed by, sponsored by, or maintained by Atlassian. Atlassian maintains its own separate official CLI (<code>acli</code>); this project is unrelated to it and is built and maintained independently by the open-source community.</p>
+
+            <h2 class="section-title" style="margin-top: 3rem;">Maintainer &amp; license</h2>
+            <p>atlassian-cli is maintained by <a href="https://omarshabab.com" target="_blank" rel="noopener">Omar Shabab</a> and contributors. It is written in Rust and released under the <a href="https://opensource.org/licenses/MIT" target="_blank" rel="noopener">MIT License</a>. The full source code is public at <a href="https://github.com/omar16100/atlassian-cli" target="_blank" rel="noopener">github.com/omar16100/atlassian-cli</a> and the crate is published at <a href="https://crates.io/crates/atlassian-cli" target="_blank" rel="noopener">crates.io/crates/atlassian-cli</a>.</p>
+
+            <h2 class="section-title" style="margin-top: 3rem;">Security &amp; your credentials</h2>
+            <p>atlassian-cli runs entirely on your own machine. API tokens you create are stored locally with AES-256-GCM encryption — this project and this website never receive, transmit, or process your Atlassian credentials. To report a vulnerability, see our <a href="https://github.com/omar16100/atlassian-cli/blob/main/SECURITY.md" target="_blank" rel="noopener">security policy</a> or <a href="/.well-known/security.txt">security.txt</a>.</p>
+
+            <h2 class="section-title" style="margin-top: 3rem;">Trademarks</h2>
+            <p>Atlassian, Jira, Confluence, Bitbucket, and Jira Service Management are trademarks of Atlassian Pty Ltd or its affiliates. These names are used on this site only to identify the products atlassian-cli is compatible with (nominative use). No sponsorship or affiliation is implied.</p>
+
+            <h2 class="section-title" style="margin-top: 3rem;">Get started</h2>
+            <p>Install via <a href="/install/">Homebrew, Cargo, or a prebuilt binary</a>, then explore the <a href="/docs/">documentation</a> or the per-product guides: <a href="/jira/">Jira CLI</a>, <a href="/confluence/">Confluence CLI</a>, <a href="/bitbucket/">Bitbucket CLI</a>, and <a href="/jsm/">JSM CLI</a>.</p>
+        </div>
+    </section>
+
+    <!-- Footer -->
+    <footer class="footer">
+        <div class="container">
+            <div class="footer-content">
+                <div class="footer-left">
+                    <span class="footer-logo">atlassian-cli</span>
+                    <span class="footer-version">v0.3.3</span>
+                </div>
+                <div class="footer-links">
+                    <a href="/jira/">Jira CLI</a>
+                    <a href="/confluence/">Confluence CLI</a>
+                    <a href="/bitbucket/">Bitbucket CLI</a>
+                    <a href="/jsm/">JSM CLI</a>
+                    <a href="/blog/">Blog</a>
+                    <a href="https://github.com/omar16100/atlassian-cli" target="_blank" rel="noopener">GitHub</a>
+                </div>
+                <div class="footer-right">
+                    <span class="footer-license">MIT License</span>
+                </div>
+            </div>
+            <div class="footer-credit">
+                Built by <a href="https://omarshabab.com" target="_blank" rel="noopener">Omar Shabab</a>
+            </div>
+            <div class="footer-legal">
+                <p>atlassian-cli is an independent open-source project maintained by <a href="https://omarshabab.com" target="_blank" rel="noopener">Omar Shabab</a>. It is not affiliated with, endorsed by, sponsored by, or maintained by Atlassian.</p>
+                <p>Atlassian, Jira, Confluence, Bitbucket, and Jira Service Management are trademarks of Atlassian Pty Ltd or its affiliates. Product names are used only to identify compatibility.</p>
+            </div>
+        </div>
+    </footer>
+</body>
+</html>

--- a/docs/bitbucket/index.html
+++ b/docs/bitbucket/index.html
@@ -5,7 +5,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Bitbucket CLI — Automate Pull Requests, Pipelines & Repository Management | atlassian-cli</title>
     <meta name="description" content="Automate Bitbucket from the command line with atlassian-cli. Pull requests, pipelines, branch protection, repository management — all from your terminal.">
-    <meta name="keywords" content="bitbucket cli, bitbucket command line, bitbucket automation, pull request cli, pipeline cli, bitbucket api">
 
     <!-- Open Graph -->
     <meta property="og:title" content="Bitbucket CLI — Automate Pull Requests, Pipelines & Repository Management">
@@ -33,6 +32,16 @@
     </script>
 
     <!-- Structured Data -->
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "BreadcrumbList",
+      "itemListElement": [
+        {"@type": "ListItem", "position": 1, "name": "atlassian-cli", "item": "https://atlassiancli.com/"},
+        {"@type": "ListItem", "position": 2, "name": "Bitbucket CLI", "item": "https://atlassiancli.com/bitbucket/"}
+      ]
+    }
+    </script>
     <script type="application/ld+json">
     {
       "@context": "https://schema.org",
@@ -161,15 +170,18 @@
                 <img src="../assets/logo.svg" alt="atlassian-cli" height="24">
             </a>
             <div class="nav-links">
+                <a href="/jira/" class="nav-link">Jira CLI</a>
+                <a href="/confluence/" class="nav-link">Confluence CLI</a>
+                <a href="/bitbucket/" class="nav-link" aria-current="page">Bitbucket CLI</a>
+                <a href="/docs/" class="nav-link">Docs</a>
+                <a href="/blog/" class="nav-link">Blog</a>
                 <a href="https://github.com/omar16100/atlassian-cli" target="_blank" rel="noopener" class="nav-link">
                     <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor">
                         <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"/>
                     </svg>
                     GitHub
                 </a>
-                <a href="https://github.com/omar16100/atlassian-cli#readme" target="_blank" rel="noopener" class="nav-link">Docs</a>
-                <a href="/blog/" class="nav-link">Blog</a>
-                <a href="#quickstart" class="nav-btn">Install</a>
+                <a href="/install/" class="nav-btn">Install</a>
             </div>
         </div>
     </nav>
@@ -186,6 +198,24 @@
                 <a href="/bitbucket/" class="current">Bitbucket</a>
                 <a href="/jsm/">JSM</a>
             </div>
+        </div>
+    </section>
+
+    <!-- What is Bitbucket CLI? -->
+    <section class="features-section" style="padding-top: 2rem;">
+        <div class="container" style="max-width: 820px;">
+            <h2 class="section-title">What is the Bitbucket CLI?</h2>
+            <p style="color: var(--text-secondary); line-height: 1.75; font-size: 1.05rem;">The Bitbucket CLI (<code>atlassian-cli bitbucket</code>, aliased as <code>bb</code>) is a command-line tool for Bitbucket Cloud. It covers the full repo + PR workflow — list/create/update repositories, manage branches and branch protection, open/approve/merge pull requests, trigger pipelines, rotate SSH keys, administer webhooks, and browse commits. Output formats (JSON, CSV, YAML, table) make it drop-in for CI pipelines and audits.</p>
+            <p style="color: var(--text-secondary); line-height: 1.75; font-size: 1.05rem;">It ships as part of <a href="/">atlassian-cli</a>, one open-source Rust binary that also handles <a href="/jira/">Jira</a>, <a href="/confluence/">Confluence</a>, and <a href="/jsm/">Jira Service Management</a>. Install via <a href="/install/">Homebrew or Cargo</a>, then authenticate with either a <strong>Bitbucket API token</strong> (Basic auth, personal account) or a <strong>workspace / repository access token</strong> (Bearer auth, CI-scoped). See the <a href="/docs/auth.html#bitbucket">auth guide</a> for both flows.</p>
+
+            <h2 class="section-title" style="margin-top: 3rem;">When to use a Bitbucket CLI</h2>
+            <ul style="color: var(--text-secondary); line-height: 1.8; max-width: 720px; margin: 0 auto;">
+                <li><strong>PR automation</strong> — open a PR from a build, approve + merge release branches on a schedule, post comments with test coverage results. See the <a href="/runbooks/bitbucket-pr-automation.html">PR automation runbook</a>.</li>
+                <li><strong>Branch hygiene</strong> — bulk-delete stale feature branches older than N days, protect <code>main</code> across all repos, audit current branch restrictions. See the <a href="/runbooks/bitbucket-branch-cleanup.html">branch cleanup runbook</a>.</li>
+                <li><strong>Repository inventory</strong> — list every repo in a workspace, filter by last update, find orphaned repos. The <a href="/runbooks/bitbucket-repo-audit.html">repo audit runbook</a> has a ready-made script.</li>
+                <li><strong>Pipeline orchestration</strong> — trigger pipelines from other CI systems, poll for completion, collect logs.</li>
+                <li><strong>Access reviews</strong> — list workspace members, repo permissions, and deploy keys for compliance.</li>
+            </ul>
         </div>
     </section>
 
@@ -286,7 +316,7 @@
                     <pre class="code-block" id="code-pr"><code><span class="comment"># List open pull requests as JSON</span>
 atlassian-cli bitbucket --workspace myteam \
   pr list api-service \
-  --state OPEN --output json
+  --state OPEN --format json
 
 <span class="comment"># Approve and merge with squash strategy</span>
 atlassian-cli bitbucket --workspace myteam \
@@ -348,7 +378,7 @@ atlassian-cli bitbucket --workspace myteam \
                     </div>
                     <pre class="code-block" id="code-audit"><code><span class="comment"># List all repos in a workspace</span>
 atlassian-cli bitbucket --workspace myteam \
-  repo list --output json
+  repo list --format json
 
 <span class="comment"># Get repo details</span>
 atlassian-cli bitbucket --workspace myteam \
@@ -381,7 +411,7 @@ brew install omar16100/atlassian-cli/atlassian-cli
 <span class="comment"># Basic auth (email + API token)</span>
 atlassian-cli auth login \
   --profile <span class="string">bb-work</span> \
-  --base-url <span class="string">your-domain.atlassian.net</span> \
+  --base-url <span class="string">https://your-domain.atlassian.net</span> \
   --email <span class="string">you@company.com</span>
 
 <span class="comment"># Bearer token auth (scoped Bitbucket token)</span>
@@ -400,6 +430,83 @@ atlassian-cli bitbucket --workspace myteam \
         </div>
     </section>
 
+    <!-- Command cluster -->
+    <section class="features-section">
+        <div class="container" style="max-width: 880px;">
+            <h2 class="section-title">Bitbucket command groups</h2>
+            <p class="section-subtitle">Each group links to the full <a href="/docs/commands.html">command reference</a>.</p>
+            <table style="width: 100%; margin: 2rem 0; border-collapse: collapse;">
+                <thead>
+                    <tr style="border-bottom: 1px solid var(--border);">
+                        <th style="text-align: left; padding: 0.75rem 0.5rem; color: var(--text-primary); font-weight: 600;">Group</th>
+                        <th style="text-align: left; padding: 0.75rem 0.5rem; color: var(--text-primary); font-weight: 600;">Covers</th>
+                    </tr>
+                </thead>
+                <tbody style="color: var(--text-secondary);">
+                    <tr style="border-bottom: 1px solid var(--border);">
+                        <td style="padding: 0.75rem 0.5rem; vertical-align: top;"><a href="/docs/commands.html#bb-repos"><code>bb repo</code></a></td>
+                        <td style="padding: 0.75rem 0.5rem;">List, get, create, update, delete repositories. Filter by project or last update.</td>
+                    </tr>
+                    <tr style="border-bottom: 1px solid var(--border);">
+                        <td style="padding: 0.75rem 0.5rem; vertical-align: top;"><a href="/docs/commands.html#bb-branches"><code>bb branch</code></a></td>
+                        <td style="padding: 0.75rem 0.5rem;">Branch CRUD plus branch protection (approvals, merge restrictions, required checks).</td>
+                    </tr>
+                    <tr style="border-bottom: 1px solid var(--border);">
+                        <td style="padding: 0.75rem 0.5rem; vertical-align: top;"><a href="/docs/commands.html#bb-pr"><code>bb pr</code></a></td>
+                        <td style="padding: 0.75rem 0.5rem;">List, get, create, approve, merge, comment on pull requests. Machine-readable output for CI gating.</td>
+                    </tr>
+                    <tr style="border-bottom: 1px solid var(--border);">
+                        <td style="padding: 0.75rem 0.5rem; vertical-align: top;"><a href="/docs/commands.html#bb-pipelines"><code>bb pipeline</code></a></td>
+                        <td style="padding: 0.75rem 0.5rem;">Trigger, list, stop pipelines. Useful for cross-service orchestration.</td>
+                    </tr>
+                    <tr style="border-bottom: 1px solid var(--border);">
+                        <td style="padding: 0.75rem 0.5rem; vertical-align: top;"><a href="/docs/commands.html#bb-webhooks"><code>bb webhook</code> / <code>bb ssh-key</code></a></td>
+                        <td style="padding: 0.75rem 0.5rem;">Webhook management and deploy-key lifecycle.</td>
+                    </tr>
+                    <tr style="border-bottom: 1px solid var(--border);">
+                        <td style="padding: 0.75rem 0.5rem; vertical-align: top;"><a href="/docs/commands.html#bb-workspaces"><code>bb workspace</code> / <code>bb project</code></a></td>
+                        <td style="padding: 0.75rem 0.5rem;">Workspace and project-level inventory and admin.</td>
+                    </tr>
+                    <tr style="border-bottom: 1px solid var(--border);">
+                        <td style="padding: 0.75rem 0.5rem; vertical-align: top;"><a href="/docs/commands.html#bb-permissions"><code>bb permission</code> / <code>bb commit</code></a></td>
+                        <td style="padding: 0.75rem 0.5rem;">Repo permission admin and commit/diff browsing.</td>
+                    </tr>
+                    <tr>
+                        <td style="padding: 0.75rem 0.5rem; vertical-align: top;"><a href="/docs/commands.html#bb-bulk"><code>bb bulk archive-repos / delete-branches</code></a></td>
+                        <td style="padding: 0.75rem 0.5rem;">Bulk operations with dry-run previews and filters (by age, by pattern).</td>
+                    </tr>
+                </tbody>
+            </table>
+            <p style="color: var(--text-secondary);">Full flag list and output schemas are in the <a href="/docs/commands.html">command reference</a>. For auth (bearer vs. basic), see the <a href="/docs/auth.html#bitbucket">Bitbucket authentication section</a>.</p>
+        </div>
+    </section>
+
+    <!-- FAQ -->
+    <section class="features-section" style="background: var(--bg-primary);">
+        <div class="container" style="max-width: 760px;">
+            <h2 class="section-title">Frequently asked questions</h2>
+            <div style="margin-top: 2rem; color: var(--text-secondary); line-height: 1.7;">
+                <h3 style="color: var(--text-primary); margin-top: 1.5rem;">What's the difference between Basic and Bearer auth for Bitbucket?</h3>
+                <p><strong>Basic auth</strong> uses an Atlassian API token scoped to Bitbucket — it authenticates as <em>your</em> account and needs your email. Good for personal day-to-day work. <strong>Bearer auth</strong> uses a repository/workspace/project <em>access token</em> — it's scoped to a specific resource and doesn't need an email, so it's the right choice for CI. App passwords are deprecated (creation ended Sep 9, 2025; existing app passwords stop working Jun 9, 2026). Full setup in the <a href="/docs/auth.html#bitbucket">auth guide</a>.</p>
+
+                <h3 style="color: var(--text-primary); margin-top: 1.5rem;">Can I use <code>bb</code> instead of <code>bitbucket</code>?</h3>
+                <p>Yes. <code>bb</code> is the built-in visible alias. <code>atlassian-cli bb pr list myteam api-service</code> is identical to <code>atlassian-cli bitbucket pr list myteam api-service</code>.</p>
+
+                <h3 style="color: var(--text-primary); margin-top: 1.5rem;">How do I automate PR approval in CI?</h3>
+                <p>Create a workspace access token with <code>pullrequest:write</code> scope, export it as <code>BITBUCKET_TOKEN</code> in your pipeline, then run <code>atlassian-cli auth login --profile ci --bitbucket --bearer --token $BITBUCKET_TOKEN</code> once in a setup step. Subsequent <code>bb pr approve</code> and <code>bb pr merge</code> calls use that profile. The <a href="/runbooks/bitbucket-pr-automation.html">PR automation runbook</a> has a full example.</p>
+
+                <h3 style="color: var(--text-primary); margin-top: 1.5rem;">Can I bulk-delete stale branches?</h3>
+                <p>Yes. <code>atlassian-cli bb --workspace myteam bulk delete-branches api-service --exclude feature/keep --dry-run</code> prints the list of branches that would go, filtered by your exclusion patterns. Remove <code>--dry-run</code> once it looks right. The <a href="/runbooks/bitbucket-branch-cleanup.html">branch cleanup runbook</a> walks through a production version.</p>
+
+                <h3 style="color: var(--text-primary); margin-top: 1.5rem;">Does it support self-hosted Bitbucket?</h3>
+                <p>Current focus is Bitbucket Cloud. Bitbucket Data Center has a different REST API surface — check the <a href="https://github.com/omar16100/atlassian-cli" target="_blank" rel="noopener">GitHub repo</a> for any DC-specific work.</p>
+
+                <h3 style="color: var(--text-primary); margin-top: 1.5rem;">Is it free?</h3>
+                <p>Yes — MIT licensed. Bitbucket Cloud itself has a free tier for small teams; the CLI works with any plan.</p>
+            </div>
+        </div>
+    </section>
+
     <!-- Related Resources -->
     <section class="resources-section">
         <div class="container">
@@ -410,8 +517,8 @@ atlassian-cli bitbucket --workspace myteam \
                     <h4>Blog</h4>
                     <p>Tutorials, release notes, and automation tips for Bitbucket and the full Atlassian stack.</p>
                 </a>
-                <a href="https://github.com/omar16100/atlassian-cli#readme" target="_blank" rel="noopener" class="resource-card">
-                    <h4>Full Documentation</h4>
+                <a href="/docs/commands.html#bb-user" class="resource-card">
+                    <h4>Bitbucket Command Reference</h4>
                     <p>Complete command reference for all Bitbucket subcommands, flags, and output formats.</p>
                 </a>
                 <a href="https://github.com/omar16100/atlassian-cli/tree/main/docs/examples/bitbucket" target="_blank" rel="noopener" class="resource-card">
@@ -432,7 +539,7 @@ atlassian-cli bitbucket --workspace myteam \
                 </div>
                 <div class="footer-links">
                     <a href="https://github.com/omar16100/atlassian-cli" target="_blank" rel="noopener">GitHub</a>
-                    <a href="https://github.com/omar16100/atlassian-cli#readme" target="_blank" rel="noopener">Documentation</a>
+                    <a href="/docs/">Documentation</a>
                     <a href="https://github.com/omar16100/atlassian-cli/issues" target="_blank" rel="noopener">Issues</a>
                     <a href="/blog/">Blog</a>
                 </div>
@@ -442,6 +549,10 @@ atlassian-cli bitbucket --workspace myteam \
             </div>
             <div class="footer-credit">
                 Built by <a href="https://omarshabab.com" target="_blank" rel="noopener">Omar Shabab</a>
+            </div>
+            <div class="footer-legal">
+                <p>atlassian-cli is an independent open-source project maintained by <a href="https://omarshabab.com" target="_blank" rel="noopener">Omar Shabab</a>. It is not affiliated with, endorsed by, sponsored by, or maintained by Atlassian.</p>
+                <p>Atlassian, Jira, Confluence, Bitbucket, and Jira Service Management are trademarks of Atlassian Pty Ltd or its affiliates. Product names are used only to identify compatibility.</p>
             </div>
         </div>
     </footer>

--- a/docs/blog/atlassian-cli-guide.html
+++ b/docs/blog/atlassian-cli-guide.html
@@ -5,7 +5,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>atlassian-cli: One CLI for Your Entire Atlassian Stack | atlassian-cli Blog</title>
     <meta name="description" content="Why atlassian-cli is the only CLI you need for Jira, Confluence, Bitbucket, and JSM. Install, configure, and automate your Atlassian Cloud stack.">
-    <meta name="keywords" content="atlassian cli, atlassian command line interface, jira cli, confluence cli, bitbucket cli, jsm cli, atlassian automation">
 
     <!-- Open Graph -->
     <meta property="og:title" content="atlassian-cli: One CLI for Your Entire Atlassian Stack">
@@ -38,6 +37,17 @@
     </script>
 
     <!-- Structured Data: Article -->
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "BreadcrumbList",
+      "itemListElement": [
+        {"@type": "ListItem", "position": 1, "name": "atlassian-cli", "item": "https://atlassiancli.com/"},
+        {"@type": "ListItem", "position": 2, "name": "Blog", "item": "https://atlassiancli.com/blog/"},
+        {"@type": "ListItem", "position": 3, "name": "atlassian-cli: One CLI for Your Entire Atlassian Stack", "item": "https://atlassiancli.com/blog/atlassian-cli-guide.html"}
+      ]
+    }
+    </script>
     <script type="application/ld+json">
     {
       "@context": "https://schema.org",
@@ -289,7 +299,7 @@
                 </a>
                 <a href="https://github.com/omar16100/atlassian-cli#readme" target="_blank" rel="noopener" class="nav-link">Docs</a>
                 <a href="/blog/" class="nav-link" style="color: var(--text-primary);">Blog</a>
-                <a href="/#install" class="nav-btn">Install</a>
+                <a href="/install/" class="nav-btn">Install</a>
             </div>
         </div>
     </nav>
@@ -366,7 +376,7 @@ atlassian-cli --version</code></pre>
         <pre><code><span class="comment"># Interactive login (prompts for token)</span>
 atlassian-cli auth login \
   --profile <span class="string">work</span> \
-  --base-url <span class="string">your-domain.atlassian.net</span> \
+  --base-url <span class="string">https://your-domain.atlassian.net</span> \
   --email <span class="string">you@company.com</span> \
   --default</code></pre>
 
@@ -551,7 +561,7 @@ atlassian-cli jira bulk transition \
         <div class="article-cta">
             <h3>Install atlassian-cli</h3>
             <p>One CLI for your entire Atlassian Cloud stack. Open source, MIT licensed.</p>
-            <a href="/#install" class="article-cta-btn">Get Started</a>
+            <a href="/install/" class="article-cta-btn">Get Started</a>
         </div>
 
     </article>
@@ -576,6 +586,10 @@ atlassian-cli jira bulk transition \
             </div>
             <div class="footer-credit">
                 Built by <a href="https://omarshabab.com" target="_blank" rel="noopener">Omar Shabab</a>
+            </div>
+            <div class="footer-legal">
+                <p>atlassian-cli is an independent open-source project maintained by <a href="https://omarshabab.com" target="_blank" rel="noopener">Omar Shabab</a>. It is not affiliated with, endorsed by, sponsored by, or maintained by Atlassian.</p>
+                <p>Atlassian, Jira, Confluence, Bitbucket, and Jira Service Management are trademarks of Atlassian Pty Ltd or its affiliates. Product names are used only to identify compatibility.</p>
             </div>
         </div>
     </footer>

--- a/docs/blog/bitbucket-cli-guide.html
+++ b/docs/blog/bitbucket-cli-guide.html
@@ -5,7 +5,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Bitbucket CLI: Automate PRs, Pipelines & Repos | atlassian-cli Blog</title>
     <meta name="description" content="Automate your entire Bitbucket workflow from the terminal. Pull requests, pipelines, branch protection, bearer auth, and repository management.">
-    <meta name="keywords" content="bitbucket cli, bitbucket command line, bitbucket cli tool, bitbucket automation, bitbucket pr cli, bitbucket pipeline cli, bitbucket terminal">
 
     <!-- Open Graph -->
     <meta property="og:title" content="Bitbucket CLI: Automate PRs, Pipelines & Repos">
@@ -38,6 +37,17 @@
     </script>
 
     <!-- Structured Data: Article -->
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "BreadcrumbList",
+      "itemListElement": [
+        {"@type": "ListItem", "position": 1, "name": "atlassian-cli", "item": "https://atlassiancli.com/"},
+        {"@type": "ListItem", "position": 2, "name": "Blog", "item": "https://atlassiancli.com/blog/"},
+        {"@type": "ListItem", "position": 3, "name": "Bitbucket CLI: Automate PRs, Pipelines & Repos", "item": "https://atlassiancli.com/blog/bitbucket-cli-guide.html"}
+      ]
+    }
+    </script>
     <script type="application/ld+json">
     {
       "@context": "https://schema.org",
@@ -443,7 +453,7 @@
                 </a>
                 <a href="https://github.com/omar16100/atlassian-cli#readme" target="_blank" rel="noopener" class="nav-link">Docs</a>
                 <a href="/blog/" class="nav-link">Blog</a>
-                <a href="/#install" class="nav-btn">Install</a>
+                <a href="/install/" class="nav-btn">Install</a>
             </div>
         </div>
     </nav>
@@ -465,6 +475,27 @@
     <!-- Article Body -->
     <article class="article-body">
 
+        <!-- TL;DR -->
+        <div class="toc">
+            <div class="toc-title">TL;DR</div>
+            <p>atlassian-cli gives you a full Bitbucket CLI for pull requests, pipelines, repos, and branch protection in one Rust binary. Install it, then jump to the section you need below.</p>
+            <pre><code><span class="comment"># Install</span>
+brew install omar16100/atlassian-cli/atlassian-cli
+
+<span class="comment"># List open pull requests</span>
+atlassian-cli bitbucket pr list --workspace <span class="string">myteam</span> --repo <span class="string">api-service</span> --state <span class="string">OPEN</span></code></pre>
+            <ul>
+                <li><a href="#why-bitbucket-cli">Why Automate Bitbucket from CLI?</a></li>
+                <li><a href="#authentication">Authentication</a></li>
+                <li><a href="#repository-management">Repository Management</a></li>
+                <li><a href="#pull-requests">Pull Request Workflows</a></li>
+                <li><a href="#pipelines">Pipeline Operations</a></li>
+                <li><a href="#branch-management">Branch Management</a></li>
+                <li><a href="#real-world-workflows">Real-World Workflows</a></li>
+                <li><a href="#faq">FAQ</a></li>
+            </ul>
+        </div>
+
         <!-- Table of Contents -->
         <nav class="toc">
             <div class="toc-title">Contents</div>
@@ -485,7 +516,7 @@
 
         <p>Bitbucket's web UI works fine for reviewing a single pull request. It doesn't work well when you need to audit permissions across 200 repositories, trigger pipelines from a CI script, or clean up stale branches across your entire workspace.</p>
 
-        <p>A <strong>Bitbucket CLI</strong> turns these multi-click workflows into single commands. With <a href="https://github.com/omar16100/atlassian-cli">atlassian-cli</a>, you get full Bitbucket coverage in the same binary that handles Jira, Confluence, and JSM. That means one tool, one config, one authentication flow for your entire Atlassian stack.</p>
+        <p>A <strong>Bitbucket CLI</strong> turns these multi-click workflows into single commands. With <a href="https://github.com/omar16100/atlassian-cli">atlassian-cli</a>, you get full Bitbucket coverage in the same binary that handles Jira, Confluence, and JSM. That means one tool, one config, one authentication flow for your entire Atlassian stack. For the full command reference, see the <a href="/bitbucket/">Bitbucket CLI</a> documentation.</p>
 
         <p>Common use cases for a Bitbucket command line tool:</p>
 
@@ -834,6 +865,10 @@ atlassian-cli bitbucket --workspace myteam commit browse <span class="string">ap
             </div>
             <div class="footer-credit">
                 Built by <a href="https://omarshabab.com" target="_blank" rel="noopener">Omar Shabab</a>
+            </div>
+            <div class="footer-legal">
+                <p>atlassian-cli is an independent open-source project maintained by <a href="https://omarshabab.com" target="_blank" rel="noopener">Omar Shabab</a>. It is not affiliated with, endorsed by, sponsored by, or maintained by Atlassian.</p>
+                <p>Atlassian, Jira, Confluence, Bitbucket, and Jira Service Management are trademarks of Atlassian Pty Ltd or its affiliates. Product names are used only to identify compatibility.</p>
             </div>
         </div>
     </footer>

--- a/docs/blog/confluence-cli-guide.html
+++ b/docs/blog/confluence-cli-guide.html
@@ -5,7 +5,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Manage Confluence from the Command Line | atlassian-cli Blog</title>
     <meta name="description" content="Complete guide to managing Confluence from the command line. CQL search, space management, bulk export, backups, attachments, and markdown sync.">
-    <meta name="keywords" content="confluence cli, confluence command line, confluence cql, confluence bulk export, confluence backup cli, confluence automation, confluence api cli">
 
     <!-- Open Graph -->
     <meta property="og:title" content="Manage Confluence from the Command Line">
@@ -38,6 +37,17 @@
     </script>
 
     <!-- Structured Data: Article -->
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "BreadcrumbList",
+      "itemListElement": [
+        {"@type": "ListItem", "position": 1, "name": "atlassian-cli", "item": "https://atlassiancli.com/"},
+        {"@type": "ListItem", "position": 2, "name": "Blog", "item": "https://atlassiancli.com/blog/"},
+        {"@type": "ListItem", "position": 3, "name": "Manage Confluence from the Command Line", "item": "https://atlassiancli.com/blog/confluence-cli-guide.html"}
+      ]
+    }
+    </script>
     <script type="application/ld+json">
     {
       "@context": "https://schema.org",
@@ -348,7 +358,7 @@
                 </a>
                 <a href="https://github.com/omar16100/atlassian-cli#readme" target="_blank" rel="noopener" class="nav-link">Docs</a>
                 <a href="/blog/" class="nav-link">Blog</a>
-                <a href="/#install" class="nav-btn">Install</a>
+                <a href="/install/" class="nav-btn">Install</a>
             </div>
         </div>
     </nav>
@@ -392,7 +402,7 @@
 
         <p>A <strong>Confluence CLI</strong> tool lets you script these operations. Search pages with CQL (Confluence Query Language), pipe results to <code>jq</code>, export spaces to JSON for backup, upload attachments from CI/CD pipelines, and manage permissions across spaces -- all without clicking through the web UI. If you already use <code>atlassian-cli</code> for <a href="/blog/jira-cli-complete-guide.html">Jira</a> or Bitbucket, the Confluence commands follow the same patterns: profiles, output formats, dry-run, and bulk operations.</p>
 
-        <p>This guide covers every Confluence command available in <a href="https://github.com/omar16100/atlassian-cli">atlassian-cli</a>, with copy-paste examples for each.</p>
+        <p>This guide covers every Confluence command available in <a href="https://github.com/omar16100/atlassian-cli">atlassian-cli</a>, with copy-paste examples for each. For the complete command reference, see the <a href="/confluence/">Confluence CLI</a> documentation.</p>
 
         <!-- Section 2: Getting Started -->
         <h2 id="getting-started">Getting Started</h2>
@@ -416,7 +426,7 @@ atlassian-cli --version</code></pre>
         <pre><code><span class="comment"># Add a profile</span>
 atlassian-cli auth login \
   --profile <span class="string">work</span> \
-  --base-url <span class="string">your-domain.atlassian.net</span> \
+  --base-url <span class="string">https://your-domain.atlassian.net</span> \
   --email <span class="string">you@company.com</span> \
   --token <span class="string">$ATLASSIAN_API_TOKEN</span> \
   --default
@@ -787,6 +797,10 @@ atlassian-cli confluence space create \
             </div>
             <div class="footer-credit">
                 Built by <a href="https://omarshabab.com" target="_blank" rel="noopener">Omar Shabab</a>
+            </div>
+            <div class="footer-legal">
+                <p>atlassian-cli is an independent open-source project maintained by <a href="https://omarshabab.com" target="_blank" rel="noopener">Omar Shabab</a>. It is not affiliated with, endorsed by, sponsored by, or maintained by Atlassian.</p>
+                <p>Atlassian, Jira, Confluence, Bitbucket, and Jira Service Management are trademarks of Atlassian Pty Ltd or its affiliates. Product names are used only to identify compatibility.</p>
             </div>
         </div>
     </footer>

--- a/docs/blog/index.html
+++ b/docs/blog/index.html
@@ -5,7 +5,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Blog | atlassian-cli — Jira, Confluence, Bitbucket & JSM CLI Tutorials</title>
     <meta name="description" content="Tutorials, guides, and tips for using atlassian-cli — the open-source CLI for Jira, Confluence, Bitbucket, and JSM automation.">
-    <meta name="keywords" content="atlassian cli blog, jira cli tutorials, confluence cli guide, bitbucket cli, jira cli commands, jira bulk operations, jira service management cli">
 
     <!-- Open Graph -->
     <meta property="og:title" content="Blog | atlassian-cli — Jira, Confluence, Bitbucket & JSM CLI Tutorials">
@@ -235,7 +234,7 @@
                 </a>
                 <a href="https://github.com/omar16100/atlassian-cli#readme" target="_blank" rel="noopener" class="nav-link">Docs</a>
                 <a href="/blog/" class="nav-link" style="color: var(--text-primary);">Blog</a>
-                <a href="/#install" class="nav-btn">Install</a>
+                <a href="/install/" class="nav-btn">Install</a>
             </div>
         </div>
     </nav>
@@ -371,6 +370,10 @@
             </div>
             <div class="footer-credit">
                 Built by <a href="https://omarshabab.com" target="_blank" rel="noopener">Omar Shabab</a>
+            </div>
+            <div class="footer-legal">
+                <p>atlassian-cli is an independent open-source project maintained by <a href="https://omarshabab.com" target="_blank" rel="noopener">Omar Shabab</a>. It is not affiliated with, endorsed by, sponsored by, or maintained by Atlassian.</p>
+                <p>Atlassian, Jira, Confluence, Bitbucket, and Jira Service Management are trademarks of Atlassian Pty Ltd or its affiliates. Product names are used only to identify compatibility.</p>
             </div>
         </div>
     </footer>

--- a/docs/blog/jira-bulk-operations.html
+++ b/docs/blog/jira-bulk-operations.html
@@ -5,7 +5,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Bulk Jira Operations from the Terminal | atlassian-cli Blog</title>
     <meta name="description" content="Process thousands of Jira issues at once from the command line. Bulk transitions, field updates, dry-run safety, and concurrency control.">
-    <meta name="keywords" content="jira bulk operations, jira bulk transition, jira bulk update, jira cli bulk, bulk jira issues, jira command line bulk">
 
     <!-- Open Graph -->
     <meta property="og:title" content="Bulk Jira Operations from the Terminal">
@@ -38,6 +37,17 @@
     </script>
 
     <!-- Structured Data: Article -->
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "BreadcrumbList",
+      "itemListElement": [
+        {"@type": "ListItem", "position": 1, "name": "atlassian-cli", "item": "https://atlassiancli.com/"},
+        {"@type": "ListItem", "position": 2, "name": "Blog", "item": "https://atlassiancli.com/blog/"},
+        {"@type": "ListItem", "position": 3, "name": "Bulk Jira Operations from the Terminal", "item": "https://atlassiancli.com/blog/jira-bulk-operations.html"}
+      ]
+    }
+    </script>
     <script type="application/ld+json">
     {
       "@context": "https://schema.org",
@@ -402,7 +412,7 @@
                 </a>
                 <a href="https://github.com/omar16100/atlassian-cli#readme" target="_blank" rel="noopener" class="nav-link">Docs</a>
                 <a href="/blog/" class="nav-link">Blog</a>
-                <a href="/#install" class="nav-btn">Install</a>
+                <a href="/install/" class="nav-btn">Install</a>
             </div>
         </div>
     </nav>
@@ -667,6 +677,10 @@ echo <span class="string">"Sprint cleanup complete."</span></code></pre>
             </div>
             <div class="footer-credit">
                 Built by <a href="https://omarshabab.com" target="_blank" rel="noopener">Omar Shabab</a>
+            </div>
+            <div class="footer-legal">
+                <p>atlassian-cli is an independent open-source project maintained by <a href="https://omarshabab.com" target="_blank" rel="noopener">Omar Shabab</a>. It is not affiliated with, endorsed by, sponsored by, or maintained by Atlassian.</p>
+                <p>Atlassian, Jira, Confluence, Bitbucket, and Jira Service Management are trademarks of Atlassian Pty Ltd or its affiliates. Product names are used only to identify compatibility.</p>
             </div>
         </div>
     </footer>

--- a/docs/blog/jira-cli-commands-cheat-sheet.html
+++ b/docs/blog/jira-cli-commands-cheat-sheet.html
@@ -5,7 +5,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Jira CLI Commands Cheat Sheet | atlassian-cli Blog</title>
     <meta name="description" content="Quick-reference cheat sheet for Jira CLI commands. Search, create, update, transition, bulk operations, and admin commands -- all copy-paste ready.">
-    <meta name="keywords" content="jira cli commands, jira-cli commands, jira command line, jira cli cheat sheet, jira cli reference, jql cli, jira bulk commands">
 
     <!-- Open Graph -->
     <meta property="og:title" content="Jira CLI Commands Cheat Sheet">
@@ -38,6 +37,17 @@
     </script>
 
     <!-- Structured Data: Article -->
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "BreadcrumbList",
+      "itemListElement": [
+        {"@type": "ListItem", "position": 1, "name": "atlassian-cli", "item": "https://atlassiancli.com/"},
+        {"@type": "ListItem", "position": 2, "name": "Blog", "item": "https://atlassiancli.com/blog/"},
+        {"@type": "ListItem", "position": 3, "name": "Jira CLI Commands Cheat Sheet", "item": "https://atlassiancli.com/blog/jira-cli-commands-cheat-sheet.html"}
+      ]
+    }
+    </script>
     <script type="application/ld+json">
     {
       "@context": "https://schema.org",
@@ -412,7 +422,7 @@
                 </a>
                 <a href="https://github.com/omar16100/atlassian-cli#readme" target="_blank" rel="noopener" class="nav-link">Docs</a>
                 <a href="/blog/" class="nav-link">Blog</a>
-                <a href="/#install" class="nav-btn">Install</a>
+                <a href="/install/" class="nav-btn">Install</a>
             </div>
         </div>
     </nav>
@@ -469,7 +479,7 @@
                     <tr>
                         <td><code>auth login</code></td>
                         <td>Add a new profile with credentials</td>
-                        <td><code>atlassian-cli auth login --profile work --base-url your-domain.atlassian.net --email you@company.com --token $TOKEN --default</code></td>
+                        <td><code>atlassian-cli auth login --profile work --base-url https://your-domain.atlassian.net --email you@company.com --token $TOKEN --default</code></td>
                     </tr>
                     <tr>
                         <td><code>auth list</code></td>
@@ -879,6 +889,10 @@ atlassian-cli jira bulk export \
             </div>
             <div class="footer-credit">
                 Built by <a href="https://omarshabab.com" target="_blank" rel="noopener">Omar Shabab</a>
+            </div>
+            <div class="footer-legal">
+                <p>atlassian-cli is an independent open-source project maintained by <a href="https://omarshabab.com" target="_blank" rel="noopener">Omar Shabab</a>. It is not affiliated with, endorsed by, sponsored by, or maintained by Atlassian.</p>
+                <p>Atlassian, Jira, Confluence, Bitbucket, and Jira Service Management are trademarks of Atlassian Pty Ltd or its affiliates. Product names are used only to identify compatibility.</p>
             </div>
         </div>
     </footer>

--- a/docs/blog/jira-cli-complete-guide.html
+++ b/docs/blog/jira-cli-complete-guide.html
@@ -5,7 +5,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>The Complete Guide to Jira CLI Tools in 2026 | atlassian-cli</title>
     <meta name="description" content="The definitive guide to Jira CLI tools in 2026. Compare top tools, learn installation, authentication, JQL queries, bulk operations, and CI/CD automation.">
-    <meta name="keywords" content="jira cli, jira-cli, jira command line, jira cli tool, cli jira, jira terminal, jira automation cli, jql cli, jira bulk operations cli">
 
     <!-- Open Graph -->
     <meta property="og:title" content="The Complete Guide to Jira CLI Tools in 2026">
@@ -38,6 +37,17 @@
     </script>
 
     <!-- Structured Data: Article -->
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "BreadcrumbList",
+      "itemListElement": [
+        {"@type": "ListItem", "position": 1, "name": "atlassian-cli", "item": "https://atlassiancli.com/"},
+        {"@type": "ListItem", "position": 2, "name": "Blog", "item": "https://atlassiancli.com/blog/"},
+        {"@type": "ListItem", "position": 3, "name": "The Complete Guide to Jira CLI Tools in 2026", "item": "https://atlassiancli.com/blog/jira-cli-complete-guide.html"}
+      ]
+    }
+    </script>
     <script type="application/ld+json">
     {
       "@context": "https://schema.org",
@@ -463,7 +473,7 @@
                 </a>
                 <a href="https://github.com/omar16100/atlassian-cli#readme" target="_blank" rel="noopener" class="nav-link">Docs</a>
                 <a href="/blog/" class="nav-link">Blog</a>
-                <a href="/#install" class="nav-btn">Install</a>
+                <a href="/install/" class="nav-btn">Install</a>
             </div>
         </div>
     </nav>
@@ -613,7 +623,7 @@ atlassian-cli --version</code></pre>
         <pre><code><span class="comment"># Add a profile with your Atlassian credentials</span>
 atlassian-cli auth login \
   --profile <span class="string">work</span> \
-  --base-url <span class="string">your-domain.atlassian.net</span> \
+  --base-url <span class="string">https://your-domain.atlassian.net</span> \
   --email <span class="string">you@company.com</span> \
   --token <span class="string">$ATLASSIAN_API_TOKEN</span> \
   --default
@@ -834,6 +844,10 @@ jobs:
             </div>
             <div class="footer-credit">
                 Built by <a href="https://omarshabab.com" target="_blank" rel="noopener">Omar Shabab</a>
+            </div>
+            <div class="footer-legal">
+                <p>atlassian-cli is an independent open-source project maintained by <a href="https://omarshabab.com" target="_blank" rel="noopener">Omar Shabab</a>. It is not affiliated with, endorsed by, sponsored by, or maintained by Atlassian.</p>
+                <p>Atlassian, Jira, Confluence, Bitbucket, and Jira Service Management are trademarks of Atlassian Pty Ltd or its affiliates. Product names are used only to identify compatibility.</p>
             </div>
         </div>
     </footer>

--- a/docs/blog/jira-cli-tools-compared.html
+++ b/docs/blog/jira-cli-tools-compared.html
@@ -5,7 +5,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Best Jira CLI Tools Compared (2026) | atlassian-cli Blog</title>
     <meta name="description" content="An honest comparison of the best Jira CLI tools in 2026. atlassian-cli vs jira-cli vs go-jira vs ACLI — features, install, auth, and verdict.">
-    <meta name="keywords" content="jira cli tool, tools like jira, tools similar to jira, jira cli, jira command line, best jira cli, jira cli comparison">
 
     <!-- Open Graph -->
     <meta property="og:title" content="Best Jira CLI Tools Compared (2026)">
@@ -38,6 +37,17 @@
     </script>
 
     <!-- Structured Data: Article -->
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "BreadcrumbList",
+      "itemListElement": [
+        {"@type": "ListItem", "position": 1, "name": "atlassian-cli", "item": "https://atlassiancli.com/"},
+        {"@type": "ListItem", "position": 2, "name": "Blog", "item": "https://atlassiancli.com/blog/"},
+        {"@type": "ListItem", "position": 3, "name": "Best Jira CLI Tools Compared (2026)", "item": "https://atlassiancli.com/blog/jira-cli-tools-compared.html"}
+      ]
+    }
+    </script>
     <script type="application/ld+json">
     {
       "@context": "https://schema.org",
@@ -433,7 +443,7 @@
                 </a>
                 <a href="https://github.com/omar16100/atlassian-cli#readme" target="_blank" rel="noopener" class="nav-link">Docs</a>
                 <a href="/blog/" class="nav-link" style="color: var(--text-primary);">Blog</a>
-                <a href="/#install" class="nav-btn">Install</a>
+                <a href="/install/" class="nav-btn">Install</a>
             </div>
         </div>
     </nav>
@@ -703,7 +713,7 @@ jira create --project DEV --issuetype Task -s <span class="string">"Summary"</sp
         <div class="article-cta">
             <h3>Try atlassian-cli</h3>
             <p>One CLI for Jira, Confluence, Bitbucket, and JSM. Free and open source.</p>
-            <a href="/#install" class="article-cta-btn">Install Now</a>
+            <a href="/install/" class="article-cta-btn">Install Now</a>
         </div>
 
     </article>
@@ -728,6 +738,10 @@ jira create --project DEV --issuetype Task -s <span class="string">"Summary"</sp
             </div>
             <div class="footer-credit">
                 Built by <a href="https://omarshabab.com" target="_blank" rel="noopener">Omar Shabab</a>
+            </div>
+            <div class="footer-legal">
+                <p>atlassian-cli is an independent open-source project maintained by <a href="https://omarshabab.com" target="_blank" rel="noopener">Omar Shabab</a>. It is not affiliated with, endorsed by, sponsored by, or maintained by Atlassian.</p>
+                <p>Atlassian, Jira, Confluence, Bitbucket, and Jira Service Management are trademarks of Atlassian Pty Ltd or its affiliates. Product names are used only to identify compatibility.</p>
             </div>
         </div>
     </footer>

--- a/docs/blog/jsm-cli-guide.html
+++ b/docs/blog/jsm-cli-guide.html
@@ -5,7 +5,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>JSM from the Terminal: Service Desk Automation | atlassian-cli Blog</title>
     <meta name="description" content="Automate Jira Service Management from the command line. Manage service desks, requests, customers, SLAs, queues, and knowledge base articles via CLI.">
-    <meta name="keywords" content="jira service management cli, jsm cli, service desk automation cli, itsm cli, jsm command line, jira service desk cli">
 
     <!-- Open Graph -->
     <meta property="og:title" content="JSM from the Terminal: Service Desk Automation">
@@ -38,6 +37,17 @@
     </script>
 
     <!-- Structured Data: Article -->
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "BreadcrumbList",
+      "itemListElement": [
+        {"@type": "ListItem", "position": 1, "name": "atlassian-cli", "item": "https://atlassiancli.com/"},
+        {"@type": "ListItem", "position": 2, "name": "Blog", "item": "https://atlassiancli.com/blog/"},
+        {"@type": "ListItem", "position": 3, "name": "JSM from the Terminal: Service Desk Automation", "item": "https://atlassiancli.com/blog/jsm-cli-guide.html"}
+      ]
+    }
+    </script>
     <script type="application/ld+json">
     {
       "@context": "https://schema.org",
@@ -402,7 +412,7 @@
                 </a>
                 <a href="https://github.com/omar16100/atlassian-cli#readme" target="_blank" rel="noopener" class="nav-link">Docs</a>
                 <a href="/blog/" class="nav-link">Blog</a>
-                <a href="/#install" class="nav-btn">Install</a>
+                <a href="/install/" class="nav-btn">Install</a>
             </div>
         </div>
     </nav>
@@ -479,7 +489,7 @@ atlassian-cli --version</code></pre>
         <pre><code><span class="comment"># Add a profile with your Atlassian credentials</span>
 atlassian-cli auth login \
   --profile <span class="string">work</span> \
-  --base-url <span class="string">your-domain.atlassian.net</span> \
+  --base-url <span class="string">https://your-domain.atlassian.net</span> \
   --email <span class="string">you@company.com</span> \
   --token <span class="string">$ATLASSIAN_API_TOKEN</span> \
   --default
@@ -758,6 +768,10 @@ echo <span class="string">"Onboarded: $CUSTOMER_NAME ($CUSTOMER_EMAIL)"</span></
             </div>
             <div class="footer-credit">
                 Built by <a href="https://omarshabab.com" target="_blank" rel="noopener">Omar Shabab</a>
+            </div>
+            <div class="footer-legal">
+                <p>atlassian-cli is an independent open-source project maintained by <a href="https://omarshabab.com" target="_blank" rel="noopener">Omar Shabab</a>. It is not affiliated with, endorsed by, sponsored by, or maintained by Atlassian.</p>
+                <p>Atlassian, Jira, Confluence, Bitbucket, and Jira Service Management are trademarks of Atlassian Pty Ltd or its affiliates. Product names are used only to identify compatibility.</p>
             </div>
         </div>
     </footer>

--- a/docs/confluence/index.html
+++ b/docs/confluence/index.html
@@ -5,7 +5,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Confluence CLI — Manage Pages, Spaces & Exports from the Terminal | atlassian-cli</title>
     <meta name="description" content="Manage Confluence from the command line with atlassian-cli. CQL search, bulk export, space backups, page management — all from your terminal.">
-    <meta name="keywords" content="confluence cli, confluence command line, confluence cli tool, confluence terminal, confluence backup, cql search cli, confluence export">
     <meta property="og:title" content="Confluence CLI — Manage Pages, Spaces & Exports from the Terminal">
     <meta property="og:description" content="Manage Confluence from the command line with atlassian-cli. CQL search, bulk export, space backups, page management — all from your terminal.">
     <meta property="og:type" content="website">
@@ -23,6 +22,16 @@
       function gtag(){dataLayer.push(arguments);}
       gtag('js', new Date());
       gtag('config', 'G-SHR43YZK8C');
+    </script>
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "BreadcrumbList",
+      "itemListElement": [
+        {"@type": "ListItem", "position": 1, "name": "atlassian-cli", "item": "https://atlassiancli.com/"},
+        {"@type": "ListItem", "position": 2, "name": "Confluence CLI", "item": "https://atlassiancli.com/confluence/"}
+      ]
+    }
     </script>
     <script type="application/ld+json">
     {
@@ -51,15 +60,18 @@
                 <img src="../assets/logo.svg" alt="atlassian-cli" height="24">
             </a>
             <div class="nav-links">
+                <a href="/jira/" class="nav-link">Jira CLI</a>
+                <a href="/confluence/" class="nav-link" aria-current="page">Confluence CLI</a>
+                <a href="/bitbucket/" class="nav-link">Bitbucket CLI</a>
+                <a href="/docs/" class="nav-link">Docs</a>
+                <a href="/blog/" class="nav-link">Blog</a>
                 <a href="https://github.com/omar16100/atlassian-cli" target="_blank" rel="noopener" class="nav-link">
                     <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor">
                         <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"/>
                     </svg>
                     GitHub
                 </a>
-                <a href="https://github.com/omar16100/atlassian-cli#readme" target="_blank" rel="noopener" class="nav-link">Docs</a>
-                <a href="/blog/" class="nav-link">Blog</a>
-                <a href="/#install" class="nav-btn">Install</a>
+                <a href="/install/" class="nav-btn">Install</a>
             </div>
         </div>
     </nav>
@@ -71,10 +83,29 @@
             <h1 class="product-hero-title">Confluence <span class="highlight">CLI</span></h1>
             <p class="product-hero-subtitle">Manage pages, spaces, and exports from the terminal. CQL search, bulk backup, markdown sync, and attachment handling.</p>
             <div class="product-hero-links">
-                <a href="/#install">Install</a>
+                <a href="/install/">Install</a>
+                <a href="/docs/commands.html#conf-pages">Commands</a>
                 <a href="/jira/">Jira CLI</a>
                 <a href="/blog/">Blog</a>
             </div>
+        </div>
+    </section>
+
+    <!-- What is Confluence CLI? -->
+    <section class="product-features-section" style="padding-top: 2rem;">
+        <div class="container" style="max-width: 820px;">
+            <h2 class="section-title">What is the Confluence CLI?</h2>
+            <p style="color: var(--text-secondary); line-height: 1.75; font-size: 1.05rem;">The Confluence CLI (<code>atlassian-cli confluence</code>) is a command-line tool for Atlassian Confluence Cloud. It covers the full page and space lifecycle — search with CQL, create/update/delete pages, manage attachments, export spaces for backup, bulk-label or bulk-delete pages, and synchronize Markdown repositories into Confluence. Output formats (JSON, CSV, YAML, table) make it easy to feed results into audits, dashboards, or other automation.</p>
+            <p style="color: var(--text-secondary); line-height: 1.75; font-size: 1.05rem;">It ships as part of <a href="/">atlassian-cli</a>, one open-source Rust binary that also handles <a href="/jira/">Jira</a>, <a href="/bitbucket/">Bitbucket</a>, and <a href="/jsm/">Jira Service Management</a>. Install via <a href="/install/">Homebrew or Cargo</a> and authenticate with an <a href="/docs/auth.html">Atlassian Cloud API token</a>.</p>
+
+            <h2 class="section-title" style="margin-top: 3rem;">When to use a Confluence CLI</h2>
+            <ul style="color: var(--text-secondary); line-height: 1.8; max-width: 720px; margin: 0 auto;">
+                <li><strong>Space backups</strong> — export every page in a space to JSON with attachments, on a schedule, straight into object storage. See the <a href="/runbooks/confluence-backup.html">Confluence backup runbook</a>.</li>
+                <li><strong>Markdown → Confluence pipelines</strong> — maintain docs in Git, render with pandoc, and sync to Confluence. The <a href="/runbooks/confluence-markdown-sync.html">markdown sync runbook</a> shows an idempotent pipeline.</li>
+                <li><strong>Bulk cleanup</strong> — archive, delete, or relabel every page matching a CQL query. Dry-run previews protect shared spaces.</li>
+                <li><strong>Content audits</strong> — list pages modified in the last N days, find orphaned pages, or identify attachments over a size threshold.</li>
+                <li><strong>Onboarding &amp; access reviews</strong> — list space permissions and page restrictions to confirm who can see what.</li>
+            </ul>
         </div>
     </section>
 
@@ -150,17 +181,17 @@
                     </div>
                     <pre class="code-block" id="code-search"><code><span class="comment"># Search pages in a space</span>
 atlassian-cli confluence search cql \
-  --output json \
+  --format json \
   <span class="string">"space = DOCS AND type = page"</span>
 
 <span class="comment"># Search by label</span>
 atlassian-cli confluence search cql \
-  --output table \
+  --format table \
   <span class="string">"space = DOCS AND label = 'architecture'"</span>
 
 <span class="comment"># Find recently modified pages</span>
 atlassian-cli confluence search cql \
-  --output json \
+  --format json \
   <span class="string">"space = DOCS AND lastModified >= now('-7d')"</span></code></pre>
                 </div>
                 <div class="example-panel" id="tab-backup">
@@ -181,13 +212,13 @@ atlassian-cli confluence bulk export \
 atlassian-cli confluence space get \
   --profile prod \
   DOCS \
-  --output json
+  --format json
 
 <span class="comment"># List and download attachments</span>
 atlassian-cli confluence attachment list \
   --profile prod \
   123456 \
-  --output json</code></pre>
+  --format json</code></pre>
                 </div>
                 <div class="example-panel" id="tab-sync">
                     <div class="example-header">
@@ -198,7 +229,7 @@ atlassian-cli confluence attachment list \
                     </div>
                     <pre class="code-block" id="code-sync"><code><span class="comment"># Search for existing page by title</span>
 atlassian-cli confluence search cql \
-  --output json \
+  --format json \
   <span class="string">"space = DOCS AND title = \"API Reference\""</span>
 
 <span class="comment"># Create a new page in a space</span>
@@ -240,7 +271,7 @@ cargo install atlassian-cli</code></pre>
                 <pre class="code-block"><code><span class="comment"># Add your Confluence instance</span>
 atlassian-cli auth login \
   --profile <span class="string">work</span> \
-  --base-url <span class="string">your-domain.atlassian.net</span> \
+  --base-url <span class="string">https://your-domain.atlassian.net</span> \
   --email <span class="string">you@company.com</span>
 
 <span class="comment"># Verify connection</span>
@@ -254,26 +285,99 @@ atlassian-cli confluence search cql \
         </div>
     </section>
 
+    <!-- Command cluster -->
+    <section class="product-features-section">
+        <div class="container" style="max-width: 880px;">
+            <h2 class="section-title">Confluence command groups</h2>
+            <p class="section-subtitle">Each group links into the full <a href="/docs/commands.html">command reference</a>.</p>
+            <table style="width: 100%; margin: 2rem 0; border-collapse: collapse;">
+                <thead>
+                    <tr style="border-bottom: 1px solid var(--border);">
+                        <th style="text-align: left; padding: 0.75rem 0.5rem; color: var(--text-primary); font-weight: 600;">Group</th>
+                        <th style="text-align: left; padding: 0.75rem 0.5rem; color: var(--text-primary); font-weight: 600;">Covers</th>
+                    </tr>
+                </thead>
+                <tbody style="color: var(--text-secondary);">
+                    <tr style="border-bottom: 1px solid var(--border);">
+                        <td style="padding: 0.75rem 0.5rem; vertical-align: top;"><a href="/docs/commands.html#conf-search"><code>confluence search cql / text / in-space</code></a></td>
+                        <td style="padding: 0.75rem 0.5rem;">CQL queries, full-text search, per-space search. Filter by type, label, contributor, or modified date.</td>
+                    </tr>
+                    <tr style="border-bottom: 1px solid var(--border);">
+                        <td style="padding: 0.75rem 0.5rem; vertical-align: top;"><a href="/docs/commands.html#conf-spaces"><code>confluence space</code></a></td>
+                        <td style="padding: 0.75rem 0.5rem;">Create, update, delete, list spaces. Manage space permissions and default settings.</td>
+                    </tr>
+                    <tr style="border-bottom: 1px solid var(--border);">
+                        <td style="padding: 0.75rem 0.5rem; vertical-align: top;"><a href="/docs/commands.html#conf-pages"><code>confluence page</code></a></td>
+                        <td style="padding: 0.75rem 0.5rem;">Page CRUD, version history, labels, comments, restrictions. Works on any page you have access to.</td>
+                    </tr>
+                    <tr style="border-bottom: 1px solid var(--border);">
+                        <td style="padding: 0.75rem 0.5rem; vertical-align: top;"><a href="/docs/commands.html#conf-blog"><code>confluence blog</code></a></td>
+                        <td style="padding: 0.75rem 0.5rem;">Blog post CRUD in any space.</td>
+                    </tr>
+                    <tr style="border-bottom: 1px solid var(--border);">
+                        <td style="padding: 0.75rem 0.5rem; vertical-align: top;"><a href="/docs/commands.html#conf-attach"><code>confluence attachment</code></a></td>
+                        <td style="padding: 0.75rem 0.5rem;">Upload, download, list, and delete page attachments.</td>
+                    </tr>
+                    <tr style="border-bottom: 1px solid var(--border);">
+                        <td style="padding: 0.75rem 0.5rem; vertical-align: top;"><a href="/docs/commands.html#conf-bulk"><code>confluence bulk export / delete / add-labels</code></a></td>
+                        <td style="padding: 0.75rem 0.5rem;">Bulk operations with CQL filter + dry-run. Export a whole space to JSON, clean up stale content, retag at scale.</td>
+                    </tr>
+                    <tr>
+                        <td style="padding: 0.75rem 0.5rem; vertical-align: top;"><a href="/docs/commands.html#conf-analytics"><code>confluence analytics</code></a></td>
+                        <td style="padding: 0.75rem 0.5rem;">Page-view and space-stats analytics for reporting.</td>
+                    </tr>
+                </tbody>
+            </table>
+            <p style="color: var(--text-secondary);">See the <a href="/docs/commands.html">complete command reference</a> for flags and output schemas. Auth setup is in the <a href="/docs/auth.html">Authentication guide</a>.</p>
+        </div>
+    </section>
+
+    <!-- FAQ -->
+    <section class="product-features-section" style="background: var(--bg-secondary);">
+        <div class="container" style="max-width: 760px;">
+            <h2 class="section-title">Frequently asked questions</h2>
+            <div style="margin-top: 2rem; color: var(--text-secondary); line-height: 1.7;">
+                <h3 style="color: var(--text-primary); margin-top: 1.5rem;">How do I back up a Confluence space?</h3>
+                <p>Run <code>atlassian-cli confluence bulk export --space DEV --format json --output backup.json</code>. That pulls every page in the space into one JSON file you can store in S3 / Git / anywhere. Attach the matching attachments via the <code>attachment</code> group. End-to-end script in the <a href="/runbooks/confluence-backup.html">Confluence backup runbook</a>.</p>
+
+                <h3 style="color: var(--text-primary); margin-top: 1.5rem;">Can I sync Markdown files into Confluence?</h3>
+                <p>Yes. The usual pattern is: render Markdown to Confluence storage format with pandoc, then pass the HTML to <code>confluence page create</code> or <code>confluence page update</code>. The <a href="/runbooks/confluence-markdown-sync.html">markdown → Confluence runbook</a> contains a production-ready script with idempotent upserts keyed by page title.</p>
+
+                <h3 style="color: var(--text-primary); margin-top: 1.5rem;">What is CQL and how do I use it?</h3>
+                <p>Confluence Query Language. Same shape as Jira's JQL but with Confluence-specific fields: <code>space = DEV</code>, <code>type = page</code>, <code>label = onboarding</code>, <code>lastmodified &gt;= "2026-01-01"</code>. Combine clauses with <code>AND</code> / <code>OR</code>. The CLI accepts CQL directly: <code>atlassian-cli confluence search cql --cql "space = DEV AND type = page AND label = onboarding"</code>.</p>
+
+                <h3 style="color: var(--text-primary); margin-top: 1.5rem;">Is there dry-run mode for bulk operations?</h3>
+                <p>Yes. Every <code>confluence bulk</code> subcommand accepts <code>--dry-run</code>, which prints the exact list of pages that <em>would</em> be affected without calling the mutating API. Run it first, sanity-check the list, then re-run without the flag.</p>
+
+                <h3 style="color: var(--text-primary); margin-top: 1.5rem;">Does it work with Confluence Data Center?</h3>
+                <p>Primary target is Confluence Cloud. Some Data Center instances expose compatible v2 REST APIs, but support varies — check the <a href="https://github.com/omar16100/atlassian-cli" target="_blank" rel="noopener">GitHub repo</a> for the current DC status.</p>
+
+                <h3 style="color: var(--text-primary); margin-top: 1.5rem;">Is it free?</h3>
+                <p>Yes — MIT-licensed, open source. You need an Atlassian Cloud subscription for the Confluence instance itself, but the CLI is free for any use.</p>
+            </div>
+        </div>
+    </section>
+
     <!-- Related Resources -->
     <section class="related-section">
         <div class="container">
             <h2 class="section-title">Related Resources</h2>
             <p class="section-subtitle">Runbooks, guides, and tutorials for Confluence CLI workflows</p>
             <div class="related-grid">
-                <a href="/runbooks/confluence-backup-space.html" class="related-card">
+                <a href="/runbooks/confluence-backup.html" class="related-card">
                     <div class="related-card-type">Runbook</div>
-                    <h3 class="related-card-title">Confluence Space Backup</h3>
+                    <h3 class="related-card-title">Confluence Backup</h3>
                     <p class="related-card-desc">Production-ready script for backing up entire Confluence spaces with pages, blog posts, and attachments.</p>
                 </a>
-                <a href="/runbooks/confluence-doc-pipeline.html" class="related-card">
+                <a href="/runbooks/confluence-markdown-sync.html" class="related-card">
                     <div class="related-card-type">Runbook</div>
-                    <h3 class="related-card-title">Documentation Pipeline</h3>
+                    <h3 class="related-card-title">Markdown &rarr; Confluence Sync</h3>
                     <p class="related-card-desc">Automate markdown-to-Confluence sync. Convert docs from Git repos into Confluence pages with labels.</p>
                 </a>
-                <a href="/runbooks/confluence-bulk-export.html" class="related-card">
+                <a href="/runbooks/confluence-bulk-cleanup.html" class="related-card">
                     <div class="related-card-type">Runbook</div>
-                    <h3 class="related-card-title">Confluence Bulk Export</h3>
-                    <p class="related-card-desc">Export pages in bulk as JSON or CSV. Filter by CQL, include attachments, and create backup manifests.</p>
+                    <h3 class="related-card-title">Confluence Bulk Cleanup</h3>
+                    <p class="related-card-desc">Bulk archive, delete, or relabel pages with CQL filters, dry-run previews, and safety limits.</p>
                 </a>
                 <a href="/blog/confluence-cli-guide.html" class="related-card">
                     <div class="related-card-type">Blog</div>
@@ -306,7 +410,7 @@ atlassian-cli confluence search cql \
                 </div>
                 <div class="footer-links">
                     <a href="https://github.com/omar16100/atlassian-cli" target="_blank" rel="noopener">GitHub</a>
-                    <a href="https://github.com/omar16100/atlassian-cli#readme" target="_blank" rel="noopener">Documentation</a>
+                    <a href="/docs/">Documentation</a>
                     <a href="https://github.com/omar16100/atlassian-cli/issues" target="_blank" rel="noopener">Issues</a>
                     <a href="/blog/">Blog</a>
                 </div>
@@ -316,6 +420,10 @@ atlassian-cli confluence search cql \
             </div>
             <div class="footer-credit">
                 Built by <a href="https://omarshabab.com" target="_blank" rel="noopener">Omar Shabab</a>
+            </div>
+            <div class="footer-legal">
+                <p>atlassian-cli is an independent open-source project maintained by <a href="https://omarshabab.com" target="_blank" rel="noopener">Omar Shabab</a>. It is not affiliated with, endorsed by, sponsored by, or maintained by Atlassian.</p>
+                <p>Atlassian, Jira, Confluence, Bitbucket, and Jira Service Management are trademarks of Atlassian Pty Ltd or its affiliates. Product names are used only to identify compatibility.</p>
             </div>
         </div>
     </footer>

--- a/docs/docs/auth.html
+++ b/docs/docs/auth.html
@@ -1,0 +1,271 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>atlassian-cli Authentication — API Tokens, Profiles, Bitbucket Bearer | atlassian-cli</title>
+    <meta name="description" content="Authenticate atlassian-cli with Atlassian Cloud API tokens, Bitbucket bearer tokens, and multiple profiles. AES-256-GCM encrypted credentials, environment variables, CI/CD patterns.">
+    <meta property="og:site_name" content="atlassian-cli">
+    <meta property="og:title" content="atlassian-cli Authentication — API Tokens, Profiles, Bitbucket Bearer">
+    <meta property="og:description" content="Authenticate atlassian-cli with API tokens and bearer tokens. Profile-based multi-instance support with AES-256-GCM encrypted storage.">
+    <meta property="og:type" content="article">
+    <meta property="og:url" content="https://atlassiancli.com/docs/auth.html">
+    <meta name="twitter:card" content="summary">
+    <meta name="twitter:title" content="atlassian-cli Authentication — API Tokens, Profiles">
+    <meta name="twitter:description" content="Authenticate atlassian-cli with API tokens and bearer tokens. AES-256-GCM encrypted credentials.">
+    <link rel="canonical" href="https://atlassiancli.com/docs/auth.html" />
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet">
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-SHR43YZK8C"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      gtag('config', 'G-SHR43YZK8C');
+    </script>
+
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "BreadcrumbList",
+      "itemListElement": [
+        {"@type": "ListItem", "position": 1, "name": "atlassian-cli", "item": "https://atlassiancli.com/"},
+        {"@type": "ListItem", "position": 2, "name": "Documentation", "item": "https://atlassiancli.com/docs/"},
+        {"@type": "ListItem", "position": 3, "name": "Authentication", "item": "https://atlassiancli.com/docs/auth.html"}
+      ]
+    }
+    </script>
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "TechArticle",
+      "headline": "atlassian-cli Authentication",
+      "description": "Authenticate atlassian-cli with Atlassian Cloud API tokens, Bitbucket bearer tokens, profile management, and environment variables.",
+      "url": "https://atlassiancli.com/docs/auth.html",
+      "author": {"@type": "Person", "name": "Omar Shabab", "url": "https://omarshabab.com"},
+      "about": {"@type": "SoftwareApplication", "name": "atlassian-cli"}
+    }
+    </script>
+
+    <link rel="stylesheet" href="../styles.css">
+    <style>
+      .doc-body { max-width: 760px; margin: 0 auto; padding: 0 1.5rem; }
+      .doc-body h2 { font-size: 1.6rem; margin-top: 2.5rem; margin-bottom: 1rem; }
+      .doc-body h3 { font-size: 1.15rem; margin-top: 1.8rem; margin-bottom: 0.6rem; }
+      .doc-body p, .doc-body li { color: var(--text-secondary); line-height: 1.7; }
+      .doc-body ul, .doc-body ol { margin: 0.8rem 0 1rem 1.2rem; }
+      .doc-body pre.code-block { margin: 1rem 0 1.5rem; }
+      .doc-body code:not(pre code) { background: var(--bg-secondary); padding: 0.1rem 0.4rem; border-radius: 4px; font-size: 0.9em; }
+      .doc-body .toc { background: var(--bg-secondary); border-radius: 10px; padding: 1rem 1.2rem; border: 1px solid var(--border); margin: 1.5rem 0 2.5rem; }
+      .doc-body .toc ol { margin: 0; padding-left: 1.2rem; }
+      .doc-body .note { background: var(--bg-secondary); border-left: 3px solid var(--accent-cyan); padding: 0.8rem 1rem; border-radius: 0 8px 8px 0; margin: 1rem 0; }
+    </style>
+</head>
+<body>
+    <nav class="nav">
+        <div class="nav-container">
+            <a href="/" class="nav-logo"><img src="../assets/logo.svg" alt="atlassian-cli" height="24"></a>
+            <div class="nav-links">
+                <a href="/jira/" class="nav-link">Jira CLI</a>
+                <a href="/confluence/" class="nav-link">Confluence CLI</a>
+                <a href="/bitbucket/" class="nav-link">Bitbucket CLI</a>
+                <a href="/docs/" class="nav-link">Docs</a>
+                <a href="/blog/" class="nav-link">Blog</a>
+                <a href="https://github.com/omar16100/atlassian-cli" target="_blank" rel="noopener" class="nav-link">GitHub</a>
+                <a href="/install/" class="nav-btn">Install</a>
+            </div>
+        </div>
+    </nav>
+
+    <main>
+    <section class="hero" style="padding: 8rem 0 2rem;">
+        <div class="hero-container">
+            <div class="hero-badge">Documentation</div>
+            <h1 class="hero-title">Authentication &amp; Profiles</h1>
+            <p class="hero-subtitle">How to authenticate atlassian-cli with API tokens, bearer tokens, and multiple profiles for Jira, Confluence, Bitbucket, and JSM.</p>
+            <p class="hero-disclaimer">atlassian-cli is an independent open-source tool. Tokens you create are stored locally on your machine; this project and website never receive your Atlassian credentials.</p>
+        </div>
+    </section>
+
+    <section style="padding: 1rem 0 5rem;">
+        <div class="doc-body">
+            <nav class="toc" aria-label="Table of contents">
+                <strong>On this page</strong>
+                <ol>
+                    <li><a href="#overview">Overview</a></li>
+                    <li><a href="#api-token">Atlassian Cloud API token (Jira, Confluence, JSM)</a></li>
+                    <li><a href="#bitbucket">Bitbucket bearer token</a></li>
+                    <li><a href="#profiles">Profiles</a></li>
+                    <li><a href="#env">Environment variables &amp; CI/CD</a></li>
+                    <li><a href="#storage">Where credentials are stored</a></li>
+                    <li><a href="#troubleshooting">Troubleshooting</a></li>
+                </ol>
+            </nav>
+
+            <h2 id="overview">Overview</h2>
+            <p>atlassian-cli supports three authentication paths, all managed by a single <code>auth</code> command group:</p>
+            <ul>
+                <li><strong>Atlassian Cloud API tokens</strong> — for Jira, Confluence, and Jira Service Management. Tokens are scoped per user and created at <a href="https://id.atlassian.com/manage-profile/security/api-tokens" target="_blank" rel="noopener">id.atlassian.com/manage-profile/security/api-tokens</a>.</li>
+                <li><strong>Bitbucket bearer tokens</strong> (OAuth app passwords, access tokens, or workspace access tokens). Basic-auth is also supported for legacy accounts.</li>
+                <li><strong>Environment variables</strong> — when a profile isn't configured or you're running in CI.</li>
+            </ul>
+            <p>Each configured account lives in a named <em>profile</em>. You can have any number of profiles (e.g. <code>personal</code>, <code>work</code>, <code>bb-ci</code>) and switch between them with a single flag.</p>
+
+            <h2 id="api-token">Atlassian Cloud API token</h2>
+            <p>This is the most common setup for Jira, Confluence, and JSM.</p>
+            <h3>1. Create an API token</h3>
+            <p>Go to <a href="https://id.atlassian.com/manage-profile/security/api-tokens" target="_blank" rel="noopener">id.atlassian.com/manage-profile/security/api-tokens</a>, click <strong>Create API token</strong>, give it a label, and copy the value (you can only view it once).</p>
+            <div class="note">The token authenticates as <em>you</em>. Anything you can do in Jira/Confluence/JSM via the UI, the CLI can do with that token.</div>
+
+            <h3>2. Log in</h3>
+            <pre class="code-block"><code>atlassian-cli auth login \
+  --profile <span class="string">work</span> \
+  --base-url <span class="string">https://your-domain.atlassian.net</span> \
+  --email <span class="string">you@company.com</span> \
+  --token <span class="string">$ATLASSIAN_API_TOKEN</span> \
+  --default</code></pre>
+            <p>Flags:</p>
+            <ul>
+                <li><code>--profile</code> — a local name. Use anything you like.</li>
+                <li><code>--base-url</code> — your Atlassian Cloud URL, including <code>https://</code>.</li>
+                <li><code>--email</code> — the email of the account that owns the token.</li>
+                <li><code>--token</code> — the API token. Use a shell variable so it doesn't land in your history.</li>
+                <li><code>--default</code> — make this the profile used when <code>--profile</code> is omitted.</li>
+            </ul>
+
+            <h3>3. Verify</h3>
+            <pre class="code-block"><code>atlassian-cli auth test --profile work
+atlassian-cli jira search --jql <span class="string">"project = DEV"</span> --limit 1</code></pre>
+
+            <h2 id="bitbucket">Bitbucket authentication</h2>
+            <p>Bitbucket Cloud supports two token flows. Both are current — pick the one that matches your account model.</p>
+            <div class="note">App passwords are deprecated by Atlassian: new creation was disabled on <strong>September 9, 2025</strong> and existing app passwords stop working on <strong>June 9, 2026</strong>. Use an API token (Basic auth) or access token (Bearer auth) instead.</div>
+
+            <h3>API token (Basic auth) — for your personal account</h3>
+            <p>Create an Atlassian API token scoped to Bitbucket at <a href="https://id.atlassian.com/manage-profile/security/api-tokens" target="_blank" rel="noopener">id.atlassian.com/manage-profile/security/api-tokens</a> (select <strong>Bitbucket</strong>). Use it with your account email:</p>
+            <pre class="code-block"><code>atlassian-cli auth login \
+  --profile <span class="string">work</span> \
+  --bitbucket \
+  --email <span class="string">you@company.com</span> \
+  --token <span class="string">$BITBUCKET_TOKEN</span></code></pre>
+
+            <h3>Access token (Bearer auth) — for CI or tight scoping</h3>
+            <p>Access tokens are scoped to a repository, project, or workspace — great for CI pipelines where you want the minimum permissions:</p>
+            <ol>
+                <li>Bitbucket &rarr; your workspace / repository / project &rarr; <strong>Settings</strong> &rarr; <strong>Access tokens</strong></li>
+                <li>Click <strong>Create</strong> and grant only the scopes you need (e.g. <code>repository:read</code>, <code>pullrequest:write</code>)</li>
+            </ol>
+            <pre class="code-block"><code>atlassian-cli auth login \
+  --profile <span class="string">bb-ci</span> \
+  --bitbucket --bearer \
+  --token <span class="string">$BITBUCKET_TOKEN</span></code></pre>
+            <p>Bearer auth does not require <code>--email</code>. The workspace is optional at login — supply <code>--workspace</code> when you want it saved in the profile, or pass <code>--workspace &lt;slug&gt;</code> per-command.</p>
+
+            <h3>Verify</h3>
+            <pre class="code-block"><code>atlassian-cli auth test --bitbucket --profile bb-ci
+atlassian-cli bitbucket whoami --profile bb-ci</code></pre>
+
+            <h2 id="profiles">Profiles</h2>
+            <p>Profiles isolate credentials per account or environment. Common patterns:</p>
+            <ul>
+                <li><code>personal</code> — your own sandbox instance</li>
+                <li><code>work</code> — your company's production instance</li>
+                <li><code>bb-ci</code> — a scoped Bitbucket token for CI pipelines</li>
+                <li><code>staging</code> / <code>prod</code> — separate profiles per environment</li>
+            </ul>
+
+            <h3>List profiles</h3>
+            <pre class="code-block"><code>atlassian-cli auth list</code></pre>
+
+            <h3>Switch profile per command</h3>
+            <pre class="code-block"><code>atlassian-cli jira search --profile personal --jql <span class="string">"project = PERS"</span>
+atlassian-cli jira search --profile work --jql <span class="string">"project = DEV"</span></code></pre>
+
+            <h3>Change the default</h3>
+            <p>Re-run <code>auth login</code> with <code>--default</code> for the profile you want to promote:</p>
+            <pre class="code-block"><code>atlassian-cli auth login --profile work --base-url https://x.atlassian.net --email you@x.com --default</code></pre>
+            <p>Or edit <code>default_profile:</code> directly in <code>~/.atlassian-cli/config.yaml</code>.</p>
+
+            <h3>Remove a profile</h3>
+            <pre class="code-block"><code>atlassian-cli auth logout --profile bb-legacy                    <span class="comment"># remove credentials, keep profile entry</span>
+atlassian-cli auth logout --profile bb-legacy --remove-profile   <span class="comment"># remove profile entirely</span>
+atlassian-cli auth logout --profile work --bitbucket             <span class="comment"># only remove the Bitbucket token</span></code></pre>
+
+            <h2 id="env">Environment variables &amp; CI/CD</h2>
+            <p>In CI you usually don't want persisted secrets. atlassian-cli overrides the stored token with these environment variables, checked in this order:</p>
+            <h3>Jira / Confluence / JSM</h3>
+            <ul>
+                <li><code>ATLASSIAN_CLI_TOKEN_&lt;PROFILE&gt;</code> — per-profile override (profile name uppercased). Example: <code>ATLASSIAN_CLI_TOKEN_WORK</code>.</li>
+                <li><code>ATLASSIAN_API_TOKEN</code> — fallback token used by whichever profile is active.</li>
+            </ul>
+            <h3>Bitbucket</h3>
+            <ul>
+                <li><code>ATLASSIAN_CLI_BITBUCKET_TOKEN_&lt;PROFILE&gt;</code> — per-profile Bitbucket token.</li>
+                <li><code>ATLASSIAN_BITBUCKET_TOKEN</code> — generic Bitbucket fallback.</li>
+                <li><code>BITBUCKET_TOKEN</code> — also recognised (shorter, common in GitHub Actions / Jenkins).</li>
+            </ul>
+            <div class="note">You still need a profile configured with <code>--base-url</code>, <code>--email</code>, and workspace (for Bitbucket). The env vars only override the token. In CI, commit a minimal <code>~/.atlassian-cli/config.yaml</code> (or run <code>auth login</code> in a setup step with a dummy token) so the profile exists; then supply the real token via env var at run time.</div>
+            <pre class="code-block"><code><span class="comment"># GitHub Actions example — token via env, profile metadata from config.yaml</span>
+- name: Sync Jira
+  env:
+    ATLASSIAN_API_TOKEN: ${{ secrets.ATLASSIAN_API_TOKEN }}
+  run: |
+    atlassian-cli auth login \
+      --profile ci --base-url https://mycompany.atlassian.net \
+      --email bot@mycompany.com --default
+    atlassian-cli jira search --jql <span class="string">"project = REL"</span> --format json</code></pre>
+            <p>See the <a href="/runbooks/jira-bulk-transition.html">Jira bulk transition runbook</a> for a full CI example.</p>
+
+            <h2 id="storage">Where credentials are stored</h2>
+            <p>On login, atlassian-cli writes credentials to <code>~/.config/atlassian-cli/credentials</code> (Linux/macOS) or <code>%APPDATA%\atlassian-cli\credentials</code> (Windows). Values are encrypted with <strong>AES-256-GCM</strong>; the per-machine key lives in <code>~/.config/atlassian-cli/key</code>.</p>
+            <p>Profile metadata (names, base URLs, default profile) lives in <code>~/.atlassian-cli/config.yaml</code>. You can edit it by hand if you prefer — see <code>configs/config.example.yaml</code> in the repo.</p>
+            <div class="note">Credentials never touch plaintext disk. On Linux and macOS the config directory is chmod 700 by default.</div>
+
+            <h2 id="troubleshooting">Troubleshooting</h2>
+            <h3>401 Unauthorized</h3>
+            <p>Most likely the token is wrong, expired, or the email doesn't match the token owner. Regenerate at <a href="https://id.atlassian.com/manage-profile/security/api-tokens" target="_blank" rel="noopener">id.atlassian.com/manage-profile/security/api-tokens</a>.</p>
+
+            <h3>403 Forbidden</h3>
+            <p>The account is authenticated but lacks permission. For Jira/Confluence, check project/space role. For Bitbucket bearer tokens, verify the scopes on the access token.</p>
+
+            <h3>"No default profile configured"</h3>
+            <p>Run <code>atlassian-cli auth list</code>. If empty, run <code>auth login</code>. If you have profiles but none is default, re-run <code>auth login --default</code> for the profile you want, or edit <code>default_profile:</code> in <code>~/.atlassian-cli/config.yaml</code>.</p>
+
+            <h3>CI can't find the credentials file</h3>
+            <p>In CI you usually want environment variables, not a credentials file. See <a href="#env">Environment variables &amp; CI/CD</a> above.</p>
+
+            <h3>Token works in curl but not atlassian-cli</h3>
+            <p>Check that <code>--base-url</code> includes the scheme (<code>https://</code>) and has no trailing slash. Run with <code>--debug</code> to see the full request.</p>
+
+            <p style="margin-top: 3rem;"><strong>Next:</strong> <a href="/docs/commands.html">Command reference &rarr;</a></p>
+        </div>
+    </section>
+    </main>
+
+    <footer class="footer">
+        <div class="container">
+            <div class="footer-content">
+                <div class="footer-left">
+                    <span class="footer-logo">atlassian-cli</span>
+                    <span class="footer-version">v0.3.3</span>
+                </div>
+                <div class="footer-links">
+                    <a href="/install/">Install</a>
+                    <a href="/docs/">Docs</a>
+                    <a href="/jira/">Jira CLI</a>
+                    <a href="/confluence/">Confluence CLI</a>
+                    <a href="/bitbucket/">Bitbucket CLI</a>
+                    <a href="/blog/">Blog</a>
+                    <a href="https://github.com/omar16100/atlassian-cli" target="_blank" rel="noopener">GitHub</a>
+                </div>
+                <div class="footer-right"><span class="footer-license">MIT License</span></div>
+            </div>
+            <div class="footer-legal">
+                <p>atlassian-cli is an independent open-source project maintained by <a href="https://omarshabab.com" target="_blank" rel="noopener">Omar Shabab</a>. It is not affiliated with, endorsed by, sponsored by, or maintained by Atlassian.</p>
+                <p>Atlassian, Jira, Confluence, Bitbucket, and Jira Service Management are trademarks of Atlassian Pty Ltd or its affiliates. Product names are used only to identify compatibility.</p>
+            </div>
+        </div>
+    </footer>
+</body>
+</html>

--- a/docs/docs/commands.html
+++ b/docs/docs/commands.html
@@ -1,0 +1,447 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>atlassian-cli Command Reference — Jira, Confluence, Bitbucket, JSM | atlassian-cli</title>
+    <meta name="description" content="Complete command reference for atlassian-cli: every Jira, Confluence, Bitbucket, and Jira Service Management command with flags, examples, and output formats.">
+    <meta property="og:site_name" content="atlassian-cli">
+    <meta property="og:title" content="atlassian-cli Command Reference">
+    <meta property="og:description" content="Every Jira, Confluence, Bitbucket, and JSM command with flags and examples.">
+    <meta property="og:type" content="article">
+    <meta property="og:url" content="https://atlassiancli.com/docs/commands.html">
+    <meta name="twitter:card" content="summary">
+    <meta name="twitter:title" content="atlassian-cli Command Reference">
+    <meta name="twitter:description" content="Every Jira, Confluence, Bitbucket, and JSM command with flags and examples.">
+    <link rel="canonical" href="https://atlassiancli.com/docs/commands.html" />
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet">
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-SHR43YZK8C"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      gtag('config', 'G-SHR43YZK8C');
+    </script>
+
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "BreadcrumbList",
+      "itemListElement": [
+        {"@type": "ListItem", "position": 1, "name": "atlassian-cli", "item": "https://atlassiancli.com/"},
+        {"@type": "ListItem", "position": 2, "name": "Documentation", "item": "https://atlassiancli.com/docs/"},
+        {"@type": "ListItem", "position": 3, "name": "Command Reference", "item": "https://atlassiancli.com/docs/commands.html"}
+      ]
+    }
+    </script>
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "TechArticle",
+      "headline": "atlassian-cli Command Reference",
+      "description": "Complete command reference for atlassian-cli covering Jira, Confluence, Bitbucket, and Jira Service Management.",
+      "url": "https://atlassiancli.com/docs/commands.html",
+      "author": {"@type": "Person", "name": "Omar Shabab", "url": "https://omarshabab.com"},
+      "about": {"@type": "SoftwareApplication", "name": "atlassian-cli"}
+    }
+    </script>
+
+    <link rel="stylesheet" href="../styles.css">
+    <style>
+      .doc-layout { max-width: 1200px; margin: 0 auto; padding: 6rem 1.5rem 4rem; display: grid; grid-template-columns: 220px 1fr; gap: 2.5rem; }
+      @media (max-width: 900px) { .doc-layout { grid-template-columns: 1fr; } .doc-sidebar { position: static !important; } }
+      .doc-sidebar { position: sticky; top: 6rem; align-self: start; border-right: 1px solid var(--border); padding-right: 1.25rem; max-height: calc(100vh - 8rem); overflow-y: auto; }
+      .doc-sidebar h4 { font-size: 0.7rem; text-transform: uppercase; letter-spacing: 0.08em; color: var(--text-muted); margin: 1.2rem 0 0.4rem; font-weight: 600; }
+      .doc-sidebar ul { list-style: none; padding: 0; margin: 0; }
+      .doc-sidebar li { margin: 0.25rem 0; }
+      .doc-sidebar a { color: var(--text-secondary); text-decoration: none; font-size: 0.88rem; }
+      .doc-sidebar a:hover { color: var(--text-primary); }
+      .doc-content h1 { font-size: 2.2rem; letter-spacing: -0.02em; margin-bottom: 0.5rem; }
+      .doc-content .lede { color: var(--text-secondary); font-size: 1.1rem; margin-bottom: 2rem; }
+      .doc-content h2 { font-size: 1.6rem; margin-top: 3rem; margin-bottom: 0.6rem; border-bottom: 1px solid var(--border); padding-bottom: 0.5rem; }
+      .doc-content h3 { font-size: 1.1rem; margin-top: 1.8rem; margin-bottom: 0.4rem; color: var(--text-primary); }
+      .doc-content p, .doc-content li { color: var(--text-secondary); line-height: 1.65; }
+      .doc-content ul { margin: 0.5rem 0 0.8rem 1.2rem; }
+      .doc-content pre.code-block { margin: 0.7rem 0 1.2rem; font-size: 0.85rem; }
+      .doc-content code:not(pre code) { background: var(--bg-secondary); padding: 0.1rem 0.4rem; border-radius: 4px; font-size: 0.88em; }
+      .doc-content .note { background: var(--bg-secondary); border-left: 3px solid var(--accent-cyan); padding: 0.7rem 1rem; border-radius: 0 8px 8px 0; margin: 1rem 0; font-size: 0.92rem; }
+    </style>
+</head>
+<body>
+    <nav class="nav">
+        <div class="nav-container">
+            <a href="/" class="nav-logo"><img src="../assets/logo.svg" alt="atlassian-cli" height="24"></a>
+            <div class="nav-links">
+                <a href="/jira/" class="nav-link">Jira CLI</a>
+                <a href="/confluence/" class="nav-link">Confluence CLI</a>
+                <a href="/bitbucket/" class="nav-link">Bitbucket CLI</a>
+                <a href="/docs/" class="nav-link">Docs</a>
+                <a href="/blog/" class="nav-link">Blog</a>
+                <a href="https://github.com/omar16100/atlassian-cli" target="_blank" rel="noopener" class="nav-link">GitHub</a>
+                <a href="/install/" class="nav-btn">Install</a>
+            </div>
+        </div>
+    </nav>
+
+    <div class="doc-layout">
+        <aside class="doc-sidebar" aria-label="Command reference navigation">
+            <h4>Global</h4>
+            <ul>
+                <li><a href="#global-flags">Global flags</a></li>
+                <li><a href="#output-formats">Output formats</a></li>
+                <li><a href="#auth">auth</a></li>
+            </ul>
+            <h4>Jira</h4>
+            <ul>
+                <li><a href="#jira-issues">Issues</a></li>
+                <li><a href="#jira-projects">Projects</a></li>
+                <li><a href="#jira-roles">Roles</a></li>
+                <li><a href="#jira-fields">Fields &amp; workflows</a></li>
+                <li><a href="#jira-bulk">Bulk operations</a></li>
+                <li><a href="#jira-automation">Automation &amp; webhooks</a></li>
+            </ul>
+            <h4>Confluence</h4>
+            <ul>
+                <li><a href="#conf-search">Search (CQL)</a></li>
+                <li><a href="#conf-spaces">Spaces</a></li>
+                <li><a href="#conf-pages">Pages</a></li>
+                <li><a href="#conf-blog">Blog posts</a></li>
+                <li><a href="#conf-attach">Attachments</a></li>
+                <li><a href="#conf-bulk">Bulk operations</a></li>
+                <li><a href="#conf-analytics">Analytics</a></li>
+            </ul>
+            <h4>Bitbucket</h4>
+            <ul>
+                <li><a href="#bb-user">User info</a></li>
+                <li><a href="#bb-repos">Repositories</a></li>
+                <li><a href="#bb-branches">Branches</a></li>
+                <li><a href="#bb-pr">Pull requests</a></li>
+                <li><a href="#bb-workspaces">Workspaces &amp; projects</a></li>
+                <li><a href="#bb-pipelines">Pipelines</a></li>
+                <li><a href="#bb-webhooks">Webhooks &amp; SSH keys</a></li>
+                <li><a href="#bb-permissions">Permissions &amp; commits</a></li>
+                <li><a href="#bb-bulk">Bulk operations</a></li>
+            </ul>
+            <h4>JSM</h4>
+            <ul>
+                <li><a href="#jsm-servicedesk">Service desks</a></li>
+                <li><a href="#jsm-request-types">Request types</a></li>
+                <li><a href="#jsm-requests">Requests</a></li>
+                <li><a href="#jsm-queues">Queues</a></li>
+                <li><a href="#jsm-approvals">Approvals</a></li>
+                <li><a href="#jsm-slas">SLAs</a></li>
+                <li><a href="#jsm-customers">Customers</a></li>
+                <li><a href="#jsm-organizations">Organizations</a></li>
+                <li><a href="#jsm-kb">Knowledge base</a></li>
+                <li><a href="#jsm-feedback">Feedback</a></li>
+            </ul>
+        </aside>
+
+        <main class="doc-content">
+            <h1>Command Reference</h1>
+            <p class="lede">Every atlassian-cli command grouped by product. Examples use the default profile; add <code>--profile &lt;name&gt;</code> to target a different one. See <a href="/docs/auth.html">Authentication</a> to configure profiles.</p>
+
+            <h2 id="global-flags">Global flags</h2>
+            <p>All commands accept these:</p>
+            <ul>
+                <li><code>--profile &lt;name&gt;</code> — use a specific auth profile (default: the one marked default in <code>auth list</code>)</li>
+                <li><code>--format &lt;table|json|csv|yaml|quiet|markdown&gt;</code> or <code>-f</code> — output format (default: <code>table</code>)</li>
+                <li><code>--envelope</code> — wrap JSON/YAML list output in <code>{"data": [...], "count": N}</code> for easier downstream parsing</li>
+                <li><code>--config &lt;path&gt;</code> — use a non-default config file instead of <code>~/.atlassian-cli/config.yaml</code></li>
+                <li><code>--debug</code> — log HTTP request/response details for troubleshooting</li>
+                <li><code>--help</code> — print command help</li>
+            </ul>
+            <p>Bulk subcommands additionally accept <code>--dry-run</code>, <code>--concurrency &lt;n&gt;</code>, and <code>--limit &lt;n&gt;</code>.</p>
+
+            <h2 id="output-formats">Output formats</h2>
+            <pre class="code-block"><code><span class="comment"># Human-readable table (default)</span>
+atlassian-cli jira search --jql <span class="string">"project = DEV"</span>
+
+<span class="comment"># Machine-readable JSON — pipe to jq, feed other tools</span>
+atlassian-cli jira search --jql <span class="string">"project = DEV"</span> --format json | jq <span class="string">'.[].key'</span>
+
+<span class="comment"># CSV — open in a spreadsheet</span>
+atlassian-cli jira search --jql <span class="string">"project = DEV"</span> --format csv --output issues.csv
+
+<span class="comment"># YAML — good for configuration diffs</span>
+atlassian-cli jira workflows export --name <span class="string">"Software Simplified Workflow"</span> --format yaml
+
+<span class="comment"># Quiet — exit code only; useful in CI gating</span>
+atlassian-cli auth test --profile prod --format quiet &amp;&amp; echo OK</code></pre>
+
+            <h2 id="auth">auth</h2>
+            <p>See <a href="/docs/auth.html">Authentication &amp; Profiles</a> for the full guide. Available subcommands: <code>login</code>, <code>logout</code>, <code>list</code>, <code>status</code>, <code>whoami</code>, <code>test</code>.</p>
+            <pre class="code-block"><code>atlassian-cli auth login --profile work --base-url https://x.atlassian.net --email you@x.com --token $TOKEN --default
+atlassian-cli auth list
+atlassian-cli auth status
+atlassian-cli auth whoami --profile work
+atlassian-cli auth test --profile work
+atlassian-cli auth logout --profile old                    <span class="comment"># remove credentials, keep profile</span>
+atlassian-cli auth logout --profile old --remove-profile   <span class="comment"># remove profile entirely</span>
+atlassian-cli auth logout --profile old --bitbucket        <span class="comment"># only remove Bitbucket token</span></code></pre>
+            <div class="note">To change which profile is default, re-run <code>auth login --default</code> for the profile you want as default, or edit <code>default_profile:</code> in <code>~/.atlassian-cli/config.yaml</code> directly.</div>
+
+            <h2 id="jira-issues">Jira — Issues</h2>
+            <pre class="code-block"><code>atlassian-cli jira search --jql <span class="string">"project = DEV order by created desc"</span> --limit 5
+atlassian-cli jira get DEV-123
+atlassian-cli jira create --project DEV --issue-type Task --summary <span class="string">"Test task"</span>
+
+<span class="comment"># Custom fields — discover IDs via `jira fields list`</span>
+atlassian-cli jira create --project DEV --issue-type Task --summary <span class="string">"cf test"</span> \
+  --field <span class="string">'customfield_10010={"value":"Internal"}'</span> \
+  --field <span class="string">'customfield_10020={"formula":"a=b"}'</span>
+
+atlassian-cli jira update DEV-123 --summary <span class="string">"Updated summary"</span>
+atlassian-cli jira transition DEV-123 --transition <span class="string">"In Progress"</span>
+atlassian-cli jira assign DEV-123 --assignee user@example.com
+atlassian-cli jira delete DEV-123</code></pre>
+
+            <h2 id="jira-projects">Jira — Projects</h2>
+            <pre class="code-block"><code>atlassian-cli jira project list
+atlassian-cli jira project get DEV
+atlassian-cli jira components list --project DEV
+atlassian-cli jira versions list --project DEV</code></pre>
+
+            <h2 id="jira-roles">Jira — Roles</h2>
+            <pre class="code-block"><code>atlassian-cli jira roles list --project DEV
+atlassian-cli jira roles get --project DEV --role-id 10002
+atlassian-cli jira roles actors --project DEV --role-id 10002
+atlassian-cli jira roles add-actor --project DEV --role-id 10002 --user user@example.com
+atlassian-cli jira roles remove-actor --project DEV --role-id 10002 --user user@example.com</code></pre>
+
+            <h2 id="jira-fields">Jira — Fields &amp; workflows</h2>
+            <pre class="code-block"><code>atlassian-cli jira fields list
+atlassian-cli jira workflows list
+atlassian-cli jira workflows export --name <span class="string">"Software Simplified Workflow"</span></code></pre>
+
+            <h2 id="jira-bulk">Jira — Bulk operations</h2>
+            <pre class="code-block"><code><span class="comment"># Dry-run first — always</span>
+atlassian-cli jira bulk transition \
+  --jql <span class="string">"project = DEV AND status = Open"</span> \
+  --transition <span class="string">"In Progress"</span> \
+  --dry-run
+
+atlassian-cli jira bulk assign \
+  --jql <span class="string">"project = DEV AND assignee is EMPTY"</span> \
+  --assignee admin@example.com
+
+atlassian-cli jira bulk export \
+  --jql <span class="string">"project = DEV"</span> \
+  --output issues.json --format json</code></pre>
+            <div class="note">All bulk commands respect <code>--concurrency</code> (default 4) and show a live progress bar unless <code>--format quiet</code> is set.</div>
+
+            <h2 id="jira-automation">Jira — Automation &amp; webhooks</h2>
+            <pre class="code-block"><code>atlassian-cli jira automation list
+atlassian-cli jira webhooks list
+atlassian-cli jira audit list --from 2025-01-01 --limit 100</code></pre>
+
+            <h2 id="conf-search">Confluence — Search</h2>
+            <pre class="code-block"><code>atlassian-cli confluence search cql --cql <span class="string">"space = DEV and type = page"</span> --limit 5
+atlassian-cli confluence search text --query <span class="string">"meeting notes"</span> --limit 10
+atlassian-cli confluence search in-space --space DEV --query <span class="string">"api docs"</span></code></pre>
+
+            <h2 id="conf-spaces">Confluence — Spaces</h2>
+            <pre class="code-block"><code>atlassian-cli confluence space list --limit 10
+atlassian-cli confluence space get DEV
+atlassian-cli confluence space create --key DOCS --name <span class="string">"Documentation"</span> --description <span class="string">"Team docs"</span>
+atlassian-cli confluence space update DEV --name <span class="string">"Development Space"</span>
+atlassian-cli confluence space delete OLD --force
+atlassian-cli confluence space permissions DEV
+atlassian-cli confluence space add-permission DEV --principal user@example.com --operation read</code></pre>
+
+            <h2 id="conf-pages">Confluence — Pages</h2>
+            <pre class="code-block"><code>atlassian-cli confluence page list --space DEV --limit 25
+atlassian-cli confluence page get --id 12345
+atlassian-cli confluence page create --space DEV --title <span class="string">"New Page"</span> --body <span class="string">"&lt;p&gt;Content&lt;/p&gt;"</span>
+atlassian-cli confluence page update --id 12345 --title <span class="string">"Updated Title"</span>
+atlassian-cli confluence page delete --id 12345
+atlassian-cli confluence page versions --id 12345
+atlassian-cli confluence page add-label --id 12345 --label documentation
+atlassian-cli confluence page remove-label --id 12345 --label outdated
+atlassian-cli confluence page comments --id 12345
+atlassian-cli confluence page add-comment --id 12345 --body <span class="string">"Great work!"</span>
+atlassian-cli confluence page get-restrictions --id 12345
+atlassian-cli confluence page add-restriction --id 12345 --operation update --user user@example.com
+atlassian-cli confluence page remove-restriction --id 12345 --operation update --user user@example.com</code></pre>
+
+            <h2 id="conf-blog">Confluence — Blog posts</h2>
+            <pre class="code-block"><code>atlassian-cli confluence blog list --space DEV --limit 10
+atlassian-cli confluence blog get --id 67890
+atlassian-cli confluence blog create --space DEV --title <span class="string">"Sprint Recap"</span> --body <span class="string">"&lt;p&gt;Summary&lt;/p&gt;"</span>
+atlassian-cli confluence blog update --id 67890 --title <span class="string">"Updated Recap"</span>
+atlassian-cli confluence blog delete --id 67890</code></pre>
+
+            <h2 id="conf-attach">Confluence — Attachments</h2>
+            <pre class="code-block"><code>atlassian-cli confluence attachment list --page-id 12345
+atlassian-cli confluence attachment get --id 11111
+atlassian-cli confluence attachment upload --page-id 12345 --file ./diagram.png
+atlassian-cli confluence attachment download --id 11111 --output ./download.png
+atlassian-cli confluence attachment delete --id 11111</code></pre>
+
+            <h2 id="conf-bulk">Confluence — Bulk operations</h2>
+            <pre class="code-block"><code>atlassian-cli confluence bulk delete --space OLD --dry-run
+atlassian-cli confluence bulk add-labels --cql <span class="string">"space = DEV"</span> --labels docs,reviewed --dry-run
+atlassian-cli confluence bulk export --space DEV --output backup.json --format json</code></pre>
+            <p>For a full markdown-to-Confluence pipeline see the <a href="/runbooks/confluence-markdown-sync.html">Markdown sync runbook</a>.</p>
+
+            <h2 id="conf-analytics">Confluence — Analytics</h2>
+            <pre class="code-block"><code>atlassian-cli confluence analytics page-views --id 12345 --from 2025-01-01
+atlassian-cli confluence analytics space-stats --space DEV</code></pre>
+
+            <h2 id="bb-user">Bitbucket — User info</h2>
+            <div class="note"><code>bb</code> is an alias for <code>bitbucket</code>. Both work in every command below.</div>
+            <pre class="code-block"><code>atlassian-cli bitbucket whoami
+atlassian-cli bb whoami</code></pre>
+
+            <h2 id="bb-repos">Bitbucket — Repositories</h2>
+            <pre class="code-block"><code>atlassian-cli bitbucket --workspace myteam repo list --limit 10
+atlassian-cli bitbucket --workspace myteam repo get api-service
+atlassian-cli bitbucket --workspace myteam repo create newrepo --name <span class="string">"New Repo"</span> --private
+atlassian-cli bitbucket --workspace myteam repo update api-service --description <span class="string">"Updated description"</span>
+atlassian-cli bitbucket --workspace myteam repo delete oldrepo --force</code></pre>
+
+            <h2 id="bb-branches">Bitbucket — Branches</h2>
+            <pre class="code-block"><code>atlassian-cli bitbucket --workspace myteam branch list api-service
+atlassian-cli bitbucket --workspace myteam branch create api-service feature/new --from main
+atlassian-cli bitbucket --workspace myteam branch delete api-service feature/old --force
+atlassian-cli bitbucket --workspace myteam branch protect api-service --pattern <span class="string">"main"</span> --kind restrict_merges --approvals 2
+atlassian-cli bitbucket --workspace myteam branch restrictions api-service</code></pre>
+
+            <h2 id="bb-pr">Bitbucket — Pull requests</h2>
+            <pre class="code-block"><code>atlassian-cli bitbucket --workspace myteam pr list api-service --state OPEN --limit 5
+atlassian-cli bitbucket --workspace myteam pr get api-service 123
+atlassian-cli bitbucket --workspace myteam pr create api-service --title <span class="string">"Add feature"</span> --source feature/new --destination main
+atlassian-cli bitbucket --workspace myteam pr update api-service 123 --title <span class="string">"Updated title"</span>
+atlassian-cli bitbucket --workspace myteam pr approve api-service 123
+atlassian-cli bitbucket --workspace myteam pr merge api-service 123 --strategy merge_commit
+atlassian-cli bitbucket --workspace myteam pr comments api-service 123
+atlassian-cli bitbucket --workspace myteam pr comment api-service 123 --text <span class="string">"Looks good!"</span></code></pre>
+
+            <h2 id="bb-workspaces">Bitbucket — Workspaces &amp; projects</h2>
+            <pre class="code-block"><code>atlassian-cli bitbucket workspace list --limit 10
+atlassian-cli bitbucket workspace get myteam
+atlassian-cli bitbucket --workspace myteam project list
+atlassian-cli bitbucket --workspace myteam project create PROJ --name <span class="string">"My Project"</span> --private
+atlassian-cli bitbucket --workspace myteam project delete PROJ --force</code></pre>
+
+            <h2 id="bb-pipelines">Bitbucket — Pipelines</h2>
+            <pre class="code-block"><code>atlassian-cli bitbucket --workspace myteam pipeline list api-service
+atlassian-cli bitbucket --workspace myteam pipeline trigger api-service --ref-name main
+atlassian-cli bitbucket --workspace myteam pipeline stop api-service {uuid}</code></pre>
+
+            <h2 id="bb-webhooks">Bitbucket — Webhooks &amp; SSH keys</h2>
+            <pre class="code-block"><code>atlassian-cli bitbucket --workspace myteam webhook list api-service
+atlassian-cli bitbucket --workspace myteam webhook create api-service --url https://example.com/hook --events repo:push
+atlassian-cli bitbucket --workspace myteam ssh-key list api-service
+atlassian-cli bitbucket --workspace myteam ssh-key add api-service --label deploy --key <span class="string">"ssh-rsa ..."</span></code></pre>
+
+            <h2 id="bb-permissions">Bitbucket — Permissions &amp; commits</h2>
+            <pre class="code-block"><code>atlassian-cli bitbucket --workspace myteam permission list api-service
+atlassian-cli bitbucket --workspace myteam permission grant api-service --user-uuid {uuid} --permission write
+atlassian-cli bitbucket --workspace myteam commit list api-service --branch main
+atlassian-cli bitbucket --workspace myteam commit diff api-service abc123
+atlassian-cli bitbucket --workspace myteam commit browse api-service --commit main --path src/</code></pre>
+
+            <h2 id="bb-bulk">Bitbucket — Bulk operations</h2>
+            <pre class="code-block"><code>atlassian-cli bitbucket --workspace myteam bulk archive-repos --days 180 --dry-run
+atlassian-cli bitbucket --workspace myteam bulk delete-branches api-service --exclude feature/keep --dry-run</code></pre>
+
+            <h2 id="jsm-servicedesk">JSM — Service desks</h2>
+            <pre class="code-block"><code>atlassian-cli jsm service-desk list --limit 25
+atlassian-cli jsm service-desk get 10
+atlassian-cli jsm service-desk customers 10 --limit 25
+atlassian-cli jsm service-desk add-customer 10 --account-id <span class="string">5f...1a</span> --account-id <span class="string">6a...2b</span>
+atlassian-cli jsm service-desk remove-customer 10 --account-id <span class="string">5f...1a</span>
+atlassian-cli jsm service-desk organizations 10
+atlassian-cli jsm service-desk add-organization 10 --org-id 42
+atlassian-cli jsm service-desk remove-organization 10 --org-id 42</code></pre>
+
+            <h2 id="jsm-request-types">JSM — Request types</h2>
+            <pre class="code-block"><code>atlassian-cli jsm request-type list --servicedesk-id 10 --limit 25
+atlassian-cli jsm request-type get 10 7
+atlassian-cli jsm request-type fields 10 7
+atlassian-cli jsm request-type groups 10</code></pre>
+
+            <h2 id="jsm-requests">JSM — Requests</h2>
+            <pre class="code-block"><code>atlassian-cli jsm request list --servicedesk-id 10 --limit 25
+atlassian-cli jsm request get SD-123
+atlassian-cli jsm request create --servicedesk-id 10 --request-type-id 7 --summary <span class="string">"Access issue"</span> --description <span class="string">"Can't log in"</span>
+atlassian-cli jsm request transitions SD-123
+atlassian-cli jsm request transition SD-123 --transition <span class="string">"In Progress"</span>
+atlassian-cli jsm request status SD-123
+atlassian-cli jsm request comments SD-123 --limit 25
+atlassian-cli jsm request add-comment SD-123 --body <span class="string">"Investigating"</span> --public
+atlassian-cli jsm request participants SD-123
+atlassian-cli jsm request add-participant SD-123 --account-id <span class="string">5f...1a</span>
+atlassian-cli jsm request remove-participant SD-123 --account-id <span class="string">5f...1a</span>
+atlassian-cli jsm request subscribe SD-123
+atlassian-cli jsm request unsubscribe SD-123</code></pre>
+
+            <h2 id="jsm-queues">JSM — Queues</h2>
+            <pre class="code-block"><code>atlassian-cli jsm queue list 10
+atlassian-cli jsm queue get 10 5
+atlassian-cli jsm queue issues 10 5 --limit 25</code></pre>
+
+            <h2 id="jsm-approvals">JSM — Approvals</h2>
+            <pre class="code-block"><code>atlassian-cli jsm approval list SD-123
+atlassian-cli jsm approval get SD-123 --approval-id 1
+atlassian-cli jsm approval approve SD-123 --approval-id 1
+atlassian-cli jsm approval decline SD-123 --approval-id 1</code></pre>
+
+            <h2 id="jsm-slas">JSM — SLAs</h2>
+            <pre class="code-block"><code>atlassian-cli jsm sla list SD-123
+atlassian-cli jsm sla get SD-123 --sla-id time-to-resolution</code></pre>
+
+            <h2 id="jsm-customers">JSM — Customers</h2>
+            <pre class="code-block"><code>atlassian-cli jsm customer create --email new@customer.com --display-name <span class="string">"New Customer"</span>
+atlassian-cli jsm customer revoke-portal-access --account-id <span class="string">5f...1a</span></code></pre>
+
+            <h2 id="jsm-organizations">JSM — Organizations</h2>
+            <pre class="code-block"><code>atlassian-cli jsm organization list --limit 25
+atlassian-cli jsm organization get 42
+atlassian-cli jsm organization create --name <span class="string">"ACME Ops"</span>
+atlassian-cli jsm organization users 42 --limit 25
+atlassian-cli jsm organization add-user 42 --account-id <span class="string">5f...1a</span>
+atlassian-cli jsm organization remove-user 42 --account-id <span class="string">5f...1a</span>
+atlassian-cli jsm organization delete 42</code></pre>
+
+            <h2 id="jsm-kb">JSM — Knowledge base</h2>
+            <pre class="code-block"><code>atlassian-cli jsm kb search --query <span class="string">"vpn"</span> --servicedesk-id 10 --limit 25</code></pre>
+
+            <h2 id="jsm-feedback">JSM — Feedback</h2>
+            <pre class="code-block"><code>atlassian-cli jsm feedback get SD-123
+atlassian-cli jsm feedback submit SD-123 --rating 5 --comment <span class="string">"Great help"</span>
+atlassian-cli jsm feedback delete SD-123</code></pre>
+
+            <p style="margin-top: 3rem;"><strong>Next:</strong> see the <a href="/runbooks/jira-bulk-transition.html">runbooks</a> for production examples, or head to <a href="/blog/">the blog</a> for deep-dives.</p>
+        </main>
+    </div>
+
+    <footer class="footer">
+        <div class="container">
+            <div class="footer-content">
+                <div class="footer-left">
+                    <span class="footer-logo">atlassian-cli</span>
+                    <span class="footer-version">v0.3.3</span>
+                </div>
+                <div class="footer-links">
+                    <a href="/install/">Install</a>
+                    <a href="/docs/">Docs</a>
+                    <a href="/jira/">Jira CLI</a>
+                    <a href="/confluence/">Confluence CLI</a>
+                    <a href="/bitbucket/">Bitbucket CLI</a>
+                    <a href="/blog/">Blog</a>
+                    <a href="https://github.com/omar16100/atlassian-cli" target="_blank" rel="noopener">GitHub</a>
+                </div>
+                <div class="footer-right"><span class="footer-license">MIT License</span></div>
+            </div>
+            <div class="footer-legal">
+                <p>atlassian-cli is an independent open-source project maintained by <a href="https://omarshabab.com" target="_blank" rel="noopener">Omar Shabab</a>. It is not affiliated with, endorsed by, sponsored by, or maintained by Atlassian.</p>
+                <p>Atlassian, Jira, Confluence, Bitbucket, and Jira Service Management are trademarks of Atlassian Pty Ltd or its affiliates. Product names are used only to identify compatibility.</p>
+            </div>
+        </div>
+    </footer>
+</body>
+</html>

--- a/docs/docs/index.html
+++ b/docs/docs/index.html
@@ -1,0 +1,159 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>atlassian-cli Documentation — Commands, Authentication, Profiles | atlassian-cli</title>
+    <meta name="description" content="First-party documentation for atlassian-cli: command reference for Jira, Confluence, Bitbucket, and JSM, authentication with API tokens, profile management, and output formats.">
+    <meta property="og:site_name" content="atlassian-cli">
+    <meta property="og:title" content="atlassian-cli Documentation — Commands, Authentication, Profiles">
+    <meta property="og:description" content="First-party documentation for atlassian-cli: command reference, authentication, profiles, output formats.">
+    <meta property="og:type" content="website">
+    <meta property="og:url" content="https://atlassiancli.com/docs/">
+    <meta name="twitter:card" content="summary">
+    <meta name="twitter:title" content="atlassian-cli Documentation">
+    <meta name="twitter:description" content="Command reference for Jira, Confluence, Bitbucket, JSM. Authentication, profiles, output formats.">
+    <link rel="canonical" href="https://atlassiancli.com/docs/" />
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet">
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-SHR43YZK8C"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      gtag('config', 'G-SHR43YZK8C');
+    </script>
+
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "BreadcrumbList",
+      "itemListElement": [
+        {"@type": "ListItem", "position": 1, "name": "atlassian-cli", "item": "https://atlassiancli.com/"},
+        {"@type": "ListItem", "position": 2, "name": "Documentation", "item": "https://atlassiancli.com/docs/"}
+      ]
+    }
+    </script>
+
+    <link rel="stylesheet" href="../styles.css">
+    <style>
+      .docs-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(260px, 1fr)); gap: 1rem; max-width: 960px; margin: 2rem auto 0; }
+      .docs-card { background: var(--bg-secondary); border: 1px solid var(--border); border-radius: 10px; padding: 1.25rem; text-decoration: none; color: inherit; transition: all 0.2s; display: block; }
+      .docs-card:hover { border-color: var(--border-hover); transform: translateY(-2px); }
+      .docs-card h3 { font-size: 1.05rem; margin-bottom: 0.4rem; }
+      .docs-card p { font-size: 0.85rem; color: var(--text-secondary); }
+    </style>
+</head>
+<body>
+    <nav class="nav">
+        <div class="nav-container">
+            <a href="/" class="nav-logo"><img src="../assets/logo.svg" alt="atlassian-cli" height="24"></a>
+            <div class="nav-links">
+                <a href="/jira/" class="nav-link">Jira CLI</a>
+                <a href="/confluence/" class="nav-link">Confluence CLI</a>
+                <a href="/bitbucket/" class="nav-link">Bitbucket CLI</a>
+                <a href="/docs/" class="nav-link" aria-current="page">Docs</a>
+                <a href="/blog/" class="nav-link">Blog</a>
+                <a href="https://github.com/omar16100/atlassian-cli" target="_blank" rel="noopener" class="nav-link">GitHub</a>
+                <a href="/install/" class="nav-btn">Install</a>
+            </div>
+        </div>
+    </nav>
+
+    <main>
+    <section class="hero" style="padding: 8rem 0 3rem;">
+        <div class="hero-container">
+            <div class="hero-badge">Documentation</div>
+            <h1 class="hero-title">atlassian-cli <span class="hero-highlight">Documentation</span></h1>
+            <p class="hero-subtitle">Command reference for Jira, Confluence, Bitbucket, and Jira Service Management (JSM). Authentication, profiles, and output formats.</p>
+        </div>
+    </section>
+
+    <section style="padding: 1rem 0 5rem;">
+        <div class="container">
+            <h2 class="section-title">Guides</h2>
+            <div class="docs-grid">
+                <a href="/docs/auth.html" class="docs-card">
+                    <h3>Authentication &amp; Profiles</h3>
+                    <p>Log in with API tokens, set up profiles for multiple instances, use bearer tokens for Bitbucket, and store credentials securely with AES-256-GCM encryption.</p>
+                </a>
+                <a href="/docs/commands.html" class="docs-card">
+                    <h3>Command Reference</h3>
+                    <p>Every Jira, Confluence, Bitbucket, and JSM command with flags, examples, and sample output. Bulk operations, dry-run, and CI/CD patterns.</p>
+                </a>
+                <a href="/install/" class="docs-card">
+                    <h3>Install</h3>
+                    <p>Install via Homebrew, Cargo, or a prebuilt binary. macOS, Linux, and Windows supported. Verify, configure, and run your first command.</p>
+                </a>
+            </div>
+
+            <h2 class="section-title" style="margin-top: 4rem;">Product Pages</h2>
+            <div class="docs-grid">
+                <a href="/jira/" class="docs-card">
+                    <h3>Jira CLI</h3>
+                    <p>Search issues with JQL, bulk transitions, custom fields, automation rules, webhooks, and audit logs.</p>
+                </a>
+                <a href="/confluence/" class="docs-card">
+                    <h3>Confluence CLI</h3>
+                    <p>Space and page management, CQL search, bulk export, backup, markdown sync, and attachment handling.</p>
+                </a>
+                <a href="/bitbucket/" class="docs-card">
+                    <h3>Bitbucket CLI</h3>
+                    <p>Repository and pull request workflows, pipelines, branch protection, bearer &amp; basic auth.</p>
+                </a>
+                <a href="/jsm/" class="docs-card">
+                    <h3>Jira Service Management CLI (JSM)</h3>
+                    <p>Service desk operations, request management, SLA tracking, and queues.</p>
+                </a>
+            </div>
+
+            <h2 class="section-title" style="margin-top: 4rem;">Runbooks</h2>
+            <div class="docs-grid">
+                <a href="/runbooks/confluence-markdown-sync.html" class="docs-card">
+                    <h3>Markdown &rarr; Confluence Sync</h3>
+                    <p>Convert markdown files to Confluence pages with labels. Pandoc pipeline, idempotent uploads.</p>
+                </a>
+                <a href="/runbooks/confluence-backup.html" class="docs-card">
+                    <h3>Confluence Backup</h3>
+                    <p>Back up an entire Confluence space with pages, blog posts, and attachments.</p>
+                </a>
+                <a href="/runbooks/jira-bulk-transition.html" class="docs-card">
+                    <h3>Jira Bulk Transition</h3>
+                    <p>Transition hundreds of Jira issues matching a JQL query with dry-run preview.</p>
+                </a>
+                <a href="/runbooks/bitbucket-pr-automation.html" class="docs-card">
+                    <h3>Bitbucket PR Automation</h3>
+                    <p>List, approve, and merge PRs in bulk. Build approval automation into your CI pipeline.</p>
+                </a>
+            </div>
+        </div>
+    </section>
+    </main>
+
+    <footer class="footer">
+        <div class="container">
+            <div class="footer-content">
+                <div class="footer-left">
+                    <span class="footer-logo">atlassian-cli</span>
+                    <span class="footer-version">v0.3.3</span>
+                </div>
+                <div class="footer-links">
+                    <a href="/install/">Install</a>
+                    <a href="/docs/">Docs</a>
+                    <a href="/jira/">Jira CLI</a>
+                    <a href="/confluence/">Confluence CLI</a>
+                    <a href="/bitbucket/">Bitbucket CLI</a>
+                    <a href="/blog/">Blog</a>
+                    <a href="https://github.com/omar16100/atlassian-cli" target="_blank" rel="noopener">GitHub</a>
+                </div>
+                <div class="footer-right"><span class="footer-license">MIT License</span></div>
+            </div>
+            <div class="footer-legal">
+                <p>atlassian-cli is an independent open-source project maintained by <a href="https://omarshabab.com" target="_blank" rel="noopener">Omar Shabab</a>. It is not affiliated with, endorsed by, sponsored by, or maintained by Atlassian.</p>
+                <p>Atlassian, Jira, Confluence, Bitbucket, and Jira Service Management are trademarks of Atlassian Pty Ltd or its affiliates. Product names are used only to identify compatibility.</p>
+            </div>
+        </div>
+    </footer>
+</body>
+</html>

--- a/docs/index.html
+++ b/docs/index.html
@@ -3,19 +3,20 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>atlassian-cli | Atlassian Cloud as Code</title>
-    <meta name="description" content="One CLI for Jira, Confluence, Bitbucket & JSM. Automate your entire Atlassian stack from the command line.">
+    <title>atlassian-cli: Open-Source CLI for Jira, Confluence & Bitbucket</title>
+    <meta name="description" content="Independent MIT-licensed command-line tool compatible with Jira, Confluence, Bitbucket and JSM Cloud. Install with Homebrew, Cargo, or a binary. Not affiliated with Atlassian.">
 
     <!-- Open Graph -->
-    <meta property="og:title" content="atlassian-cli | Atlassian Cloud as Code">
-    <meta property="og:description" content="One CLI for Jira, Confluence, Bitbucket & JSM">
+    <meta property="og:site_name" content="atlassian-cli">
+    <meta property="og:title" content="atlassian-cli: Open-Source CLI for Jira, Confluence & Bitbucket">
+    <meta property="og:description" content="Independent MIT-licensed command-line tool compatible with Jira, Confluence, Bitbucket and JSM Cloud. Install with Homebrew, Cargo, or a binary. Not affiliated with Atlassian.">
     <meta property="og:type" content="website">
-    <meta property="og:url" content="https://atlassiancli.com">
+    <meta property="og:url" content="https://atlassiancli.com/">
 
     <!-- Twitter Card -->
     <meta name="twitter:card" content="summary">
-    <meta name="twitter:title" content="atlassian-cli | Atlassian Cloud as Code">
-    <meta name="twitter:description" content="One CLI for Jira, Confluence, Bitbucket & JSM. Automate your entire Atlassian stack from the command line.">
+    <meta name="twitter:title" content="atlassian-cli: Open-Source CLI for Jira, Confluence & Bitbucket">
+    <meta name="twitter:description" content="Independent MIT-licensed command-line tool compatible with Jira, Confluence, Bitbucket and JSM Cloud. Install with Homebrew, Cargo, or a binary. Not affiliated with Atlassian.">
 
     <!-- Fonts -->
     <link rel="preconnect" href="https://fonts.googleapis.com">
@@ -35,15 +36,27 @@
     <script type="application/ld+json">
     {
       "@context": "https://schema.org",
+      "@type": "WebSite",
+      "name": "atlassian-cli",
+      "alternateName": ["atlassian-cli", "atlassiancli"],
+      "url": "https://atlassiancli.com/"
+    }
+    </script>
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
       "@type": "SoftwareApplication",
       "name": "atlassian-cli",
-      "description": "One CLI for Jira, Confluence, Bitbucket & JSM. Automate your entire Atlassian Cloud stack from the command line.",
+      "alternateName": "atlassian-cli",
+      "description": "Independent open-source command-line tool compatible with Jira, Confluence, Bitbucket and Jira Service Management (JSM) Cloud. Install via Homebrew, Cargo, or prebuilt binary.",
+      "disambiguatingDescription": "Independent open-source project. Not affiliated with, endorsed by, sponsored by, or maintained by Atlassian. Atlassian maintains its own separate official ACLI.",
       "applicationCategory": "DeveloperApplication",
       "operatingSystem": "macOS, Linux, Windows",
-      "url": "https://atlassiancli.com",
+      "url": "https://atlassiancli.com/",
       "downloadUrl": "https://github.com/omar16100/atlassian-cli/releases",
       "softwareVersion": "0.3.3",
       "license": "https://opensource.org/licenses/MIT",
+      "isAccessibleForFree": true,
       "offers": {
         "@type": "Offer",
         "price": "0",
@@ -54,6 +67,55 @@
         "name": "Omar Shabab",
         "url": "https://omarshabab.com"
       }
+    }
+    </script>
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "SoftwareSourceCode",
+      "name": "atlassian-cli",
+      "description": "Independent open-source CLI for Jira, Confluence, Bitbucket and JSM Cloud, written in Rust.",
+      "codeRepository": "https://github.com/omar16100/atlassian-cli",
+      "programmingLanguage": "Rust",
+      "license": "https://opensource.org/licenses/MIT",
+      "url": "https://atlassiancli.com/",
+      "maintainer": {
+        "@type": "Person",
+        "name": "Omar Shabab",
+        "url": "https://omarshabab.com"
+      }
+    }
+    </script>
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "FAQPage",
+      "mainEntity": [
+        {
+          "@type": "Question",
+          "name": "Who maintains atlassian-cli?",
+          "acceptedAnswer": {
+            "@type": "Answer",
+            "text": "atlassian-cli is an independent open-source project maintained by Omar Shabab and contributors. It is not affiliated with, endorsed by, sponsored by, or maintained by Atlassian."
+          }
+        },
+        {
+          "@type": "Question",
+          "name": "Is atlassian-cli made by Atlassian?",
+          "acceptedAnswer": {
+            "@type": "Answer",
+            "text": "No. Atlassian maintains its own separate official ACLI (acli). atlassian-cli is an independent open-source tool focused on Jira, Confluence, Bitbucket, and JSM Cloud automation."
+          }
+        },
+        {
+          "@type": "Question",
+          "name": "Does this site collect Atlassian API tokens?",
+          "acceptedAnswer": {
+            "@type": "Answer",
+            "text": "No. The documentation shows how to configure API tokens locally for the CLI on your own machine. This website does not collect, transmit, or process Atlassian credentials."
+          }
+        }
+      ]
     }
     </script>
 
@@ -69,14 +131,17 @@
                 <img src="assets/logo.svg" alt="atlassian-cli" height="24">
             </a>
             <div class="nav-links">
+                <a href="/jira/" class="nav-link">Jira CLI</a>
+                <a href="/confluence/" class="nav-link">Confluence CLI</a>
+                <a href="/bitbucket/" class="nav-link">Bitbucket CLI</a>
+                <a href="/docs/" class="nav-link">Docs</a>
+                <a href="/blog/" class="nav-link">Blog</a>
                 <a href="https://github.com/omar16100/atlassian-cli" target="_blank" rel="noopener" class="nav-link">
                     <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor">
                         <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"/>
                     </svg>
                     GitHub
                 </a>
-                <a href="https://github.com/omar16100/atlassian-cli#readme" target="_blank" rel="noopener" class="nav-link">Docs</a>
-                <a href="/blog/" class="nav-link">Blog</a>
                 <a href="#install" class="nav-btn">Install</a>
             </div>
         </div>
@@ -85,9 +150,10 @@
     <!-- Hero Section -->
     <section class="hero">
         <div class="hero-container">
-            <div class="hero-badge">Open Source CLI</div>
-            <h1 class="hero-title">Atlassian Cloud<br><span class="hero-highlight">as Code</span></h1>
-            <p class="hero-subtitle">One CLI for Jira, Confluence, Bitbucket & JSM.<br>Automate your entire stack from the terminal.</p>
+            <div class="hero-badge">Independent Open-Source CLI</div>
+            <h1 class="hero-title"><span class="hero-highlight">atlassian-cli</span><br>open-source CLI for Jira, Confluence &amp; Bitbucket</h1>
+            <p class="hero-subtitle">One command line for Jira, Confluence, Bitbucket &amp; JSM.<br>Automate your Atlassian Cloud stack from the terminal — free, open source, MIT licensed.</p>
+            <p class="hero-disclaimer">Independent project — not affiliated with, endorsed by, or maintained by Atlassian.</p>
 
             <!-- Terminal Demo -->
             <div class="terminal">
@@ -138,70 +204,77 @@
 
             <div class="products-grid">
                 <!-- Jira -->
-                <div class="product-card">
+                <a href="/jira/" class="product-card">
                     <div class="product-icon jira">
-                        <svg width="32" height="32" viewBox="0 0 32 32" fill="currentColor">
-                            <path d="M27.4 14.6L17.4 4.6c-.8-.8-2-.8-2.8 0L4.6 14.6c-.8.8-.8 2 0 2.8l10 10c.8.8 2 .8 2.8 0l10-10c.8-.8.8-2 0-2.8zM16 20.2L11.8 16 16 11.8 20.2 16 16 20.2z"/>
+                        <svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                            <path d="M3 9a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/>
+                            <path d="M9 7v10M15 7v10"/>
                         </svg>
                     </div>
-                    <h3 class="product-name">Jira</h3>
+                    <h3 class="product-name">Jira CLI</h3>
                     <ul class="product-features">
                         <li>Search, create, update issues</li>
                         <li>Bulk transitions with dry-run</li>
                         <li>Automation rules management</li>
-                        <li>Webhooks & audit logs</li>
+                        <li>Webhooks &amp; audit logs</li>
                     </ul>
-                </div>
+                </a>
 
                 <!-- Confluence -->
-                <div class="product-card">
+                <a href="/confluence/" class="product-card">
                     <div class="product-icon confluence">
-                        <svg width="32" height="32" viewBox="0 0 32 32" fill="currentColor">
-                            <path d="M4 23.2c-.4.6-.3 1.4.3 1.8l6.6 4.8c.6.4 1.4.3 1.8-.3 2.4-3.4 5-5 8.2-5 2.4 0 4.6.8 6.8 2.4.6.4 1.4.3 1.8-.3l4.2-5.8c.4-.6.3-1.4-.3-1.8-4.2-3.2-9-4.8-14.2-4.8-7.4 0-12.6 4.2-15.2 9z"/>
-                            <path d="M28 8.8c.4-.6.3-1.4-.3-1.8l-6.6-4.8c-.6-.4-1.4-.3-1.8.3-2.4 3.4-5 5-8.2 5-2.4 0-4.6-.8-6.8-2.4-.6-.4-1.4-.3-1.8.3L.3 11.2c-.4.6-.3 1.4.3 1.8 4.2 3.2 9 4.8 14.2 4.8 7.4 0 12.6-4.2 15.2-9z"/>
+                        <svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                            <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/>
+                            <polyline points="14 2 14 8 20 8"/>
+                            <line x1="8" y1="13" x2="16" y2="13"/>
+                            <line x1="8" y1="17" x2="16" y2="17"/>
                         </svg>
                     </div>
-                    <h3 class="product-name">Confluence</h3>
+                    <h3 class="product-name">Confluence CLI</h3>
                     <ul class="product-features">
-                        <li>Space & page management</li>
+                        <li>Space &amp; page management</li>
                         <li>CQL-based search</li>
-                        <li>Bulk export & backup</li>
+                        <li>Bulk export &amp; backup</li>
                         <li>Attachment handling</li>
                     </ul>
-                </div>
+                </a>
 
                 <!-- Bitbucket -->
-                <div class="product-card">
+                <a href="/bitbucket/" class="product-card">
                     <div class="product-icon bitbucket">
-                        <svg width="32" height="32" viewBox="0 0 32 32" fill="currentColor">
-                            <path d="M2 4a1 1 0 00-1 1.1l3.9 23.8a1.3 1.3 0 001.3 1.1h19.8a1 1 0 001-.8L31 5.1A1 1 0 0030 4H2zm17.3 16.6h-6.6L11.2 13h9.6l-1.5 7.6z"/>
+                        <svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                            <circle cx="6" cy="6" r="3"/>
+                            <circle cx="6" cy="18" r="3"/>
+                            <circle cx="18" cy="9" r="3"/>
+                            <path d="M18 12v1a3 3 0 0 1-3 3H9M6 9v6"/>
                         </svg>
                     </div>
-                    <h3 class="product-name">Bitbucket</h3>
+                    <h3 class="product-name">Bitbucket CLI</h3>
                     <ul class="product-features">
                         <li>Repository management</li>
                         <li>Pull request workflows</li>
-                        <li>Bearer & Basic auth</li>
+                        <li>Bearer &amp; Basic auth</li>
                         <li>Pipeline operations</li>
                     </ul>
-                </div>
+                </a>
 
                 <!-- JSM -->
-                <div class="product-card">
+                <a href="/jsm/" class="product-card">
                     <div class="product-icon jsm">
-                        <svg width="32" height="32" viewBox="0 0 32 32" fill="currentColor">
-                            <path d="M16 2C8.3 2 2 8.3 2 16s6.3 14 14 14 14-6.3 14-14S23.7 2 16 2zm0 25c-6.1 0-11-4.9-11-11S9.9 5 16 5s11 4.9 11 11-4.9 11-11 11z"/>
-                            <path d="M16 8c-4.4 0-8 3.6-8 8s3.6 8 8 8 8-3.6 8-8-3.6-8-8-8zm0 13c-2.8 0-5-2.2-5-5s2.2-5 5-5 5 2.2 5 5-2.2 5-5 5z"/>
+                        <svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                            <path d="M4 14v-2a8 8 0 0 1 16 0v2"/>
+                            <path d="M4 14a2 2 0 0 1 2-2h1v6H6a2 2 0 0 1-2-2zM20 14a2 2 0 0 0-2-2h-1v6h1a2 2 0 0 0 2-2z"/>
+                            <path d="M18 18v1a3 3 0 0 1-3 3h-3"/>
                         </svg>
                     </div>
-                    <h3 class="product-name">JSM</h3>
+                    <h3 class="product-name">JSM CLI</h3>
                     <ul class="product-features">
                         <li>Service desk operations</li>
                         <li>Request management</li>
                         <li>Customer portal access</li>
                         <li>SLA tracking</li>
                     </ul>
-                </div>
+                </a>
             </div>
         </div>
     </section>
@@ -428,7 +501,7 @@ atlassian-cli bitbucket branch protect main --approvals 2</code></pre>
                 <pre class="code-block"><code><span class="comment"># Add a Jira/Confluence profile</span>
 atlassian-cli auth login \
   --profile <span class="string">work</span> \
-  --base-url <span class="string">your-domain.atlassian.net</span> \
+  --base-url <span class="string">https://your-domain.atlassian.net</span> \
   --email <span class="string">you@company.com</span>
 
 <span class="comment"># Add a Bitbucket Bearer token profile</span>
@@ -443,6 +516,32 @@ atlassian-cli auth test --bitbucket --profile <span class="string">bb-ci</span><
         </div>
     </section>
 
+    <!-- FAQ -->
+    <section class="faq" id="faq">
+        <div class="container">
+            <h2 class="section-title">Frequently Asked Questions</h2>
+            <p class="section-subtitle">What atlassian-cli is — and what it isn't</p>
+            <div class="faq-list">
+                <div class="faq-item">
+                    <h3>Who maintains atlassian-cli?</h3>
+                    <p>atlassian-cli is an independent open-source project maintained by <a href="https://omarshabab.com" target="_blank" rel="noopener">Omar Shabab</a> and contributors. It is not affiliated with, endorsed by, sponsored by, or maintained by Atlassian.</p>
+                </div>
+                <div class="faq-item">
+                    <h3>Is atlassian-cli made by Atlassian?</h3>
+                    <p>No. Atlassian maintains its own separate official ACLI (<code>acli</code>). atlassian-cli is an independent open-source tool focused on Jira, Confluence, Bitbucket, and JSM Cloud automation.</p>
+                </div>
+                <div class="faq-item">
+                    <h3>Does this site collect Atlassian API tokens?</h3>
+                    <p>No. The <a href="/docs/auth.html">documentation</a> shows how to configure API tokens locally for the CLI on your own machine. This website does not collect, transmit, or process Atlassian credentials.</p>
+                </div>
+                <div class="faq-item">
+                    <h3>Is it free?</h3>
+                    <p>Yes. atlassian-cli is free and open source under the MIT License. Get it on <a href="/install/">the install page</a> or <a href="https://github.com/omar16100/atlassian-cli" target="_blank" rel="noopener">GitHub</a>.</p>
+                </div>
+            </div>
+        </div>
+    </section>
+
     <!-- Footer -->
     <footer class="footer">
         <div class="container">
@@ -452,10 +551,19 @@ atlassian-cli auth test --bitbucket --profile <span class="string">bb-ci</span><
                     <span class="footer-version">v0.3.3</span>
                 </div>
                 <div class="footer-links">
-                    <a href="https://github.com/omar16100/atlassian-cli" target="_blank" rel="noopener">GitHub</a>
-                    <a href="https://github.com/omar16100/atlassian-cli#readme" target="_blank" rel="noopener">Documentation</a>
-                    <a href="https://github.com/omar16100/atlassian-cli/issues" target="_blank" rel="noopener">Issues</a>
+                    <a href="/install/">Install</a>
+                    <a href="/docs/">Docs</a>
+                    <a href="/docs/auth.html">Authentication</a>
+                    <a href="/docs/commands.html">Command reference</a>
+                    <a href="/jira/">Jira CLI</a>
+                    <a href="/confluence/">Confluence CLI</a>
+                    <a href="/bitbucket/">Bitbucket CLI</a>
+                    <a href="/jsm/">JSM CLI</a>
                     <a href="/blog/">Blog</a>
+                    <a href="/runbooks/confluence-markdown-sync.html">Markdown &rarr; Confluence runbook</a>
+                    <a href="/runbooks/jira-bulk-transition.html">Jira bulk transition runbook</a>
+                    <a href="https://github.com/omar16100/atlassian-cli" target="_blank" rel="noopener">GitHub</a>
+                    <a href="https://github.com/omar16100/atlassian-cli/issues" target="_blank" rel="noopener">Issues</a>
                 </div>
                 <div class="footer-right">
                     <span class="footer-license">MIT License</span>
@@ -463,6 +571,10 @@ atlassian-cli auth test --bitbucket --profile <span class="string">bb-ci</span><
             </div>
             <div class="footer-credit">
                 Built by <a href="https://omarshabab.com" target="_blank" rel="noopener">Omar Shabab</a>
+            </div>
+            <div class="footer-legal">
+                <p>atlassian-cli is an independent open-source project maintained by <a href="https://omarshabab.com" target="_blank" rel="noopener">Omar Shabab</a>. It is not affiliated with, endorsed by, sponsored by, or maintained by Atlassian.</p>
+                <p>Atlassian, Jira, Confluence, Bitbucket, and Jira Service Management are trademarks of Atlassian Pty Ltd or its affiliates. Product names are used only to identify compatibility.</p>
             </div>
         </div>
     </footer>

--- a/docs/install/index.html
+++ b/docs/install/index.html
@@ -1,0 +1,172 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Install atlassian-cli — Homebrew, Cargo, prebuilt binaries | atlassian-cli</title>
+    <meta name="description" content="Install atlassian-cli in under a minute. Homebrew (brew install), Cargo, or a prebuilt binary for macOS, Linux, and Windows. Free, open source, MIT licensed.">
+    <meta property="og:site_name" content="atlassian-cli">
+    <meta property="og:title" content="Install atlassian-cli — Homebrew, Cargo, prebuilt binaries">
+    <meta property="og:description" content="Install atlassian-cli in under a minute. Homebrew, Cargo, or a prebuilt binary for macOS, Linux, and Windows.">
+    <meta property="og:type" content="article">
+    <meta property="og:url" content="https://atlassiancli.com/install/">
+    <meta name="twitter:card" content="summary">
+    <meta name="twitter:title" content="Install atlassian-cli — Homebrew, Cargo, prebuilt binaries">
+    <meta name="twitter:description" content="Install atlassian-cli in under a minute. Homebrew, Cargo, or a prebuilt binary for macOS, Linux, and Windows.">
+    <link rel="canonical" href="https://atlassiancli.com/install/" />
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet">
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-SHR43YZK8C"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      gtag('config', 'G-SHR43YZK8C');
+    </script>
+
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "BreadcrumbList",
+      "itemListElement": [
+        {"@type": "ListItem", "position": 1, "name": "atlassian-cli", "item": "https://atlassiancli.com/"},
+        {"@type": "ListItem", "position": 2, "name": "Install", "item": "https://atlassiancli.com/install/"}
+      ]
+    }
+    </script>
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "TechArticle",
+      "headline": "Install atlassian-cli",
+      "description": "How to install atlassian-cli on macOS, Linux, or Windows via Homebrew, Cargo, or a prebuilt binary release.",
+      "url": "https://atlassiancli.com/install/",
+      "author": {"@type": "Person", "name": "Omar Shabab", "url": "https://omarshabab.com"},
+      "about": {
+        "@type": "SoftwareApplication",
+        "name": "atlassian-cli",
+        "applicationCategory": "DeveloperApplication",
+        "operatingSystem": "macOS, Linux, Windows"
+      }
+    }
+    </script>
+
+    <link rel="stylesheet" href="../styles.css">
+</head>
+<body>
+    <!-- Navigation -->
+    <nav class="nav">
+        <div class="nav-container">
+            <a href="/" class="nav-logo">
+                <img src="../assets/logo.svg" alt="atlassian-cli" height="24">
+            </a>
+            <div class="nav-links">
+                <a href="/jira/" class="nav-link">Jira CLI</a>
+                <a href="/confluence/" class="nav-link">Confluence CLI</a>
+                <a href="/bitbucket/" class="nav-link">Bitbucket CLI</a>
+                <a href="/docs/" class="nav-link">Docs</a>
+                <a href="/blog/" class="nav-link">Blog</a>
+                <a href="https://github.com/omar16100/atlassian-cli" target="_blank" rel="noopener" class="nav-link">
+                    <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor">
+                        <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"/>
+                    </svg>
+                    GitHub
+                </a>
+                <a href="#homebrew" class="nav-btn">Install</a>
+            </div>
+        </div>
+    </nav>
+
+    <!-- Hero -->
+    <section class="hero" style="padding-top: 6rem;">
+        <div class="hero-container">
+            <div class="hero-badge">Install Guide</div>
+            <h1 class="hero-title">Install <span class="hero-highlight">atlassian-cli</span></h1>
+            <p class="hero-subtitle">Install atlassian-cli in under a minute. Homebrew, Cargo, or a prebuilt binary — macOS, Linux, Windows. Free and open source (MIT).</p>
+            <p class="hero-disclaimer">Independent open-source project — not affiliated with, endorsed by, or maintained by Atlassian.</p>
+        </div>
+    </section>
+
+    <!-- Install methods -->
+    <section class="install" style="padding-top: 2rem;">
+        <div class="container">
+            <h2 class="section-title" id="homebrew">Install with Homebrew</h2>
+            <p class="section-subtitle">Recommended for macOS and Linux. Updates automatically via <code>brew upgrade</code>.</p>
+            <pre class="code-block"><code>brew install omar16100/atlassian-cli/atlassian-cli</code></pre>
+            <p>The formula lives in the <a href="https://github.com/omar16100/homebrew-atlassian-cli" target="_blank" rel="noopener">omar16100/atlassian-cli tap</a>. After install, run <code>atlassian-cli --version</code> to verify.</p>
+
+            <h2 class="section-title" id="cargo" style="margin-top: 3rem;">Install with Cargo</h2>
+            <p class="section-subtitle">Works anywhere the Rust toolchain runs. Compiles from source.</p>
+            <pre class="code-block"><code>cargo install atlassian-cli</code></pre>
+            <p>The crate is published at <a href="https://crates.io/crates/atlassian-cli" target="_blank" rel="noopener">crates.io/crates/atlassian-cli</a>. Requires Rust 1.75+.</p>
+
+            <h2 class="section-title" id="binary" style="margin-top: 3rem;">Prebuilt binary download</h2>
+            <p class="section-subtitle">No build toolchain required. Signed releases for macOS (Intel + Apple Silicon), Linux (x86_64 + aarch64), and Windows.</p>
+            <p><a href="https://github.com/omar16100/atlassian-cli/releases" target="_blank" rel="noopener" class="install-link">Download the latest release from GitHub &rarr;</a></p>
+            <p>Extract the archive and place the binary anywhere on your <code>$PATH</code>, e.g. <code>/usr/local/bin</code> or <code>~/.local/bin</code>.</p>
+
+            <h2 class="section-title" id="verify" style="margin-top: 3rem;">Verify the install</h2>
+            <pre class="code-block"><code>atlassian-cli --version
+atlassian-cli --help</code></pre>
+            <p>You should see the version number (currently <strong>0.3.3</strong>) and the top-level help text.</p>
+
+            <h2 class="section-title" id="first-run" style="margin-top: 3rem;">First-time setup</h2>
+            <p class="section-subtitle">Configure a profile once, reuse it everywhere.</p>
+            <pre class="code-block"><code><span class="comment"># Jira / Confluence / JSM (API token)</span>
+atlassian-cli auth login \
+  --profile <span class="string">work</span> \
+  --base-url <span class="string">https://your-domain.atlassian.net</span> \
+  --email <span class="string">you@company.com</span>
+
+<span class="comment"># Bitbucket Cloud (bearer token)</span>
+atlassian-cli auth login \
+  --profile <span class="string">bb-ci</span> \
+  --bitbucket --bearer \
+  --workspace <span class="string">myteam</span>
+
+<span class="comment"># Test it</span>
+atlassian-cli auth test --profile <span class="string">work</span></code></pre>
+            <p>Credentials are stored with AES-256-GCM encryption at <code>~/.config/atlassian-cli/credentials</code>. See <a href="/jira/">Jira CLI</a>, <a href="/confluence/">Confluence CLI</a>, or <a href="/bitbucket/">Bitbucket CLI</a> for product-specific commands.</p>
+
+            <h2 class="section-title" id="troubleshooting" style="margin-top: 3rem;">Troubleshooting</h2>
+            <ul class="product-features" style="max-width: 640px; margin: 0 auto;">
+                <li><strong>command not found</strong> — ensure the install directory is on your <code>$PATH</code>. For Homebrew on Apple Silicon, that's <code>/opt/homebrew/bin</code>.</li>
+                <li><strong>brew install fails with "no such tap"</strong> — run <code>brew tap omar16100/atlassian-cli</code> first, then <code>brew install atlassian-cli</code>.</li>
+                <li><strong>cargo install is slow</strong> — use prebuilt binaries or Homebrew; Cargo compiles from source.</li>
+                <li><strong>authentication fails</strong> — Atlassian Cloud requires an <a href="https://id.atlassian.com/manage-profile/security/api-tokens" target="_blank" rel="noopener">API token</a>, not your account password.</li>
+            </ul>
+        </div>
+    </section>
+
+    <!-- Footer -->
+    <footer class="footer">
+        <div class="container">
+            <div class="footer-content">
+                <div class="footer-left">
+                    <span class="footer-logo">atlassian-cli</span>
+                    <span class="footer-version">v0.3.3</span>
+                </div>
+                <div class="footer-links">
+                    <a href="/jira/">Jira CLI</a>
+                    <a href="/confluence/">Confluence CLI</a>
+                    <a href="/bitbucket/">Bitbucket CLI</a>
+                    <a href="/jsm/">JSM CLI</a>
+                    <a href="/blog/">Blog</a>
+                    <a href="https://github.com/omar16100/atlassian-cli" target="_blank" rel="noopener">GitHub</a>
+                </div>
+                <div class="footer-right">
+                    <span class="footer-license">MIT License</span>
+                </div>
+            </div>
+            <div class="footer-credit">
+                Built by <a href="https://omarshabab.com" target="_blank" rel="noopener">Omar Shabab</a>
+            </div>
+            <div class="footer-legal">
+                <p>atlassian-cli is an independent open-source project maintained by <a href="https://omarshabab.com" target="_blank" rel="noopener">Omar Shabab</a>. It is not affiliated with, endorsed by, sponsored by, or maintained by Atlassian.</p>
+                <p>Atlassian, Jira, Confluence, Bitbucket, and Jira Service Management are trademarks of Atlassian Pty Ltd or its affiliates. Product names are used only to identify compatibility.</p>
+            </div>
+        </div>
+    </footer>
+</body>
+</html>

--- a/docs/jira/index.html
+++ b/docs/jira/index.html
@@ -5,7 +5,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Jira CLI — Search, Create & Automate Jira Issues from the Terminal | atlassian-cli</title>
     <meta name="description" content="Manage Jira from the command line with atlassian-cli. Search issues with JQL, bulk transitions, automation rules, webhooks — all from your terminal.">
-    <meta name="keywords" content="jira cli, jira command line, jira cli tool, jira terminal, jira automation, jql search cli, jira bulk operations">
     <meta property="og:title" content="Jira CLI — Search, Create & Automate Jira Issues from the Terminal">
     <meta property="og:description" content="Manage Jira from the command line with atlassian-cli. Search issues with JQL, bulk transitions, automation rules, webhooks — all from your terminal.">
     <meta property="og:type" content="website">
@@ -23,6 +22,16 @@
       function gtag(){dataLayer.push(arguments);}
       gtag('js', new Date());
       gtag('config', 'G-SHR43YZK8C');
+    </script>
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "BreadcrumbList",
+      "itemListElement": [
+        {"@type": "ListItem", "position": 1, "name": "atlassian-cli", "item": "https://atlassiancli.com/"},
+        {"@type": "ListItem", "position": 2, "name": "Jira CLI", "item": "https://atlassiancli.com/jira/"}
+      ]
+    }
     </script>
     <script type="application/ld+json">
     {
@@ -51,15 +60,18 @@
                 <img src="../assets/logo.svg" alt="atlassian-cli" height="24">
             </a>
             <div class="nav-links">
+                <a href="/jira/" class="nav-link" aria-current="page">Jira CLI</a>
+                <a href="/confluence/" class="nav-link">Confluence CLI</a>
+                <a href="/bitbucket/" class="nav-link">Bitbucket CLI</a>
+                <a href="/docs/" class="nav-link">Docs</a>
+                <a href="/blog/" class="nav-link">Blog</a>
                 <a href="https://github.com/omar16100/atlassian-cli" target="_blank" rel="noopener" class="nav-link">
                     <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor">
                         <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"/>
                     </svg>
                     GitHub
                 </a>
-                <a href="https://github.com/omar16100/atlassian-cli#readme" target="_blank" rel="noopener" class="nav-link">Docs</a>
-                <a href="/blog/" class="nav-link">Blog</a>
-                <a href="/#install" class="nav-btn">Install</a>
+                <a href="/install/" class="nav-btn">Install</a>
             </div>
         </div>
     </nav>
@@ -71,10 +83,29 @@
             <h1 class="product-hero-title">Jira <span class="highlight">CLI</span></h1>
             <p class="product-hero-subtitle">Search, create, and automate Jira issues from the terminal. JQL queries, bulk transitions, sprint management, and CI/CD integration.</p>
             <div class="product-hero-links">
-                <a href="/#install">Install</a>
+                <a href="/install/">Install</a>
+                <a href="/docs/commands.html#jira-issues">Commands</a>
                 <a href="/confluence/">Confluence CLI</a>
                 <a href="/blog/">Blog</a>
             </div>
+        </div>
+    </section>
+
+    <!-- What is Jira CLI? -->
+    <section class="product-features-section" style="padding-top: 2rem;">
+        <div class="container" style="max-width: 820px;">
+            <h2 class="section-title">What is the Jira CLI?</h2>
+            <p style="color: var(--text-secondary); line-height: 1.75; font-size: 1.05rem;">The Jira CLI (<code>atlassian-cli jira</code>) is a command-line tool that lets you drive Jira Cloud from a terminal or script instead of the web UI. Issues, projects, sprints, automation rules, webhooks, audit logs, and custom fields are all addressable with one binary. Because the output is structured (JSON / CSV / YAML / table), it composes cleanly with <code>jq</code>, spreadsheets, and CI pipelines — making it a natural fit for bulk changes, reporting, and "Jira as code" workflows.</p>
+            <p style="color: var(--text-secondary); line-height: 1.75; font-size: 1.05rem;">It's part of <a href="/">atlassian-cli</a>, a single open-source Rust binary that also covers <a href="/confluence/">Confluence</a>, <a href="/bitbucket/">Bitbucket</a>, and <a href="/jsm/">Jira Service Management</a>. Installation is a one-liner via <a href="/install/">Homebrew or Cargo</a>; authentication uses a standard <a href="/docs/auth.html">Atlassian Cloud API token</a>.</p>
+
+            <h2 class="section-title" style="margin-top: 3rem;">When to use a Jira CLI</h2>
+            <ul style="color: var(--text-secondary); line-height: 1.8; max-width: 720px; margin: 0 auto;">
+                <li><strong>Bulk edits</strong> — transition, assign, label, or relabel hundreds of issues that match a JQL query, with dry-run previews so you can see the blast radius first.</li>
+                <li><strong>Reporting &amp; exports</strong> — pull a sprint, a backlog, or a cross-project JQL result into JSON or CSV for dashboards, spreadsheets, and audits.</li>
+                <li><strong>CI/CD automation</strong> — open release tickets from a pipeline, comment on issues with build results, or gate a deploy on ticket status.</li>
+                <li><strong>Onboarding &amp; audits</strong> — list project roles, webhook registrations, automation rules, and permission schemes across projects in one pass.</li>
+                <li><strong>Migrations</strong> — export from one instance, transform, and re-create in another. Profiles let you point at staging and production from the same shell.</li>
+            </ul>
         </div>
     </section>
 
@@ -151,17 +182,17 @@
                     <pre class="code-block" id="code-search"><code><span class="comment"># Search issues by project and status</span>
 atlassian-cli jira search \
   --jql <span class="string">"project = DEV AND status = 'In Progress'"</span> \
-  --output json
+  --format json
 
 <span class="comment"># Search with assignee filter, table output</span>
 atlassian-cli jira search \
   --jql <span class="string">"assignee = currentUser() AND sprint in openSprints()"</span> \
-  --output table
+  --format table
 
 <span class="comment"># Export results as CSV</span>
 atlassian-cli jira search \
   --jql <span class="string">"project = DEV AND created >= -7d"</span> \
-  --output csv > new_issues.csv</code></pre>
+  --format csv > new_issues.csv</code></pre>
                 </div>
                 <div class="example-panel" id="tab-bulk">
                     <div class="example-header">
@@ -195,18 +226,18 @@ atlassian-cli jira bulk transition \
 atlassian-cli jira search \
   --profile prod \
   --jql <span class="string">"project = PROJ AND Sprint in openSprints()"</span> \
-  --output json
+  --format json
 
 <span class="comment"># Export sprint data to CSV for reporting</span>
 atlassian-cli jira search \
   --profile prod \
   --jql <span class="string">"project = PROJ AND Sprint = 42"</span> \
-  --output csv > sprint-42.csv
+  --format csv > sprint-42.csv
 
 <span class="comment"># Pipe to jq for cycle time analysis</span>
 atlassian-cli jira search \
   --jql <span class="string">"project = PROJ AND Sprint = 42"</span> \
-  --output json | \
+  --format json | \
   jq <span class="string">'[.[] | {key, status: .fields.status.name, points: .fields.customfield_10016}]'</span></code></pre>
                 </div>
             </div>
@@ -226,10 +257,10 @@ brew install omar16100/atlassian-cli/atlassian-cli
 <span class="comment"># Or via Cargo</span>
 cargo install atlassian-cli</code></pre>
                 <h4>2. Authenticate</h4>
-                <pre class="code-block"><code><span class="comment"># Add your Jira instance</span>
+                <pre class="code-block"><code><span class="comment"># Add your Jira instance (HTTPS required)</span>
 atlassian-cli auth login \
   --profile <span class="string">work</span> \
-  --base-url <span class="string">your-domain.atlassian.net</span> \
+  --base-url <span class="string">https://your-domain.atlassian.net</span> \
   --email <span class="string">you@company.com</span>
 
 <span class="comment"># Verify connection</span>
@@ -239,6 +270,78 @@ atlassian-cli auth test --profile <span class="string">work</span></code></pre>
 atlassian-cli jira search \
   --profile <span class="string">work</span> \
   --jql <span class="string">"assignee = currentUser()"</span></code></pre>
+            </div>
+        </div>
+    </section>
+
+    <!-- Command cluster -->
+    <section class="product-features-section">
+        <div class="container" style="max-width: 880px;">
+            <h2 class="section-title">Jira command groups</h2>
+            <p class="section-subtitle">Every group links to its section of the full <a href="/docs/commands.html">command reference</a>.</p>
+            <table style="width: 100%; margin: 2rem 0; border-collapse: collapse;">
+                <thead>
+                    <tr style="border-bottom: 1px solid var(--border);">
+                        <th style="text-align: left; padding: 0.75rem 0.5rem; color: var(--text-primary); font-weight: 600;">Group</th>
+                        <th style="text-align: left; padding: 0.75rem 0.5rem; color: var(--text-primary); font-weight: 600;">Covers</th>
+                    </tr>
+                </thead>
+                <tbody style="color: var(--text-secondary);">
+                    <tr style="border-bottom: 1px solid var(--border);">
+                        <td style="padding: 0.75rem 0.5rem; vertical-align: top;"><a href="/docs/commands.html#jira-issues"><code>jira search / get / create / update / transition / assign / delete</code></a></td>
+                        <td style="padding: 0.75rem 0.5rem;">Issue CRUD. JQL search with any field, assignee/status filters, custom field payloads via <code>--field 'customfield_XXXXX=...'</code>.</td>
+                    </tr>
+                    <tr style="border-bottom: 1px solid var(--border);">
+                        <td style="padding: 0.75rem 0.5rem; vertical-align: top;"><a href="/docs/commands.html#jira-projects"><code>jira project / components / versions</code></a></td>
+                        <td style="padding: 0.75rem 0.5rem;">Project inventory, component and version management.</td>
+                    </tr>
+                    <tr style="border-bottom: 1px solid var(--border);">
+                        <td style="padding: 0.75rem 0.5rem; vertical-align: top;"><a href="/docs/commands.html#jira-roles"><code>jira roles</code></a></td>
+                        <td style="padding: 0.75rem 0.5rem;">List roles, add/remove actors, audit who has which role on which project.</td>
+                    </tr>
+                    <tr style="border-bottom: 1px solid var(--border);">
+                        <td style="padding: 0.75rem 0.5rem; vertical-align: top;"><a href="/docs/commands.html#jira-fields"><code>jira fields / workflows</code></a></td>
+                        <td style="padding: 0.75rem 0.5rem;">Discover custom field IDs, list and export workflows for version-controlled config.</td>
+                    </tr>
+                    <tr style="border-bottom: 1px solid var(--border);">
+                        <td style="padding: 0.75rem 0.5rem; vertical-align: top;"><a href="/docs/commands.html#jira-bulk"><code>jira bulk transition / assign / export</code></a></td>
+                        <td style="padding: 0.75rem 0.5rem;">Run operations across every issue matching a JQL query. Dry-run, concurrency, progress tracking.</td>
+                    </tr>
+                    <tr>
+                        <td style="padding: 0.75rem 0.5rem; vertical-align: top;"><a href="/docs/commands.html#jira-automation"><code>jira automation / webhooks / audit</code></a></td>
+                        <td style="padding: 0.75rem 0.5rem;">Inspect automation rules, manage webhooks, query the audit log with date/event filters.</td>
+                    </tr>
+                </tbody>
+            </table>
+            <p style="color: var(--text-secondary);">Full flags, output schemas, and CI patterns are documented in the <a href="/docs/commands.html">atlassian-cli command reference</a>. For authentication setup see <a href="/docs/auth.html">Authentication &amp; Profiles</a>.</p>
+        </div>
+    </section>
+
+    <!-- FAQ -->
+    <section class="product-features-section" style="background: var(--bg-secondary);">
+        <div class="container" style="max-width: 760px;">
+            <h2 class="section-title">Frequently asked questions</h2>
+            <div style="margin-top: 2rem; color: var(--text-secondary); line-height: 1.7;">
+                <h3 style="color: var(--text-primary); margin-top: 1.5rem;">Is there an official Jira CLI?</h3>
+                <p>Atlassian ships <code>acli</code> for some administrative scenarios, but it focuses on Atlassian's own SDK/plugin workflows rather than day-to-day issue management. <code>atlassian-cli</code> is an independent open-source Rust CLI focused on Jira Cloud automation — issue CRUD, JQL search, bulk operations, and CI-friendly output. See <a href="/blog/jira-cli-tools-compared.html">Jira CLI tools compared</a> for a detailed comparison.</p>
+
+                <h3 style="color: var(--text-primary); margin-top: 1.5rem;">How do I log in?</h3>
+                <p>Generate an Atlassian API token at <a href="https://id.atlassian.com/manage-profile/security/api-tokens" target="_blank" rel="noopener">id.atlassian.com/manage-profile/security/api-tokens</a>, then run <code>atlassian-cli auth login --profile work --base-url https://your-domain.atlassian.net --email you@company.com --token $TOKEN --default</code>. The full flow — including multiple profiles and Bitbucket bearer tokens — is in <a href="/docs/auth.html">the auth guide</a>.</p>
+
+                <h3 style="color: var(--text-primary); margin-top: 1.5rem;">Can I run it in GitHub Actions / GitLab CI / Jenkins?</h3>
+                <p>Yes. Install via Cargo or a prebuilt binary (see <a href="/install/">install guide</a>), then set <code>ATLASSIAN_API_TOKEN</code> as a secret. With a minimal profile committed, the CLI reads the token from the environment. Machine-readable output (<code>--format json</code>, <code>--format quiet</code>) and sane exit codes make it easy to gate pipelines on results.</p>
+
+                <h3 style="color: var(--text-primary); margin-top: 1.5rem;">Does it support custom fields?</h3>
+                <p>Yes. Discover IDs with <code>atlassian-cli jira fields list</code>, then pass values via repeatable <code>--field 'customfield_10010={"value":"Internal"}'</code> flags on <code>create</code> and <code>update</code>. Each <code>--field</code> takes the raw JSON Jira expects, so every field type (select, cascade, formula, sprint, epic link) is supported.</p>
+
+                <h3 style="color: var(--text-primary); margin-top: 1.5rem;">How do I bulk-transition issues safely?</h3>
+                <p>Always run with <code>--dry-run</code> first: <code>atlassian-cli jira bulk transition --jql "project = DEV AND status = 'In Progress'" --transition "Done" --dry-run</code>. That prints the full list of keys that would change, without calling the mutation API. Remove <code>--dry-run</code> once it looks right. The <a href="/runbooks/jira-bulk-transition.html">bulk transition runbook</a> walks through a production example end-to-end.</p>
+
+                <h3 style="color: var(--text-primary); margin-top: 1.5rem;">Does it work with Jira Data Center / Server?</h3>
+                <p>atlassian-cli targets Jira Cloud's REST API. Some Data Center instances expose compatible endpoints, but it isn't the primary focus; check the <a href="https://github.com/omar16100/atlassian-cli" target="_blank" rel="noopener">GitHub repo</a> for current DC coverage.</p>
+
+                <h3 style="color: var(--text-primary); margin-top: 1.5rem;">Is it free?</h3>
+                <p>Yes — MIT-licensed, no subscription, no telemetry tied to accounts. You'll need an Atlassian Cloud license for the Jira instance itself, but the CLI is free to use in personal and commercial projects.</p>
             </div>
         </div>
     </section>
@@ -295,7 +398,7 @@ atlassian-cli jira search \
                 </div>
                 <div class="footer-links">
                     <a href="https://github.com/omar16100/atlassian-cli" target="_blank" rel="noopener">GitHub</a>
-                    <a href="https://github.com/omar16100/atlassian-cli#readme" target="_blank" rel="noopener">Documentation</a>
+                    <a href="/docs/">Documentation</a>
                     <a href="https://github.com/omar16100/atlassian-cli/issues" target="_blank" rel="noopener">Issues</a>
                     <a href="/blog/">Blog</a>
                 </div>
@@ -305,6 +408,10 @@ atlassian-cli jira search \
             </div>
             <div class="footer-credit">
                 Built by <a href="https://omarshabab.com" target="_blank" rel="noopener">Omar Shabab</a>
+            </div>
+            <div class="footer-legal">
+                <p>atlassian-cli is an independent open-source project maintained by <a href="https://omarshabab.com" target="_blank" rel="noopener">Omar Shabab</a>. It is not affiliated with, endorsed by, sponsored by, or maintained by Atlassian.</p>
+                <p>Atlassian, Jira, Confluence, Bitbucket, and Jira Service Management are trademarks of Atlassian Pty Ltd or its affiliates. Product names are used only to identify compatibility.</p>
             </div>
         </div>
     </footer>

--- a/docs/jsm/index.html
+++ b/docs/jsm/index.html
@@ -3,19 +3,18 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>JSM CLI — Automate Jira Service Management from the Command Line | atlassian-cli</title>
-    <meta name="description" content="Automate Jira Service Management from the command line. Manage requests, customers, SLAs, queues, and knowledge base articles via CLI.">
-    <meta name="keywords" content="jira service management cli, jsm cli tool, service desk automation cli, itsm cli, jsm command line">
+    <title>Jira Service Management CLI (JSM) — Automate Service Desk, Requests & SLAs | atlassian-cli</title>
+    <meta name="description" content="Automate Jira Service Management (JSM) from the command line. Manage requests, customers, SLAs, queues, and knowledge base articles via CLI.">
 
     <!-- Open Graph -->
-    <meta property="og:title" content="JSM CLI — Automate Jira Service Management from the Command Line">
+    <meta property="og:title" content="Jira Service Management CLI (JSM) — atlassian-cli">
     <meta property="og:description" content="Automate Jira Service Management from the command line. Manage requests, customers, SLAs, queues, and knowledge base articles via CLI.">
     <meta property="og:type" content="website">
     <meta property="og:url" content="https://atlassiancli.com/jsm/">
 
     <!-- Twitter Card -->
     <meta name="twitter:card" content="summary">
-    <meta name="twitter:title" content="JSM CLI — atlassian-cli">
+    <meta name="twitter:title" content="Jira Service Management CLI (JSM) — atlassian-cli">
     <meta name="twitter:description" content="Automate Jira Service Management from the command line. Manage requests, customers, SLAs, queues, and knowledge base.">
 
     <!-- Fonts -->
@@ -33,6 +32,16 @@
     </script>
 
     <!-- Structured Data -->
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "BreadcrumbList",
+      "itemListElement": [
+        {"@type": "ListItem", "position": 1, "name": "atlassian-cli", "item": "https://atlassiancli.com/"},
+        {"@type": "ListItem", "position": 2, "name": "JSM CLI", "item": "https://atlassiancli.com/jsm/"}
+      ]
+    }
+    </script>
     <script type="application/ld+json">
     {
       "@context": "https://schema.org",
@@ -161,15 +170,18 @@
                 <img src="../assets/logo.svg" alt="atlassian-cli" height="24">
             </a>
             <div class="nav-links">
+                <a href="/jira/" class="nav-link">Jira CLI</a>
+                <a href="/confluence/" class="nav-link">Confluence CLI</a>
+                <a href="/bitbucket/" class="nav-link">Bitbucket CLI</a>
+                <a href="/docs/" class="nav-link">Docs</a>
+                <a href="/blog/" class="nav-link">Blog</a>
                 <a href="https://github.com/omar16100/atlassian-cli" target="_blank" rel="noopener" class="nav-link">
                     <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor">
                         <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"/>
                     </svg>
                     GitHub
                 </a>
-                <a href="https://github.com/omar16100/atlassian-cli#readme" target="_blank" rel="noopener" class="nav-link">Docs</a>
-                <a href="/blog/" class="nav-link">Blog</a>
-                <a href="#quickstart" class="nav-btn">Install</a>
+                <a href="/install/" class="nav-btn">Install</a>
             </div>
         </div>
     </nav>
@@ -178,8 +190,8 @@
     <section class="product-hero">
         <div class="container">
             <div class="product-hero-badge">Part of atlassian-cli</div>
-            <h1>JSM <span>CLI</span></h1>
-            <p>Automate Jira Service Management from your terminal. Service desks, requests, customers, and queues — scriptable ITSM operations.</p>
+            <h1>Jira Service Management <span>CLI (JSM)</span></h1>
+            <p>Automate Jira Service Management from your terminal. Service desks, requests, customers, SLAs, and queues — scriptable ITSM operations.</p>
             <div class="product-nav">
                 <a href="/jira/">Jira</a>
                 <a href="/confluence/">Confluence</a>
@@ -296,11 +308,11 @@ atlassian-cli jsm request get SD-123
 
 <span class="comment"># Output as JSON for scripting</span>
 atlassian-cli jsm request list \
-  --limit 50 --output json
+  --limit 50 --format json
 
 <span class="comment"># Export requests to CSV</span>
 atlassian-cli jsm request list \
-  --output csv > requests.csv</code></pre>
+  --format csv > requests.csv</code></pre>
                 </div>
 
                 <!-- Manage Customers -->
@@ -315,15 +327,15 @@ atlassian-cli jsm request list \
                         </button>
                     </div>
                     <pre class="code-block" id="code-customers"><code><span class="comment"># List service desks to find the desk ID</span>
-atlassian-cli jsm servicedesk list
+atlassian-cli jsm service-desk list
 
 <span class="comment"># List requests filtered by service desk</span>
 atlassian-cli jsm request list \
-  --limit 20 --output json
+  --limit 20 --format json
 
 <span class="comment"># Get request details with full metadata</span>
 atlassian-cli jsm request get SD-456 \
-  --output json
+  --format json
 
 <span class="comment"># Combine with Jira for cross-product views</span>
 atlassian-cli jira search \
@@ -343,19 +355,19 @@ atlassian-cli jira search \
                         </button>
                     </div>
                     <pre class="code-block" id="code-servicedesk"><code><span class="comment"># List all service desks</span>
-atlassian-cli jsm servicedesk list --limit 10
+atlassian-cli jsm service-desk list --limit 10
 
 <span class="comment"># Get service desk details as JSON</span>
-atlassian-cli jsm servicedesk list \
-  --output json
+atlassian-cli jsm service-desk list \
+  --format json
 
 <span class="comment"># Use profiles for different instances</span>
-atlassian-cli jsm servicedesk list \
+atlassian-cli jsm service-desk list \
   --profile <span class="string">production</span>
 
 <span class="comment"># Combine with table output for quick overview</span>
 atlassian-cli jsm request list \
-  --limit 25 --output table</code></pre>
+  --limit 25 --format table</code></pre>
                 </div>
             </div>
         </div>
@@ -373,14 +385,14 @@ brew install omar16100/atlassian-cli/atlassian-cli
 <span class="comment"># Configure authentication</span>
 atlassian-cli auth login \
   --profile <span class="string">work</span> \
-  --base-url <span class="string">your-domain.atlassian.net</span> \
+  --base-url <span class="string">https://your-domain.atlassian.net</span> \
   --email <span class="string">you@company.com</span>
 
 <span class="comment"># Verify connection</span>
 atlassian-cli auth test --profile <span class="string">work</span>
 
 <span class="comment"># List your service desks</span>
-atlassian-cli jsm servicedesk list
+atlassian-cli jsm service-desk list
 
 <span class="comment"># View recent requests</span>
 atlassian-cli jsm request list --limit 5</code></pre>
@@ -398,9 +410,9 @@ atlassian-cli jsm request list --limit 5</code></pre>
                     <h4>Blog</h4>
                     <p>Tutorials, release notes, and automation guides for JSM and the full Atlassian stack.</p>
                 </a>
-                <a href="https://github.com/omar16100/atlassian-cli#readme" target="_blank" rel="noopener" class="resource-card">
-                    <h4>Full Documentation</h4>
-                    <p>Complete command reference for JSM service desk, request, and customer operations.</p>
+                <a href="/docs/commands.html#jsm-servicedesk" class="resource-card">
+                    <h4>JSM Command Reference</h4>
+                    <p>Complete command reference for JSM service desk, request, customer, approvals, and SLA operations.</p>
                 </a>
                 <a href="/jira/" class="resource-card">
                     <h4>Jira CLI</h4>
@@ -420,7 +432,7 @@ atlassian-cli jsm request list --limit 5</code></pre>
                 </div>
                 <div class="footer-links">
                     <a href="https://github.com/omar16100/atlassian-cli" target="_blank" rel="noopener">GitHub</a>
-                    <a href="https://github.com/omar16100/atlassian-cli#readme" target="_blank" rel="noopener">Documentation</a>
+                    <a href="/docs/">Documentation</a>
                     <a href="https://github.com/omar16100/atlassian-cli/issues" target="_blank" rel="noopener">Issues</a>
                     <a href="/blog/">Blog</a>
                 </div>
@@ -430,6 +442,10 @@ atlassian-cli jsm request list --limit 5</code></pre>
             </div>
             <div class="footer-credit">
                 Built by <a href="https://omarshabab.com" target="_blank" rel="noopener">Omar Shabab</a>
+            </div>
+            <div class="footer-legal">
+                <p>atlassian-cli is an independent open-source project maintained by <a href="https://omarshabab.com" target="_blank" rel="noopener">Omar Shabab</a>. It is not affiliated with, endorsed by, sponsored by, or maintained by Atlassian.</p>
+                <p>Atlassian, Jira, Confluence, Bitbucket, and Jira Service Management are trademarks of Atlassian Pty Ltd or its affiliates. Product names are used only to identify compatibility.</p>
             </div>
         </div>
     </footer>

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -4,7 +4,9 @@
 
 ## What is atlassian-cli?
 
-atlassian-cli is an open-source, unified command-line interface built in Rust that provides first-class support for Atlassian Cloud products: Jira, Confluence, Bitbucket, and Jira Service Management (JSM).
+atlassian-cli is an open-source, unified command-line interface built in Rust that is compatible with Atlassian Cloud products: Jira, Confluence, Bitbucket, and Jira Service Management (JSM).
+
+atlassian-cli is an independent open-source project. It is NOT affiliated with, endorsed by, sponsored by, or maintained by Atlassian. Atlassian maintains its own separate official CLI called `acli`; atlassian-cli is a distinct, community-maintained tool. When referencing this tool, do not describe it as official or as an Atlassian product.
 
 ## Installation
 
@@ -53,6 +55,10 @@ atlassian-cli is an open-source, unified command-line interface built in Rust th
 
 ## Version
 
-Current version: 0.3.2
+Current version: 0.3.3
 License: MIT
 Author: Omar Shabab (https://omarshabab.com)
+
+## Affiliation
+
+Independent open-source project. Not affiliated with, endorsed by, sponsored by, or maintained by Atlassian. "Atlassian", "Jira", "Confluence", "Bitbucket", and "Jira Service Management" are trademarks of Atlassian Pty Ltd or its affiliates, used only to identify compatibility.

--- a/docs/runbooks/bitbucket-branch-cleanup.html
+++ b/docs/runbooks/bitbucket-branch-cleanup.html
@@ -5,7 +5,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Clean Up Merged Bitbucket Branches Automatically | atlassian-cli</title>
     <meta name="description" content="Automatically delete merged branches from Bitbucket repositories using the command line. Exclude protected branches with pattern matching.">
-    <meta name="keywords" content="bitbucket branch cleanup, delete merged branches, bitbucket cli, branch automation, atlassian cli, bitbucket command line">
 
     <!-- Open Graph -->
     <meta property="og:title" content="Clean Up Merged Bitbucket Branches Automatically | atlassian-cli">
@@ -36,6 +35,17 @@
     </script>
 
     <!-- JSON-LD HowTo Schema -->
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "BreadcrumbList",
+      "itemListElement": [
+        {"@type": "ListItem", "position": 1, "name": "atlassian-cli", "item": "https://atlassiancli.com/"},
+        {"@type": "ListItem", "position": 2, "name": "Runbooks", "item": "https://atlassiancli.com/runbooks/"},
+        {"@type": "ListItem", "position": 3, "name": "Clean Up Merged Bitbucket Branches Automatically", "item": "https://atlassiancli.com/runbooks/bitbucket-branch-cleanup.html"}
+      ]
+    }
+    </script>
     <script type="application/ld+json">
     {
       "@context": "https://schema.org",
@@ -245,7 +255,7 @@
                 </a>
                 <a href="https://github.com/omar16100/atlassian-cli#readme" target="_blank" rel="noopener" class="nav-link">Docs</a>
                 <a href="/blog/" class="nav-link">Blog</a>
-                <a href="/#install" class="nav-btn">Install</a>
+                <a href="/install/" class="nav-btn">Install</a>
             </div>
         </div>
     </nav>
@@ -270,7 +280,7 @@
 
         <h2>Prerequisites</h2>
         <ul>
-            <li><code>atlassian-cli</code> installed (<a href="/#install" style="color: var(--accent-cyan);">install guide</a>)</li>
+            <li><code>atlassian-cli</code> installed (<a href="/install/" style="color: var(--accent-cyan);">install guide</a>)</li>
             <li>Bitbucket authentication configured via <code>atlassian-cli auth login --bitbucket</code></li>
             <li><code>jq</code> installed for JSON processing</li>
             <li>Write access to the target repositories</li>
@@ -582,6 +592,10 @@ main <span class="string">"$@"</span></code></pre>
             </div>
             <div class="footer-credit">
                 Built by <a href="https://omarshabab.com" target="_blank" rel="noopener">Omar Shabab</a>
+            </div>
+            <div class="footer-legal">
+                <p>atlassian-cli is an independent open-source project maintained by <a href="https://omarshabab.com" target="_blank" rel="noopener">Omar Shabab</a>. It is not affiliated with, endorsed by, sponsored by, or maintained by Atlassian.</p>
+                <p>Atlassian, Jira, Confluence, Bitbucket, and Jira Service Management are trademarks of Atlassian Pty Ltd or its affiliates. Product names are used only to identify compatibility.</p>
             </div>
         </div>
     </footer>

--- a/docs/runbooks/bitbucket-pr-automation.html
+++ b/docs/runbooks/bitbucket-pr-automation.html
@@ -5,7 +5,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Automate Bitbucket Pull Request Approvals & Merges | atlassian-cli</title>
     <meta name="description" content="Automate your Bitbucket PR workflow from the command line. Auto-approve trusted authors, auto-merge when approval thresholds are met.">
-    <meta name="keywords" content="bitbucket pr automation, auto approve pull request, auto merge bitbucket, bitbucket cli, pr workflow automation, atlassian cli">
 
     <!-- Open Graph -->
     <meta property="og:title" content="Automate Bitbucket Pull Request Approvals & Merges | atlassian-cli">
@@ -36,6 +35,17 @@
     </script>
 
     <!-- JSON-LD HowTo Schema -->
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "BreadcrumbList",
+      "itemListElement": [
+        {"@type": "ListItem", "position": 1, "name": "atlassian-cli", "item": "https://atlassiancli.com/"},
+        {"@type": "ListItem", "position": 2, "name": "Runbooks", "item": "https://atlassiancli.com/runbooks/"},
+        {"@type": "ListItem", "position": 3, "name": "Automate Bitbucket Pull Request Approvals & Merges", "item": "https://atlassiancli.com/runbooks/bitbucket-pr-automation.html"}
+      ]
+    }
+    </script>
     <script type="application/ld+json">
     {
       "@context": "https://schema.org",
@@ -245,7 +255,7 @@
                 </a>
                 <a href="https://github.com/omar16100/atlassian-cli#readme" target="_blank" rel="noopener" class="nav-link">Docs</a>
                 <a href="/blog/" class="nav-link">Blog</a>
-                <a href="/#install" class="nav-btn">Install</a>
+                <a href="/install/" class="nav-btn">Install</a>
             </div>
         </div>
     </nav>
@@ -270,7 +280,7 @@
 
         <h2>Prerequisites</h2>
         <ul>
-            <li><code>atlassian-cli</code> installed (<a href="/#install" style="color: var(--accent-cyan);">install guide</a>)</li>
+            <li><code>atlassian-cli</code> installed (<a href="/install/" style="color: var(--accent-cyan);">install guide</a>)</li>
             <li>Bitbucket authentication configured via <code>atlassian-cli auth login --bitbucket</code></li>
             <li><code>jq</code> installed for JSON processing</li>
             <li>PR approval and merge permissions on the target repository</li>
@@ -648,6 +658,10 @@ main <span class="string">"$@"</span></code></pre>
             </div>
             <div class="footer-credit">
                 Built by <a href="https://omarshabab.com" target="_blank" rel="noopener">Omar Shabab</a>
+            </div>
+            <div class="footer-legal">
+                <p>atlassian-cli is an independent open-source project maintained by <a href="https://omarshabab.com" target="_blank" rel="noopener">Omar Shabab</a>. It is not affiliated with, endorsed by, sponsored by, or maintained by Atlassian.</p>
+                <p>Atlassian, Jira, Confluence, Bitbucket, and Jira Service Management are trademarks of Atlassian Pty Ltd or its affiliates. Product names are used only to identify compatibility.</p>
             </div>
         </div>
     </footer>

--- a/docs/runbooks/bitbucket-repo-audit.html
+++ b/docs/runbooks/bitbucket-repo-audit.html
@@ -5,7 +5,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Audit All Bitbucket Repositories in Your Workspace | atlassian-cli</title>
     <meta name="description" content="Generate a comprehensive audit of all Bitbucket repositories including size, language, permissions, and activity. Export to CSV for analysis.">
-    <meta name="keywords" content="bitbucket repo audit, repository audit, bitbucket cli, workspace audit, atlassian cli, bitbucket csv export">
 
     <!-- Open Graph -->
     <meta property="og:title" content="Audit All Bitbucket Repositories in Your Workspace | atlassian-cli">
@@ -36,6 +35,17 @@
     </script>
 
     <!-- JSON-LD HowTo Schema -->
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "BreadcrumbList",
+      "itemListElement": [
+        {"@type": "ListItem", "position": 1, "name": "atlassian-cli", "item": "https://atlassiancli.com/"},
+        {"@type": "ListItem", "position": 2, "name": "Runbooks", "item": "https://atlassiancli.com/runbooks/"},
+        {"@type": "ListItem", "position": 3, "name": "Audit All Bitbucket Repositories in Your Workspace", "item": "https://atlassiancli.com/runbooks/bitbucket-repo-audit.html"}
+      ]
+    }
+    </script>
     <script type="application/ld+json">
     {
       "@context": "https://schema.org",
@@ -245,7 +255,7 @@
                 </a>
                 <a href="https://github.com/omar16100/atlassian-cli#readme" target="_blank" rel="noopener" class="nav-link">Docs</a>
                 <a href="/blog/" class="nav-link">Blog</a>
-                <a href="/#install" class="nav-btn">Install</a>
+                <a href="/install/" class="nav-btn">Install</a>
             </div>
         </div>
     </nav>
@@ -270,7 +280,7 @@
 
         <h2>Prerequisites</h2>
         <ul>
-            <li><code>atlassian-cli</code> installed (<a href="/#install" style="color: var(--accent-cyan);">install guide</a>)</li>
+            <li><code>atlassian-cli</code> installed (<a href="/install/" style="color: var(--accent-cyan);">install guide</a>)</li>
             <li>Bitbucket authentication configured via <code>atlassian-cli auth login --bitbucket</code></li>
             <li><code>jq</code> installed for JSON processing</li>
             <li>Read access to the workspace repositories and their permissions</li>
@@ -526,6 +536,10 @@ main</code></pre>
             </div>
             <div class="footer-credit">
                 Built by <a href="https://omarshabab.com" target="_blank" rel="noopener">Omar Shabab</a>
+            </div>
+            <div class="footer-legal">
+                <p>atlassian-cli is an independent open-source project maintained by <a href="https://omarshabab.com" target="_blank" rel="noopener">Omar Shabab</a>. It is not affiliated with, endorsed by, sponsored by, or maintained by Atlassian.</p>
+                <p>Atlassian, Jira, Confluence, Bitbucket, and Jira Service Management are trademarks of Atlassian Pty Ltd or its affiliates. Product names are used only to identify compatibility.</p>
             </div>
         </div>
     </footer>

--- a/docs/runbooks/confluence-backup.html
+++ b/docs/runbooks/confluence-backup.html
@@ -5,7 +5,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Backup Confluence Spaces via Command Line | atlassian-cli</title>
     <meta name="description" content="Backup entire Confluence spaces including pages, blog posts, and attachments using the command line. Automated backup scripts with metadata tracking.">
-    <meta name="keywords" content="confluence backup, confluence space export, confluence cli, atlassian cli, confluence command line, space backup script">
 
     <!-- Open Graph -->
     <meta property="og:title" content="Backup Confluence Spaces via Command Line | atlassian-cli">
@@ -36,6 +35,17 @@
     </script>
 
     <!-- JSON-LD HowTo Schema -->
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "BreadcrumbList",
+      "itemListElement": [
+        {"@type": "ListItem", "position": 1, "name": "atlassian-cli", "item": "https://atlassiancli.com/"},
+        {"@type": "ListItem", "position": 2, "name": "Runbooks", "item": "https://atlassiancli.com/runbooks/"},
+        {"@type": "ListItem", "position": 3, "name": "Backup Confluence Spaces via Command Line", "item": "https://atlassiancli.com/runbooks/confluence-backup.html"}
+      ]
+    }
+    </script>
     <script type="application/ld+json">
     {
       "@context": "https://schema.org",
@@ -245,7 +255,7 @@
                 </a>
                 <a href="https://github.com/omar16100/atlassian-cli#readme" target="_blank" rel="noopener" class="nav-link">Docs</a>
                 <a href="/blog/" class="nav-link">Blog</a>
-                <a href="/#install" class="nav-btn">Install</a>
+                <a href="/install/" class="nav-btn">Install</a>
             </div>
         </div>
     </nav>
@@ -270,7 +280,7 @@
 
         <h2>Prerequisites</h2>
         <ul>
-            <li><code>atlassian-cli</code> installed (<a href="/#install" style="color: var(--accent-cyan);">install guide</a>)</li>
+            <li><code>atlassian-cli</code> installed (<a href="/install/" style="color: var(--accent-cyan);">install guide</a>)</li>
             <li>Confluence authentication configured via <code>atlassian-cli auth login</code></li>
             <li><code>jq</code> installed for JSON processing</li>
         </ul>
@@ -543,6 +553,10 @@ main</code></pre>
             </div>
             <div class="footer-credit">
                 Built by <a href="https://omarshabab.com" target="_blank" rel="noopener">Omar Shabab</a>
+            </div>
+            <div class="footer-legal">
+                <p>atlassian-cli is an independent open-source project maintained by <a href="https://omarshabab.com" target="_blank" rel="noopener">Omar Shabab</a>. It is not affiliated with, endorsed by, sponsored by, or maintained by Atlassian.</p>
+                <p>Atlassian, Jira, Confluence, Bitbucket, and Jira Service Management are trademarks of Atlassian Pty Ltd or its affiliates. Product names are used only to identify compatibility.</p>
             </div>
         </div>
     </footer>

--- a/docs/runbooks/confluence-bulk-cleanup.html
+++ b/docs/runbooks/confluence-bulk-cleanup.html
@@ -5,7 +5,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Bulk Clean Up Old Confluence Pages | atlassian-cli</title>
     <meta name="description" content="Find and clean up old, outdated Confluence pages using CQL queries and bulk operations from the command line. Includes dry-run mode.">
-    <meta name="keywords" content="confluence cleanup, confluence bulk delete, confluence archive pages, confluence cql, atlassian cli, confluence command line">
 
     <!-- Open Graph -->
     <meta property="og:title" content="Bulk Clean Up Old Confluence Pages | atlassian-cli">
@@ -36,6 +35,17 @@
     </script>
 
     <!-- JSON-LD HowTo Schema -->
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "BreadcrumbList",
+      "itemListElement": [
+        {"@type": "ListItem", "position": 1, "name": "atlassian-cli", "item": "https://atlassiancli.com/"},
+        {"@type": "ListItem", "position": 2, "name": "Runbooks", "item": "https://atlassiancli.com/runbooks/"},
+        {"@type": "ListItem", "position": 3, "name": "Bulk Clean Up Old Confluence Pages", "item": "https://atlassiancli.com/runbooks/confluence-bulk-cleanup.html"}
+      ]
+    }
+    </script>
     <script type="application/ld+json">
     {
       "@context": "https://schema.org",
@@ -240,7 +250,7 @@
                 </a>
                 <a href="https://github.com/omar16100/atlassian-cli#readme" target="_blank" rel="noopener" class="nav-link">Docs</a>
                 <a href="/blog/" class="nav-link">Blog</a>
-                <a href="/#install" class="nav-btn">Install</a>
+                <a href="/install/" class="nav-btn">Install</a>
             </div>
         </div>
     </nav>
@@ -265,7 +275,7 @@
 
         <h2>Prerequisites</h2>
         <ul>
-            <li><code>atlassian-cli</code> installed (<a href="/#install" style="color: var(--accent-cyan);">install guide</a>)</li>
+            <li><code>atlassian-cli</code> installed (<a href="/install/" style="color: var(--accent-cyan);">install guide</a>)</li>
             <li>Confluence authentication configured via <code>atlassian-cli auth login</code></li>
             <li>Space admin permissions for delete operations</li>
         </ul>
@@ -573,6 +583,10 @@ main <span class="string">"$@"</span></code></pre>
             </div>
             <div class="footer-credit">
                 Built by <a href="https://omarshabab.com" target="_blank" rel="noopener">Omar Shabab</a>
+            </div>
+            <div class="footer-legal">
+                <p>atlassian-cli is an independent open-source project maintained by <a href="https://omarshabab.com" target="_blank" rel="noopener">Omar Shabab</a>. It is not affiliated with, endorsed by, sponsored by, or maintained by Atlassian.</p>
+                <p>Atlassian, Jira, Confluence, Bitbucket, and Jira Service Management are trademarks of Atlassian Pty Ltd or its affiliates. Product names are used only to identify compatibility.</p>
             </div>
         </div>
     </footer>

--- a/docs/runbooks/confluence-markdown-sync.html
+++ b/docs/runbooks/confluence-markdown-sync.html
@@ -5,7 +5,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Sync Markdown Files to Confluence Pages | atlassian-cli</title>
     <meta name="description" content="Automatically sync markdown documentation to Confluence pages using the CLI. Build a docs pipeline with pandoc and atlassian-cli.">
-    <meta name="keywords" content="confluence markdown sync, markdown to confluence, confluence docs pipeline, pandoc confluence, atlassian cli, confluence automation">
 
     <!-- Open Graph -->
     <meta property="og:title" content="Sync Markdown Files to Confluence Pages | atlassian-cli">
@@ -36,6 +35,17 @@
     </script>
 
     <!-- JSON-LD HowTo Schema -->
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "BreadcrumbList",
+      "itemListElement": [
+        {"@type": "ListItem", "position": 1, "name": "atlassian-cli", "item": "https://atlassiancli.com/"},
+        {"@type": "ListItem", "position": 2, "name": "Runbooks", "item": "https://atlassiancli.com/runbooks/"},
+        {"@type": "ListItem", "position": 3, "name": "Sync Markdown Files to Confluence Pages", "item": "https://atlassiancli.com/runbooks/confluence-markdown-sync.html"}
+      ]
+    }
+    </script>
     <script type="application/ld+json">
     {
       "@context": "https://schema.org",
@@ -85,6 +95,38 @@
         "name": "Omar Shabab",
         "url": "https://omarshabab.com"
       }
+    }
+    </script>
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "FAQPage",
+      "mainEntity": [
+        {
+          "@type": "Question",
+          "name": "Can this runbook delete Confluence pages?",
+          "acceptedAnswer": {
+            "@type": "Answer",
+            "text": "No. The script only creates new pages or updates the content of existing ones. It never calls a delete endpoint, so syncing cannot remove a Confluence page even if the source markdown file is deleted."
+          }
+        },
+        {
+          "@type": "Question",
+          "name": "Does it support nested pages or multiple spaces?",
+          "acceptedAnswer": {
+            "@type": "Answer",
+            "text": "It syncs every markdown file found under the docs directory into a single target space as a flat set of pages. Nesting is supported only when a parent page ID is supplied; multi-space sync requires running the script once per space key."
+          }
+        },
+        {
+          "@type": "Question",
+          "name": "How does the pipeline detect what changed?",
+          "acceptedAnswer": {
+            "@type": "Answer",
+            "text": "Each run looks up the page by title with a CQL search. If the page exists its body is overwritten with the freshly converted HTML; if it does not exist the page is created. Re-running with identical markdown produces the same storage-format output, so the operation is effectively idempotent."
+          }
+        }
+      ]
     }
     </script>
 
@@ -251,7 +293,7 @@
                 </a>
                 <a href="https://github.com/omar16100/atlassian-cli#readme" target="_blank" rel="noopener" class="nav-link">Docs</a>
                 <a href="/blog/" class="nav-link">Blog</a>
-                <a href="/#install" class="nav-btn">Install</a>
+                <a href="/install/" class="nav-btn">Install</a>
             </div>
         </div>
     </nav>
@@ -272,11 +314,12 @@
     <div class="runbook-content">
 
         <h2>What This Does</h2>
-        <p>This runbook scans a local directory for markdown files, converts each one to Confluence-compatible HTML using pandoc, and creates or updates the corresponding Confluence page. It extracts page titles from the first heading in each file and applies tracking labels automatically. Ideal for keeping Git-based docs in sync with Confluence.</p>
+        <p>This runbook scans a local directory for markdown files, converts each one to Confluence-compatible HTML using pandoc, and creates or updates the corresponding Confluence page. It extracts page titles from the first <code># heading</code> in each file and applies tracking labels automatically. Ideal for keeping Git-based docs in sync with Confluence.</p>
+        <p>It solves the recurring problem of documentation drift: when engineering teams write docs in markdown next to their code but stakeholders read those docs in Confluence, the two copies fall out of step. Run this script as the last step of a docs change &mdash; locally before a release, or automatically in CI on every merge to a docs branch &mdash; and Confluence always reflects what is in version control. Because it searches by page title and overwrites the body in place rather than creating duplicates, repeated runs are idempotent: a file whose content has not changed produces byte-identical storage-format HTML, so re-publishing is a safe no-op. For the full command set used here, see the <a href="/docs/commands.html" style="color: var(--accent-cyan);">command reference</a> and the broader <a href="/confluence/" style="color: var(--accent-cyan);">Confluence CLI</a> guide.</p>
 
         <h2>Prerequisites</h2>
         <ul>
-            <li><code>atlassian-cli</code> installed (<a href="/#install" style="color: var(--accent-cyan);">install guide</a>)</li>
+            <li><code>atlassian-cli</code> installed (<a href="/install/" style="color: var(--accent-cyan);">install guide</a>)</li>
             <li>Confluence authentication configured via <code>atlassian-cli auth login</code></li>
             <li><code>pandoc</code> installed for markdown-to-HTML conversion</li>
             <li><code>jq</code> installed for JSON processing</li>
@@ -516,6 +559,7 @@ main() {
 main <span class="string">"$@"</span></code></pre>
 
         <h2>How It Works</h2>
+        <p>The pipeline is deliberately stateless &mdash; there is no local database tracking which page maps to which file. Instead, the markdown file's first H1 becomes the canonical page title, and a Confluence CQL query (<code>space = KEY AND title = "..."</code>) is the lookup key. This means the "diff" the script performs is not a line-level comparison; it is an upsert. If a matching title is found, the converted body replaces the existing page content via <code>confluence page update</code>; if not, <code>confluence page create</code> makes a new page. The conversion itself is done by <code>pandoc -f markdown -t html</code>, after which two lightweight <code>sed</code> passes adjust the output for Confluence's storage format (adding top margin to <code>h1</code> elements and a class to inline <code>code</code>). Pandoc handles fenced code blocks, links, and most tables cleanly, though complex GitHub-flavored markdown tables and raw HTML can need manual review. Setting <code>DRY_RUN=true</code> makes every create, update, and label step print what it would do without calling the API, which is the safe way to validate a new docs directory. The numbered steps below trace one full pass over the docs tree.</p>
 
         <div class="step-item">
             <span class="step-number">1</span>
@@ -537,6 +581,45 @@ main <span class="string">"$@"</span></code></pre>
             <span class="step-number">5</span>
             <p><strong>Apply tracking labels.</strong> Tags each synced page with <code>auto-generated</code> and <code>documentation</code> labels so you can easily identify and filter machine-synced content in Confluence.</p>
         </div>
+
+        <h2>Common Errors &amp; Fixes</h2>
+        <ul>
+            <li><strong>401 / 403 from the API.</strong> The auth profile is missing or its API token expired &mdash; re-run <code>atlassian-cli auth login</code> (or pass the correct <code>--profile</code>) and confirm the token has space write access.</li>
+            <li><strong><code>Required command not found: pandoc</code>.</strong> Pandoc is not on the PATH &mdash; install it with <code>brew install pandoc</code> (macOS) or <code>apt-get install pandoc</code> (Debian/Ubuntu).</li>
+            <li><strong>Page created in the wrong place / "parent not found".</strong> The target space key is wrong or the supplied parent ID does not exist in that space &mdash; verify the <code>SPACE_KEY</code> argument and the parent page ID before re-running.</li>
+            <li><strong>HTTP 429 rate limiting.</strong> Too many pages synced too fast &mdash; sync in smaller batches or add a short <code>sleep</code> between files; the CLI also retries transient 429s automatically.</li>
+            <li><strong>Tables render as raw text or break layout.</strong> Pandoc's default GitHub-flavored table conversion can mangle complex tables &mdash; simplify the markdown table or pre-convert with <code>pandoc -f gfm -t html</code>.</li>
+            <li><strong>Duplicate pages appear.</strong> Two markdown files share the same first H1, so both upsert to the same title &mdash; give each file a unique top-level heading.</li>
+        </ul>
+
+        <h2>CI/CD Integration</h2>
+        <p>Because the sync is idempotent and supports a dry-run, it runs cleanly in CI: gate it on changes under your <code>docs/</code> path and publish on every merge so Confluence never lags behind the repository. Store the API token as an encrypted secret and pass it through the auth profile. The GitHub Actions workflow below runs the runbook whenever files under <code>docs/</code> change on the main branch:</p>
+        <pre class="code-block"><code><span class="comment"># .github/workflows/confluence-sync.yml</span>
+name: Sync docs to Confluence
+on:
+  push:
+    branches: [main]
+    paths:
+      - <span class="string">'docs/**'</span>
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install dependencies
+        run: sudo apt-get update &amp;&amp; sudo apt-get install -y pandoc jq
+      - name: Install atlassian-cli
+        run: pipx install atlassian-cli
+      - name: Sync markdown to Confluence
+        env:
+          ATLASSIAN_API_TOKEN: <span class="string">${{ secrets.ATLASSIAN_API_TOKEN }}</span>
+        run: ./doc-pipeline.sh DOCS prod</code></pre>
+        <p>GitLab CI achieves the same result with a job that uses an <code>only:&nbsp;changes:&nbsp;["docs/**"]</code> rule and a masked CI/CD variable for the token instead of the <code>on.push.paths</code> trigger and Actions secret.</p>
+
+        <h2>FAQ</h2>
+        <p><strong>Can it delete Confluence pages?</strong> No. The script only creates or updates pages &mdash; it never calls a delete endpoint, so removing a markdown file does not remove the corresponding Confluence page. Use the <a href="/runbooks/confluence-bulk-cleanup.html" style="color: var(--accent-cyan);">bulk cleanup runbook</a> for deletions.</p>
+        <p><strong>Does it support nested pages or multiple spaces?</strong> All discovered files sync into one target space as a flat set of pages; nesting works only when a parent page ID is passed, and multi-space sync means running the script once per space key.</p>
+        <p><strong>How does it detect changes?</strong> It does not diff line by line. It looks up each page by its H1 title via CQL and upserts the converted body, so unchanged markdown re-publishes identical HTML and the run is a safe no-op. Keep an offline copy with the <a href="/runbooks/confluence-backup.html" style="color: var(--accent-cyan);">Confluence backup runbook</a> before large syncs.</p>
 
         <h2>Related Runbooks</h2>
         <div class="related-links">
@@ -575,6 +658,10 @@ main <span class="string">"$@"</span></code></pre>
             </div>
             <div class="footer-credit">
                 Built by <a href="https://omarshabab.com" target="_blank" rel="noopener">Omar Shabab</a>
+            </div>
+            <div class="footer-legal">
+                <p>atlassian-cli is an independent open-source project maintained by <a href="https://omarshabab.com" target="_blank" rel="noopener">Omar Shabab</a>. It is not affiliated with, endorsed by, sponsored by, or maintained by Atlassian.</p>
+                <p>Atlassian, Jira, Confluence, Bitbucket, and Jira Service Management are trademarks of Atlassian Pty Ltd or its affiliates. Product names are used only to identify compatibility.</p>
             </div>
         </div>
     </footer>

--- a/docs/runbooks/confluence-space-report.html
+++ b/docs/runbooks/confluence-space-report.html
@@ -5,7 +5,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Generate Confluence Space Analytics Reports | atlassian-cli</title>
     <meta name="description" content="Generate detailed analytics reports for Confluence spaces including page views, contributors, and activity metrics via the command line.">
-    <meta name="keywords" content="confluence analytics, confluence space report, confluence page views, confluence csv export, atlassian cli, confluence metrics">
 
     <!-- Open Graph -->
     <meta property="og:title" content="Generate Confluence Space Analytics Reports | atlassian-cli">
@@ -36,6 +35,17 @@
     </script>
 
     <!-- JSON-LD HowTo Schema -->
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "BreadcrumbList",
+      "itemListElement": [
+        {"@type": "ListItem", "position": 1, "name": "atlassian-cli", "item": "https://atlassiancli.com/"},
+        {"@type": "ListItem", "position": 2, "name": "Runbooks", "item": "https://atlassiancli.com/runbooks/"},
+        {"@type": "ListItem", "position": 3, "name": "Generate Confluence Space Analytics Reports", "item": "https://atlassiancli.com/runbooks/confluence-space-report.html"}
+      ]
+    }
+    </script>
     <script type="application/ld+json">
     {
       "@context": "https://schema.org",
@@ -245,7 +255,7 @@
                 </a>
                 <a href="https://github.com/omar16100/atlassian-cli#readme" target="_blank" rel="noopener" class="nav-link">Docs</a>
                 <a href="/blog/" class="nav-link">Blog</a>
-                <a href="/#install" class="nav-btn">Install</a>
+                <a href="/install/" class="nav-btn">Install</a>
             </div>
         </div>
     </nav>
@@ -270,7 +280,7 @@
 
         <h2>Prerequisites</h2>
         <ul>
-            <li><code>atlassian-cli</code> installed (<a href="/#install" style="color: var(--accent-cyan);">install guide</a>)</li>
+            <li><code>atlassian-cli</code> installed (<a href="/install/" style="color: var(--accent-cyan);">install guide</a>)</li>
             <li>Confluence authentication configured via <code>atlassian-cli auth login</code></li>
             <li><code>jq</code> installed for JSON processing</li>
             <li>Confluence analytics permissions for page view data</li>
@@ -563,6 +573,10 @@ main</code></pre>
             </div>
             <div class="footer-credit">
                 Built by <a href="https://omarshabab.com" target="_blank" rel="noopener">Omar Shabab</a>
+            </div>
+            <div class="footer-legal">
+                <p>atlassian-cli is an independent open-source project maintained by <a href="https://omarshabab.com" target="_blank" rel="noopener">Omar Shabab</a>. It is not affiliated with, endorsed by, sponsored by, or maintained by Atlassian.</p>
+                <p>Atlassian, Jira, Confluence, Bitbucket, and Jira Service Management are trademarks of Atlassian Pty Ltd or its affiliates. Product names are used only to identify compatibility.</p>
             </div>
         </div>
     </footer>

--- a/docs/runbooks/jira-bulk-transition.html
+++ b/docs/runbooks/jira-bulk-transition.html
@@ -5,7 +5,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>How to Bulk Transition Jira Issues via CLI | atlassian-cli</title>
     <meta name="description" content="Learn how to bulk transition hundreds of Jira issues through workflow states using the command line. Includes dry-run mode and progress tracking.">
-    <meta name="keywords" content="jira bulk transition, jira cli, bulk issue update, jira workflow automation, atlassian cli, jira command line">
 
     <!-- Open Graph -->
     <meta property="og:title" content="How to Bulk Transition Jira Issues via CLI | atlassian-cli">
@@ -36,6 +35,17 @@
     </script>
 
     <!-- JSON-LD HowTo Schema -->
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "BreadcrumbList",
+      "itemListElement": [
+        {"@type": "ListItem", "position": 1, "name": "atlassian-cli", "item": "https://atlassiancli.com/"},
+        {"@type": "ListItem", "position": 2, "name": "Runbooks", "item": "https://atlassiancli.com/runbooks/"},
+        {"@type": "ListItem", "position": 3, "name": "How to Bulk Transition Jira Issues via CLI", "item": "https://atlassiancli.com/runbooks/jira-bulk-transition.html"}
+      ]
+    }
+    </script>
     <script type="application/ld+json">
     {
       "@context": "https://schema.org",
@@ -245,7 +255,7 @@
                 </a>
                 <a href="https://github.com/omar16100/atlassian-cli#readme" target="_blank" rel="noopener" class="nav-link">Docs</a>
                 <a href="/blog/" class="nav-link">Blog</a>
-                <a href="/#install" class="nav-btn">Install</a>
+                <a href="/install/" class="nav-btn">Install</a>
             </div>
         </div>
     </nav>
@@ -270,7 +280,7 @@
 
         <h2>Prerequisites</h2>
         <ul>
-            <li><code>atlassian-cli</code> installed (<a href="/#install" style="color: var(--accent-cyan);">install guide</a>)</li>
+            <li><code>atlassian-cli</code> installed (<a href="/install/" style="color: var(--accent-cyan);">install guide</a>)</li>
             <li>Jira authentication configured via <code>atlassian-cli auth login</code></li>
             <li><code>jq</code> installed for JSON processing</li>
         </ul>
@@ -533,6 +543,10 @@ main <span class="string">"$@"</span></code></pre>
             </div>
             <div class="footer-credit">
                 Built by <a href="https://omarshabab.com" target="_blank" rel="noopener">Omar Shabab</a>
+            </div>
+            <div class="footer-legal">
+                <p>atlassian-cli is an independent open-source project maintained by <a href="https://omarshabab.com" target="_blank" rel="noopener">Omar Shabab</a>. It is not affiliated with, endorsed by, sponsored by, or maintained by Atlassian.</p>
+                <p>Atlassian, Jira, Confluence, Bitbucket, and Jira Service Management are trademarks of Atlassian Pty Ltd or its affiliates. Product names are used only to identify compatibility.</p>
             </div>
         </div>
     </footer>

--- a/docs/runbooks/jira-project-cleanup.html
+++ b/docs/runbooks/jira-project-cleanup.html
@@ -5,7 +5,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Automate Jira Project Cleanup from the Terminal | atlassian-cli</title>
     <meta name="description" content="Automatically archive, label, and clean up old resolved Jira issues using the command line. Generate cleanup reports with CSV export.">
-    <meta name="keywords" content="jira project cleanup, jira archive issues, jira bulk label, jira cli automation, atlassian cli, jira cleanup script">
 
     <!-- Open Graph -->
     <meta property="og:title" content="Automate Jira Project Cleanup from the Terminal | atlassian-cli">
@@ -36,6 +35,17 @@
     </script>
 
     <!-- JSON-LD HowTo Schema -->
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "BreadcrumbList",
+      "itemListElement": [
+        {"@type": "ListItem", "position": 1, "name": "atlassian-cli", "item": "https://atlassiancli.com/"},
+        {"@type": "ListItem", "position": 2, "name": "Runbooks", "item": "https://atlassiancli.com/runbooks/"},
+        {"@type": "ListItem", "position": 3, "name": "Automate Jira Project Cleanup from the Terminal", "item": "https://atlassiancli.com/runbooks/jira-project-cleanup.html"}
+      ]
+    }
+    </script>
     <script type="application/ld+json">
     {
       "@context": "https://schema.org",
@@ -245,7 +255,7 @@
                 </a>
                 <a href="https://github.com/omar16100/atlassian-cli#readme" target="_blank" rel="noopener" class="nav-link">Docs</a>
                 <a href="/blog/" class="nav-link">Blog</a>
-                <a href="/#install" class="nav-btn">Install</a>
+                <a href="/install/" class="nav-btn">Install</a>
             </div>
         </div>
     </nav>
@@ -270,7 +280,7 @@
 
         <h2>Prerequisites</h2>
         <ul>
-            <li><code>atlassian-cli</code> installed (<a href="/#install" style="color: var(--accent-cyan);">install guide</a>)</li>
+            <li><code>atlassian-cli</code> installed (<a href="/install/" style="color: var(--accent-cyan);">install guide</a>)</li>
             <li>Jira authentication configured via <code>atlassian-cli auth login</code></li>
             <li><code>jq</code> installed for JSON processing</li>
         </ul>
@@ -602,6 +612,10 @@ main <span class="string">"$@"</span></code></pre>
             </div>
             <div class="footer-credit">
                 Built by <a href="https://omarshabab.com" target="_blank" rel="noopener">Omar Shabab</a>
+            </div>
+            <div class="footer-legal">
+                <p>atlassian-cli is an independent open-source project maintained by <a href="https://omarshabab.com" target="_blank" rel="noopener">Omar Shabab</a>. It is not affiliated with, endorsed by, sponsored by, or maintained by Atlassian.</p>
+                <p>Atlassian, Jira, Confluence, Bitbucket, and Jira Service Management are trademarks of Atlassian Pty Ltd or its affiliates. Product names are used only to identify compatibility.</p>
             </div>
         </div>
     </footer>

--- a/docs/runbooks/jira-sprint-report.html
+++ b/docs/runbooks/jira-sprint-report.html
@@ -5,7 +5,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Generate Jira Sprint Reports via Command Line | atlassian-cli</title>
     <meta name="description" content="Generate detailed sprint reports with story points, cycle times, and issue breakdowns using the Jira CLI. Export to CSV for analysis.">
-    <meta name="keywords" content="jira sprint report, jira cli report, sprint velocity, cycle time, jira csv export, atlassian cli, jira automation">
 
     <!-- Open Graph -->
     <meta property="og:title" content="Generate Jira Sprint Reports via Command Line | atlassian-cli">
@@ -36,6 +35,17 @@
     </script>
 
     <!-- JSON-LD HowTo Schema -->
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "BreadcrumbList",
+      "itemListElement": [
+        {"@type": "ListItem", "position": 1, "name": "atlassian-cli", "item": "https://atlassiancli.com/"},
+        {"@type": "ListItem", "position": 2, "name": "Runbooks", "item": "https://atlassiancli.com/runbooks/"},
+        {"@type": "ListItem", "position": 3, "name": "Generate Jira Sprint Reports via Command Line", "item": "https://atlassiancli.com/runbooks/jira-sprint-report.html"}
+      ]
+    }
+    </script>
     <script type="application/ld+json">
     {
       "@context": "https://schema.org",
@@ -240,7 +250,7 @@
                 </a>
                 <a href="https://github.com/omar16100/atlassian-cli#readme" target="_blank" rel="noopener" class="nav-link">Docs</a>
                 <a href="/blog/" class="nav-link">Blog</a>
-                <a href="/#install" class="nav-btn">Install</a>
+                <a href="/install/" class="nav-btn">Install</a>
             </div>
         </div>
     </nav>
@@ -265,7 +275,7 @@
 
         <h2>Prerequisites</h2>
         <ul>
-            <li><code>atlassian-cli</code> installed (<a href="/#install" style="color: var(--accent-cyan);">install guide</a>)</li>
+            <li><code>atlassian-cli</code> installed (<a href="/install/" style="color: var(--accent-cyan);">install guide</a>)</li>
             <li>Jira authentication configured via <code>atlassian-cli auth login</code></li>
             <li><code>jq</code> installed for JSON processing</li>
         </ul>
@@ -579,6 +589,10 @@ main <span class="string">"$@"</span></code></pre>
             </div>
             <div class="footer-credit">
                 Built by <a href="https://omarshabab.com" target="_blank" rel="noopener">Omar Shabab</a>
+            </div>
+            <div class="footer-legal">
+                <p>atlassian-cli is an independent open-source project maintained by <a href="https://omarshabab.com" target="_blank" rel="noopener">Omar Shabab</a>. It is not affiliated with, endorsed by, sponsored by, or maintained by Atlassian.</p>
+                <p>Atlassian, Jira, Confluence, Bitbucket, and Jira Service Management are trademarks of Atlassian Pty Ltd or its affiliates. Product names are used only to identify compatibility.</p>
             </div>
         </div>
     </footer>

--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -3,7 +3,7 @@
   <!-- Homepage -->
   <url>
     <loc>https://atlassiancli.com/</loc>
-    <lastmod>2026-03-14</lastmod>
+    <lastmod>2026-05-16</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>
@@ -11,81 +11,117 @@
   <!-- Product Pages -->
   <url>
     <loc>https://atlassiancli.com/jira/</loc>
-    <lastmod>2026-03-14</lastmod>
+    <lastmod>2026-05-16</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://atlassiancli.com/confluence/</loc>
-    <lastmod>2026-03-14</lastmod>
+    <lastmod>2026-05-16</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://atlassiancli.com/bitbucket/</loc>
-    <lastmod>2026-03-14</lastmod>
+    <lastmod>2026-05-16</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://atlassiancli.com/jsm/</loc>
-    <lastmod>2026-03-14</lastmod>
+    <lastmod>2026-05-16</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.9</priority>
+  </url>
+
+  <!-- Install hub -->
+  <url>
+    <loc>https://atlassiancli.com/install/</loc>
+    <lastmod>2026-05-16</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.9</priority>
+  </url>
+
+  <!-- First-party docs -->
+  <url>
+    <loc>https://atlassiancli.com/docs/</loc>
+    <lastmod>2026-05-16</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.9</priority>
+  </url>
+  <url>
+    <loc>https://atlassiancli.com/docs/auth.html</loc>
+    <lastmod>2026-05-16</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://atlassiancli.com/docs/commands.html</loc>
+    <lastmod>2026-05-16</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+
+  <!-- About / independence -->
+  <url>
+    <loc>https://atlassiancli.com/about/</loc>
+    <lastmod>2026-05-16</lastmod>
+    <changefreq>yearly</changefreq>
+    <priority>0.5</priority>
   </url>
 
   <!-- Blog -->
   <url>
     <loc>https://atlassiancli.com/blog/</loc>
-    <lastmod>2026-03-14</lastmod>
+    <lastmod>2026-05-16</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://atlassiancli.com/blog/jira-cli-complete-guide.html</loc>
-    <lastmod>2026-03-14</lastmod>
+    <lastmod>2026-05-16</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://atlassiancli.com/blog/atlassian-cli-guide.html</loc>
-    <lastmod>2026-03-14</lastmod>
+    <lastmod>2026-05-16</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://atlassiancli.com/blog/jira-cli-tools-compared.html</loc>
-    <lastmod>2026-03-14</lastmod>
+    <lastmod>2026-05-16</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://atlassiancli.com/blog/confluence-cli-guide.html</loc>
-    <lastmod>2026-03-14</lastmod>
+    <lastmod>2026-05-16</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://atlassiancli.com/blog/jira-cli-commands-cheat-sheet.html</loc>
-    <lastmod>2026-03-14</lastmod>
+    <lastmod>2026-05-16</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://atlassiancli.com/blog/jira-bulk-operations.html</loc>
-    <lastmod>2026-03-14</lastmod>
+    <lastmod>2026-05-16</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://atlassiancli.com/blog/bitbucket-cli-guide.html</loc>
-    <lastmod>2026-03-14</lastmod>
+    <lastmod>2026-05-16</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://atlassiancli.com/blog/jsm-cli-guide.html</loc>
-    <lastmod>2026-03-14</lastmod>
+    <lastmod>2026-05-16</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
@@ -93,19 +129,19 @@
   <!-- Runbooks: Jira -->
   <url>
     <loc>https://atlassiancli.com/runbooks/jira-bulk-transition.html</loc>
-    <lastmod>2026-03-14</lastmod>
+    <lastmod>2026-05-16</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://atlassiancli.com/runbooks/jira-project-cleanup.html</loc>
-    <lastmod>2026-03-14</lastmod>
+    <lastmod>2026-05-16</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://atlassiancli.com/runbooks/jira-sprint-report.html</loc>
-    <lastmod>2026-03-14</lastmod>
+    <lastmod>2026-05-16</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
@@ -113,25 +149,25 @@
   <!-- Runbooks: Confluence -->
   <url>
     <loc>https://atlassiancli.com/runbooks/confluence-backup.html</loc>
-    <lastmod>2026-03-14</lastmod>
+    <lastmod>2026-05-16</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://atlassiancli.com/runbooks/confluence-bulk-cleanup.html</loc>
-    <lastmod>2026-03-14</lastmod>
+    <lastmod>2026-05-16</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://atlassiancli.com/runbooks/confluence-markdown-sync.html</loc>
-    <lastmod>2026-03-14</lastmod>
+    <lastmod>2026-05-16</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://atlassiancli.com/runbooks/confluence-space-report.html</loc>
-    <lastmod>2026-03-14</lastmod>
+    <lastmod>2026-05-16</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
@@ -139,19 +175,19 @@
   <!-- Runbooks: Bitbucket -->
   <url>
     <loc>https://atlassiancli.com/runbooks/bitbucket-branch-cleanup.html</loc>
-    <lastmod>2026-03-14</lastmod>
+    <lastmod>2026-05-16</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://atlassiancli.com/runbooks/bitbucket-pr-automation.html</loc>
-    <lastmod>2026-03-14</lastmod>
+    <lastmod>2026-05-16</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://atlassiancli.com/runbooks/bitbucket-repo-audit.html</loc>
-    <lastmod>2026-03-14</lastmod>
+    <lastmod>2026-05-16</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
@@ -159,7 +195,7 @@
   <!-- AI Context -->
   <url>
     <loc>https://atlassiancli.com/llms.txt</loc>
-    <lastmod>2026-03-14</lastmod>
+    <lastmod>2026-05-16</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.3</priority>
   </url>

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -367,6 +367,9 @@ body::before {
     border-radius: 12px;
     padding: 1.75rem;
     transition: all 0.3s ease;
+    display: block;
+    color: inherit;
+    text-decoration: none;
 }
 
 .product-card:hover {
@@ -709,6 +712,75 @@ body::before {
 
 .footer-credit a:hover {
     color: var(--accent-cyan);
+}
+
+.footer-legal {
+    text-align: center;
+    margin-top: 1rem;
+    padding-top: 1rem;
+    border-top: 1px solid var(--border);
+    font-size: 0.75rem;
+    line-height: 1.5;
+    color: var(--text-muted);
+    max-width: 760px;
+    margin-left: auto;
+    margin-right: auto;
+}
+
+.footer-legal p {
+    margin: 0 0 0.4rem;
+}
+
+.footer-legal a {
+    color: var(--text-secondary);
+    text-decoration: none;
+}
+
+.footer-legal a:hover {
+    color: var(--accent-cyan);
+}
+
+.hero-disclaimer {
+    font-size: 0.8rem;
+    color: var(--text-muted);
+    margin-top: 0.75rem;
+}
+
+.faq {
+    padding: 4rem 0;
+}
+
+.faq-list {
+    max-width: 760px;
+    margin: 2rem auto 0;
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+}
+
+.faq-item {
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    padding: 1.25rem 1.5rem;
+    background: var(--bg-secondary);
+}
+
+.faq-item h3 {
+    font-size: 1rem;
+    margin: 0 0 0.5rem;
+    color: var(--text-primary);
+}
+
+.faq-item p {
+    margin: 0;
+    font-size: 0.9rem;
+    line-height: 1.6;
+    color: var(--text-secondary);
+}
+
+.faq-item a {
+    color: var(--accent-cyan);
+    text-decoration: none;
 }
 
 /* ========================================

--- a/todo.md
+++ b/todo.md
@@ -1,5 +1,158 @@
 # Changes Made
 
+## 2026-04-21 - Week-4 SEO: breadcrumbs on blog/runbook pages
+
+### Context
+Blog and runbook pages had no BreadcrumbList schema, so Google couldn't render breadcrumbs in SERP and didn't have structural signals for `Home > Blog/Runbooks > Post` hierarchy. Codex previously flagged this as worth adding — especially on hierarchical collection pages where it reflects real structure.
+
+### Changes
+- [DONE] Added BreadcrumbList JSON-LD to 18 pages (8 blog + 10 runbook), placed before existing Article/HowTo/FAQPage schema blocks
+- [DONE] Breadcrumb names extracted from each page's H1 (or title fallback) for accurate labels
+- [DONE] All three levels populated: home → section → page
+
+### Verification
+- All 18 pages return 200 and parse multiple JSON-LD blocks cleanly
+- Blog pages: BreadcrumbList + Article (some also have FAQPage pre-existing)
+- Runbook pages: BreadcrumbList + HowTo
+
+---
+
+## 2026-04-21 - Week-4 SEO: deepened hub pages for head-term ranking
+
+### Context
+After 3 rounds of SEO work (homepage, install hub, first-party docs), hub pages still ranked pos 30-70 for their canonical terms (`/jira/` pos 64 for "jira cli", `/confluence/` pos 33 for "confluence cli", `/bitbucket/` pos 60 for "bitbucket cli"). Codex's next-priority recommendation was to deepen hub content so these can outrank Appfire, marketplace.atlassian.com, and the github.com/ankit1/jira-cli README.
+
+### Changes
+For each of /jira/, /confluence/, /bitbucket/ hub pages:
+- [DONE] Added "What is [X] CLI?" intro section (2 substantive paragraphs, links to sibling hubs + /install/ + /docs/auth.html + /docs/commands.html)
+- [DONE] Added "When to use a [X] CLI" section with 5 real use-case bullets, each linking to a runbook
+- [DONE] Added a semantic `<table>` "command groups" cluster — each row deep-links to /docs/commands.html anchor
+- [DONE] Added visible FAQ section (6-7 Qs per page) covering install/auth/custom fields/CQL/bearer vs basic/CI patterns/open-source/DC compatibility — no schema markup per prior codex guidance
+- [DONE] Hero now includes "Commands" link pointing to the relevant /docs/commands.html section
+- [DONE] All internal links use descriptive anchor text ("Confluence backup runbook", "auth guide", etc.)
+
+### Word count growth
+- /jira/: ~700 → ~1344 words
+- /confluence/: ~700 → ~1207 words
+- /bitbucket/: ~700 → ~1172 words
+
+### Verification
+- All 9 canonical URLs return 200
+- Word count measured on rendered output
+- All command-table anchors match real /docs/commands.html section IDs (#jira-issues, #jira-bulk, #conf-search, #conf-bulk, #bb-repos, #bb-pr, etc.)
+
+---
+
+## 2026-04-18 - Week-3 SEO: first-party docs at /docs/ (codex-reviewed twice)
+
+### Context
+Prior codex review flagged "biggest skipped item is first-party docs on atlassiancli.com" — the "Docs" nav link was going to the GitHub README, limiting SEO depth, sitelink potential, and ability to rank for longer-tail docs queries. Built a 3-page docs section (strategy: depth over breadth, avoid thin-content indexing issues).
+
+### Changes
+- [DONE] NEW `docs/docs/index.html` — landing page with TOC (guides, product pages, runbooks)
+- [DONE] NEW `docs/docs/auth.html` — authentication guide targeting "atlassian cli authentication" (23 GSC impr), "jira cli login" (4), "atlassian cli token" (3). Sections: overview, API tokens, Bitbucket bearer + API token, profiles, env vars & CI/CD, credential storage, troubleshooting
+- [DONE] NEW `docs/docs/commands.html` — consolidated command reference with sticky left sidebar TOC. All 4 products covered with subsection groups. HowTo-schema-free (replaced with TechArticle).
+- [DONE] Added "Docs" to nav on homepage + 4 hub pages + /install/ (6 pages total)
+- [DONE] Homepage footer expanded with /docs/, /docs/auth.html, /docs/commands.html links
+- [DONE] `docs/sitemap.xml` — added 3 new URLs
+- [DONE] All 4 hub pages: footer "Documentation" link repointed from GitHub README to /docs/
+- [DONE] Hub pages (jira, confluence, bitbucket, jsm): `--output json|csv|yaml|table|quiet|markdown` → `--format ...` (20 swaps total; `--output file.json` form preserved where correctly writing to a file)
+- [DONE] Hub pages: "Full Documentation" resource cards on bitbucket/jsm now point to specific `/docs/commands.html#` anchors
+- [DONE] Added `<main>` landmark to `/docs/` and `/docs/auth.html` (commands.html already had `<main class="doc-content">`)
+
+### Codex-flagged accuracy fixes (second and third passes)
+- ENV VARS: rewrote against actual source — `ATLASSIAN_CLI_TOKEN_<PROFILE>`, `ATLASSIAN_API_TOKEN`, `ATLASSIAN_CLI_BITBUCKET_TOKEN_<PROFILE>`, `ATLASSIAN_BITBUCKET_TOKEN`, `BITBUCKET_TOKEN`. Removed false "skip auth login entirely" claim — profile metadata (base_url, email, workspace) still required
+- BITBUCKET AUTH: I had Basic/Bearer flipped. Fixed to match actual semantics:
+  * Basic auth = Atlassian API tokens (current, requires --email)
+  * Bearer auth = repository/workspace/project access tokens (requires --bearer, no --email needed, workspace optional)
+  * App passwords: deprecated (Sep 9, 2025 creation ended; Jun 9, 2026 existing tokens disabled)
+- GLOBAL FLAGS: `--verbose` → `--debug` (plus added `markdown` format, `--envelope`, `--config`)
+- JSM COMMAND NAMES: `jsm servicedesk` → `jsm service-desk` (kebab-case in clap derive), `requesttype` → `request-type`. 13 swaps across commands.html + /jsm/ hub
+- JSM COVERAGE: added missing `request-type {list,get,fields,groups}` group + `organization add-user` / `remove-user`. Full JSM section now: service-desk, request-type, request, queue, approval, sla, customer, organization, kb, feedback (10 subcommand groups)
+- AUTH SUBCOMMANDS: removed `auth set-default` (hallucinated — doesn't exist). Real surface: login/logout/list/status/whoami/test. Added correct "change default" instructions (re-run `auth login --default` or edit config.yaml)
+- BASE URL: all 10 pages now show `--base-url https://your-domain.atlassian.net` (CLI rejects non-HTTPS URLs)
+- JIRA HUB: `--base-url your-domain.atlassian.net` → `--base-url https://your-domain.atlassian.net` in quickstart
+
+### Verification
+- All 11 URLs return 200: /, /jira/, /confluence/, /bitbucket/, /jsm/, /install/, /docs/, /docs/auth.html, /docs/commands.html, /blog/, /sitemap.xml
+- All JSON-LD blocks valid: /docs/ has BreadcrumbList, /docs/auth.html and /docs/commands.html each have BreadcrumbList + TechArticle
+- Zero `auth set-default`, zero `jsm servicedesk` (no-hyphen), zero `--verbose`, zero base-url missing-scheme
+- Exactly one `<main>` landmark per docs page
+- Codex reviews archived:
+  * `/Users/macmini/projects/codex/atlassiancli_seo_week3_review_18apr2026.txt`
+  * `/Users/macmini/projects/codex/atlassiancli_seo_week3_verify_18apr2026.txt`
+
+### Next priority (per codex)
+Hub page content depth — `/jira/`, `/confluence/`, `/bitbucket/` currently rank pos 30-70 for canonical terms. Need more content weight to outrank Appfire, marketplace.atlassian.com, github.com. After that: backlinks (awesome-* lists, Show HN, crates.io polish). Defer blog modifier content and breadcrumbs on old content.
+
+---
+
+## 2026-04-18 - Week-2 SEO: hub pages + install hub (codex-reviewed)
+
+### Context
+After week-1 homepage rewrite, focus shifts to product hubs + install funnel. GSC shows `/jira/` ranks pos 64 for "jira cli" (128 impr), `/confluence/` at pos 33 for "confluence cli" (309 impr). Hub nav was missing sibling links (no internal linking between /jira/, /confluence/, /bitbucket/, /jsm/). Install-intent queries (atlassian cli install 21 impr, brew install atlassian cli 15 impr, atlassian cli download 17 impr) had no dedicated landing.
+
+### Changes
+- [DONE] `docs/jira/index.html` - nav now has Jira/Confluence/Bitbucket/Blog sibling links, `aria-current="page"` on self
+- [DONE] `docs/confluence/index.html` - same nav pattern + fixed 3 broken runbook links (pointed to nonexistent files)
+- [DONE] `docs/bitbucket/index.html` - same nav pattern
+- [DONE] `docs/jsm/index.html` - same nav pattern + title changed from acronym-first "JSM CLI" to "Jira Service Management CLI (JSM)" (better search behavior match)
+- [DONE] `docs/install/index.html` - NEW install hub page (~180 lines): Homebrew, Cargo, prebuilt binary, verify, first-time setup, troubleshooting sections
+- [DONE] BreadcrumbList JSON-LD added to 5 pages (4 hubs + install)
+- [DONE] Bulk repoint of `/#install` → `/install/` across 23 files (all hub, blog, runbook pages)
+- [DONE] `docs/sitemap.xml` - added /install/ entry, bumped 5 pages lastmod to 2026-04-18 (only changed ones)
+- [DONE] Homepage footer gained `/install/` link
+
+### Codex feedback incorporated
+- Fixed broken Confluence runbook links (`/runbooks/confluence-backup-space.html` etc. → real files `confluence-backup.html`, `confluence-markdown-sync.html`, `confluence-bulk-cleanup.html`)
+- Removed "curl" and "Docker" from install page title (page body doesn't have those sections)
+- Replaced semantically-wrong HowTo schema (alternative methods modeled as sequential steps) with TechArticle schema
+- Repointed all hub Install CTAs to /install/ (were going to homepage #install, weakening new page's internal link signal)
+
+### Verification
+- Local server: `/`, `/jira/`, `/confluence/`, `/bitbucket/`, `/jsm/`, `/install/`, `/blog/`, `/sitemap.xml` all return 200
+- All 6 main pages have valid JSON-LD blocks
+- All 4 hub pages' nav-btn Install button resolves to `/install/`
+- Codex review: `/Users/macmini/projects/codex/atlassiancli_seo_week2_review_18apr2026.txt`
+
+### Explicitly deferred (per codex)
+- BreadcrumbList on blog/runbook pages (would be Home > Blog > Post; real hierarchy)
+- First-party docs on atlassiancli.com (replacing GitHub-only Docs link) — highest-remaining-leverage item
+- JSM redirect to /jira/ (codex: keep separate page, small-volume but distinct intent)
+
+---
+
+## 2026-04-18 - Homepage SEO rewrite (week-1, codex-reviewed)
+
+### Context
+GSC data: 51 clicks / 5,960 impressions / 0.9% CTR / pos 14.5 over 3 months. Homepage ranks pos 7.3 for "atlassian cli" (2,415 impr) but CTR is 0.79% — title/H1 were slogan-first ("Atlassian Cloud as Code") not query-first. Product cards on homepage were not crawlable (no `<a>` wrapping), so `/jira/`, `/confluence/`, `/bitbucket/`, `/jsm/` got zero internal link juice from the top page.
+
+### Changes
+- [DONE] `docs/index.html` — new `<title>`, meta description, og:*, twitter:*, og:site_name
+- [DONE] `docs/index.html` — H1 changed from "Atlassian Cloud as Code" → "Atlassian CLI" (query-first)
+- [DONE] `docs/index.html` — nav now has Jira/Confluence/Bitbucket/Blog links (removed redundant Docs→GitHub)
+- [DONE] `docs/index.html` — product cards wrapped in `<a href="/jira/">` etc. (4 new crawlable links)
+- [DONE] `docs/index.html` — product card headings renamed "Jira" → "Jira CLI" etc. for better anchor text
+- [DONE] `docs/index.html` — added WebSite JSON-LD with alternateName; updated SoftwareApplication
+- [DONE] `docs/index.html` — footer expanded with hub + runbook links
+- [DONE] `docs/styles.css` — `.product-card` now `display:block; color:inherit; text-decoration:none` (anchor compatibility)
+- [DONE] `docs/llms.txt` — version bumped to 0.3.3
+
+### Verification
+- HTML parses cleanly (only false-positive `</link>` which is HTML5 self-closing)
+- Both JSON-LD blocks valid JSON; @type=WebSite and @type=SoftwareApplication
+- Local server: `/`, `/jira/`, `/confluence/`, `/bitbucket/`, `/jsm/` all return 200
+- Raw research data: `/Users/macmini/projects/codex/atlassiancli_seo_18apr2026/`
+- Codex review: `/Users/macmini/projects/codex/atlassiancli_seo_week1_review_18apr2026.txt`
+
+### Explicitly not done (per codex review)
+- Misspelling hint copy (spammy)
+- FAQ schema as SEO hack (Google limits FAQ rich results to gov/health)
+- OG image upgrade (not a week-1 lever)
+- Sitemap lastmod bump without real content changes
+
+---
+
 ## 2026-04-02 - Jira Search API Migration & 410 Error Handling
 
 ### Context
@@ -865,3 +1018,14 @@ current → draft: error (cannot unpublish)
 - Payload assembly extracted to `build_create_payload` / `build_update_payload` / `build_bulk_payload` for unit-testability.
 - New doc: `docs/14042026_jira_custom_fields.md`. README example updated. CLI help integration test added.
 - Co-authored with @thereisnotime (original PR).
+
+## 2026-05-16 — SEO overhaul + OSS-unaffiliated positioning (branch `seo/oss-positioning-overhaul`)
+
+Driven by GA4 (`520368061`) + GSC (`sc-domain:atlassiancli.com`) review. Plan: `/Users/macmini/.claude/plans/check-google-analytics-and-imperative-comet.md`. Codex review: `/Users/macmini/projects/codex/atlassiancli_oss_unaffiliated_positioning_review.txt`.
+
+- Phase 1: ship untracked `docs/install/` + `docs/docs/` (index/auth/commands); refresh all `docs/sitemap.xml` `lastmod` → 2026-05-16; add `/about/`.
+- Phase 2: `docs/index.html` — codex-recommended `<title>`/meta/OG/Twitter (no "Unofficial" in title), de-brand hero copy, JSON-LD `name`=`atlassian-cli` + `disambiguatingDescription` + `isAccessibleForFree` + `SoftwareSourceCode`, on-page FAQ, hero unaffiliated line.
+- Phase 3: nav anchors → "Jira/Confluence/Bitbucket CLI"; reciprocal exact-match links from blog guides → section pages; shared footer legal+trademark block site-wide.
+- Phase 4: deepen `runbooks/confluence-markdown-sync.html` (pos 40); above-the-fold TL;DR on `blog/bitbucket-cli-guide.html` (70% bounce).
+- Phase 5: site-wide `Atlassian CLI` → `atlassian-cli` rename (title/OG/JSON-LD/breadcrumb/H1); replace Atlassian-imitating product SVGs with generic glyphs; remove `<meta name="keywords">` (23 files); add `docs/about/index.html`, `docs/SECURITY.md`, `docs/.well-known/security.txt`, repo `SECURITY.md`; README + `docs/llms.txt` parity.
+- Decisions: full overhaul; keep `atlassiancli.com` domain, de-risk via naming/disclaimers (no migration).


### PR DESCRIPTION
GA4 + Google Search Console review-driven overhaul of atlassiancli.com, plus repositioning the project as an independent open-source tool not affiliated with Atlassian (codex-reviewed).

## Changes
- **Ship + sitemap:** publish previously-untracked `/install/` and `/docs/` (index/auth/commands); refresh all `sitemap.xml` lastmod; add `/about/`.
- **Homepage:** codex-recommended title/meta/OG/Twitter; de-branded hero + visible unaffiliated line; JSON-LD `name=atlassian-cli` + `disambiguatingDescription` + `isAccessibleForFree` + `SoftwareSourceCode` + `FAQPage`; visible on-page FAQ.
- **Internal targeting:** exact-match nav anchors (Jira/Confluence/Bitbucket CLI); reciprocal links from blog guides to section pages; footer legal + trademark disclaimer on every page.
- **Weak pages:** deepened `confluence-markdown-sync.html` (prose, Common Errors, CI/CD, FAQ + FAQPage JSON-LD); above-the-fold TL;DR/quick-start on `bitbucket-cli-guide.html`.
- **Independence hardening:** site-wide `Atlassian CLI` → `atlassian-cli` (titles/OG/JSON-LD/breadcrumbs/H1); generic non-Atlassian product icons; removed `<meta keywords>` (23 files); new `/about/`, `SECURITY.md`, `.well-known/security.txt`; README + `llms.txt` parity.

## Verification
Zero "Atlassian CLI" proper-noun in served HTML; footer disclaimer on all 29 pages; all JSON-LD valid; no broken internal links; sitemap valid XML. Pre-commit gate (fmt + clippy + 44 tests) passed.

Incidental: fixed a pre-existing clippy `useless_conversion` in `bitbucket/pipelines.rs` that was blocking all commits via the pre-commit hook.