### PR TITLE
feat(bitbucket): add --custom-pipeline flag to pipeline trigger

### DIFF
--- a/crates/cli/src/commands/bitbucket/mod.rs
+++ b/crates/cli/src/commands/bitbucket/mod.rs
@@ -496,6 +496,9 @@ enum PipelineCommands {
         /// Mark all variables as secured.
         #[arg(long, default_value_t = false)]
         secured: bool,
+        /// Custom pipeline name to trigger (selector pattern from bitbucket-pipelines.yml).
+        #[arg(long)]
+        custom_pipeline: Option<String>,
     },
     /// Stop a running pipeline.
     Stop {
@@ -1293,10 +1296,18 @@ pub async fn execute(
                 ref_type,
                 variables,
                 secured,
+                custom_pipeline,
             } => {
                 let repo_slug = require_repo(None, global_repo.as_deref(), "pipeline trigger")?;
                 pipelines::trigger_pipeline(
-                    &ctx, &workspace, &repo_slug, &ref_name, &ref_type, variables, secured,
+                    &ctx,
+                    &workspace,
+                    &repo_slug,
+                    &ref_name,
+                    &ref_type,
+                    variables,
+                    secured,
+                    custom_pipeline,
                 )
                 .await
             }

--- a/crates/cli/src/commands/bitbucket/pipelines.rs
+++ b/crates/cli/src/commands/bitbucket/pipelines.rs
@@ -769,6 +769,7 @@ pub async fn trigger_pipeline(
     ref_type: &str,
     variable_strings: Vec<String>,
     secured: bool,
+    custom_pipeline: Option<String>,
 ) -> Result<()> {
     let mut payload = serde_json::json!({
         "target": {
@@ -777,6 +778,13 @@ pub async fn trigger_pipeline(
             "type": "pipeline_ref_target"
         }
     });
+
+    if let Some(name) = custom_pipeline {
+        payload["target"]["selector"] = serde_json::json!({
+            "type": "custom",
+            "pattern": name
+        });
+    }
 
     // Add variables if provided
     if !variable_strings.is_empty() {

--- a/crates/cli/src/commands/bitbucket/pipelines.rs
+++ b/crates/cli/src/commands/bitbucket/pipelines.rs
@@ -761,16 +761,17 @@ pub async fn get_pipeline(
     ctx.renderer.render(&view)
 }
 
-pub async fn trigger_pipeline(
-    ctx: &BitbucketContext<'_>,
-    workspace: &str,
-    repo_slug: &str,
+/// Build the POST body for triggering a pipeline. Pure and testable.
+///
+/// `custom_pipeline` injects a `target.selector` so a named custom pipeline from
+/// `bitbucket-pipelines.yml` is run instead of the branch default. `variables`,
+/// when non-empty, is serialized as the top-level `variables` array.
+fn build_trigger_payload(
     ref_name: &str,
     ref_type: &str,
-    variable_strings: Vec<String>,
-    secured: bool,
-    custom_pipeline: Option<String>,
-) -> Result<()> {
+    custom_pipeline: Option<&str>,
+    variables: &[PipelineVariable],
+) -> serde_json::Value {
     let mut payload = serde_json::json!({
         "target": {
             "ref_name": ref_name,
@@ -786,11 +787,31 @@ pub async fn trigger_pipeline(
         });
     }
 
-    // Add variables if provided
-    if !variable_strings.is_empty() {
-        let variables = parse_variables(variable_strings.clone(), secured)?;
-        payload["variables"] = serde_json::to_value(variables)?;
+    if !variables.is_empty() {
+        payload["variables"] = serde_json::json!(variables);
     }
+
+    payload
+}
+
+#[allow(clippy::too_many_arguments)]
+pub async fn trigger_pipeline(
+    ctx: &BitbucketContext<'_>,
+    workspace: &str,
+    repo_slug: &str,
+    ref_name: &str,
+    ref_type: &str,
+    variable_strings: Vec<String>,
+    secured: bool,
+    custom_pipeline: Option<String>,
+) -> Result<()> {
+    let variables = if variable_strings.is_empty() {
+        Vec::new()
+    } else {
+        parse_variables(variable_strings.clone(), secured)?
+    };
+
+    let payload = build_trigger_payload(ref_name, ref_type, custom_pipeline.as_deref(), &variables);
 
     let path = format!("/2.0/repositories/{workspace}/{repo_slug}/pipelines/");
     let pipeline: Pipeline = ctx.client.post(&path, &payload).await.with_context(|| {
@@ -1841,6 +1862,48 @@ mod tests {
         }"#;
         let target: Target = serde_json::from_str(json).unwrap();
         assert!(target.commit.is_none());
+    }
+
+    #[test]
+    fn test_build_trigger_payload_default_has_no_selector() {
+        let payload = build_trigger_payload("main", "branch", None, &[]);
+        assert_eq!(payload["target"]["ref_name"], "main");
+        assert_eq!(payload["target"]["ref_type"], "branch");
+        assert_eq!(payload["target"]["type"], "pipeline_ref_target");
+        assert!(payload["target"].get("selector").is_none());
+        assert!(payload.get("variables").is_none());
+    }
+
+    #[test]
+    fn test_build_trigger_payload_injects_custom_selector() {
+        let payload = build_trigger_payload("dev", "branch", Some("s3-access-test"), &[]);
+        assert_eq!(payload["target"]["selector"]["type"], "custom");
+        assert_eq!(payload["target"]["selector"]["pattern"], "s3-access-test");
+    }
+
+    #[test]
+    fn test_build_trigger_payload_includes_variables() {
+        let vars = vec![PipelineVariable {
+            key: "ENV".to_string(),
+            value: "prod".to_string(),
+            secured: false,
+        }];
+        let payload = build_trigger_payload("main", "branch", None, &vars);
+        assert_eq!(payload["variables"][0]["key"], "ENV");
+        assert_eq!(payload["variables"][0]["value"], "prod");
+        assert_eq!(payload["variables"][0]["secured"], false);
+    }
+
+    #[test]
+    fn test_build_trigger_payload_selector_and_variables_together() {
+        let vars = vec![PipelineVariable {
+            key: "REGION".to_string(),
+            value: "eu".to_string(),
+            secured: true,
+        }];
+        let payload = build_trigger_payload("main", "branch", Some("deploy"), &vars);
+        assert_eq!(payload["target"]["selector"]["pattern"], "deploy");
+        assert_eq!(payload["variables"][0]["secured"], true);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Closes #54.

Adds an optional `--custom-pipeline <NAME>` flag to `bitbucket pipeline trigger`. When provided, the Bitbucket API `selector` field is injected into the request body so the named custom pipeline is triggered instead of the default branch pipeline.

**Before:**
```bash
# No way to trigger a custom pipeline from CLI — UI-only
atlassian-cli bitbucket pipeline trigger --ref-name main
```

**After:**
```bash
atlassian-cli bitbucket pipeline trigger \
  --ref-name my-branch \
  --custom-pipeline s3-access-test
```

## Changes

- `mod.rs`: add optional `--custom-pipeline` arg to `Trigger` struct; forward to `trigger_pipeline()`
- `pipelines.rs`: add `custom_pipeline: Option<String>` param; inject `selector` into payload when provided

## API reference

Bitbucket REST API supports the `selector` field on pipeline targets:
```json
{
  "target": {
    "type": "pipeline_ref_target",
    "ref_name": "branch",
    "ref_type": "branch",
    "selector": { "type": "custom", "pattern": "my-pipeline" }
  }
}
```

## Test plan

- [x] Built locally (`cargo build --release`) — compiles clean
- [x] Triggered a real custom Bitbucket pipeline via `--custom-pipeline` flag against a live workspace — pipeline started successfully (build #1209)
- [ ] Unit tests (existing test suite passes; no new test added — selector logic is a single conditional JSON field)