### PR TITLE
fix: HTTP 204 false errors (#45) + Confluence list parse hardening (#49)

### DIFF
--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -524,10 +524,26 @@ impl ApiClient {
                         message,
                     })
                 }
-                status if status.is_success() => response.json::<T>().await.map_err(|e| {
-                    error!("Failed to parse JSON response: {}", e);
-                    ApiError::InvalidResponse(e.to_string())
-                }),
+                status if status.is_success() => {
+                    let bytes = response
+                        .bytes()
+                        .await
+                        .map_err(|e| ApiError::InvalidResponse(e.to_string()))?;
+                    // Successful responses with an empty (or whitespace-only) body,
+                    // e.g. HTTP 204 No Content from Jira update/transition/assign and
+                    // most DELETEs, are treated as JSON `null`. Callers that discard
+                    // the body (`let _: Value`) then succeed instead of failing to
+                    // parse an empty body as JSON.
+                    let slice: &[u8] = if bytes.iter().all(|b| b.is_ascii_whitespace()) {
+                        b"null"
+                    } else {
+                        &bytes
+                    };
+                    serde_json::from_slice::<T>(slice).map_err(|e| {
+                        error!("Failed to parse JSON response: {}", e);
+                        ApiError::InvalidResponse(e.to_string())
+                    })
+                }
                 _ => {
                     let message = response
                         .text()
@@ -646,5 +662,64 @@ mod tests {
             }
             other => panic!("Expected Forbidden, got: {:?}", other),
         }
+    }
+
+    // Regression for #45: a successful PUT/POST returning HTTP 204 No Content (empty
+    // body) must not fail JSON parsing. Callers discard the body as `Value`.
+    #[tokio::test]
+    async fn test_204_no_content_put_succeeds() {
+        let server = MockServer::start().await;
+        Mock::given(method("PUT"))
+            .and(path("issue/AEA-1"))
+            .respond_with(ResponseTemplate::new(204))
+            .mount(&server)
+            .await;
+
+        let client = ApiClient::new(server.uri()).unwrap();
+        let result: error::Result<serde_json::Value> = client
+            .put("/issue/AEA-1", &serde_json::json!({"fields": {}}))
+            .await;
+
+        match result {
+            Ok(serde_json::Value::Null) => {}
+            other => panic!("Expected Ok(Null) for 204, got: {:?}", other),
+        }
+    }
+
+    // A 200 with an empty/whitespace-only body is also treated as null.
+    #[tokio::test]
+    async fn test_200_empty_body_succeeds() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("transitions"))
+            .respond_with(ResponseTemplate::new(200).set_body_string("  \n"))
+            .mount(&server)
+            .await;
+
+        let client = ApiClient::new(server.uri()).unwrap();
+        let result: error::Result<serde_json::Value> =
+            client.post("/transitions", &serde_json::json!({})).await;
+
+        match result {
+            Ok(serde_json::Value::Null) => {}
+            other => panic!("Expected Ok(Null) for empty 200, got: {:?}", other),
+        }
+    }
+
+    // A non-empty JSON body on success still parses normally.
+    #[tokio::test]
+    async fn test_200_json_body_still_parses() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("issue/AEA-1"))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_json(serde_json::json!({"key": "AEA-1"})),
+            )
+            .mount(&server)
+            .await;
+
+        let client = ApiClient::new(server.uri()).unwrap();
+        let result: serde_json::Value = client.get("/issue/AEA-1").await.unwrap();
+        assert_eq!(result["key"], "AEA-1");
     }
 }

--- a/crates/cli/src/commands/confluence/pages.rs
+++ b/crates/cli/src/commands/confluence/pages.rs
@@ -20,13 +20,18 @@ pub async fn list_pages(
         results: Vec<Page>,
     }
 
+    // Fields beyond `id` are optional: the Confluence v2 pages list may omit `type`
+    // entirely and can return null/absent `title`/`status` for some content, which
+    // would otherwise abort the whole parse with "error decoding response body".
     #[derive(Deserialize)]
     struct Page {
         id: String,
-        title: String,
-        #[serde(rename = "type")]
-        page_type: String,
-        status: String,
+        #[serde(default)]
+        title: Option<String>,
+        #[serde(rename = "type", default)]
+        page_type: Option<String>,
+        #[serde(default)]
+        status: Option<String>,
     }
 
     let query_string = {
@@ -65,9 +70,9 @@ pub async fn list_pages(
         .iter()
         .map(|p| Row {
             id: p.id.as_str(),
-            title: p.title.as_str(),
-            page_type: p.page_type.as_str(),
-            status: p.status.as_str(),
+            title: p.title.as_deref().unwrap_or(""),
+            page_type: p.page_type.as_deref().unwrap_or(""),
+            status: p.status.as_deref().unwrap_or(""),
         })
         .collect();
 

--- a/crates/cli/src/commands/confluence/search.rs
+++ b/crates/cli/src/commands/confluence/search.rs
@@ -15,12 +15,15 @@ pub async fn search_cql(
         results: Vec<SearchResult>,
     }
 
+    // Only `id` is guaranteed; `title`/`type` may be null or absent for some
+    // content types, which would otherwise abort the parse.
     #[derive(Deserialize)]
     struct SearchResult {
         id: String,
-        title: String,
-        #[serde(rename = "type")]
-        content_type: String,
+        #[serde(default)]
+        title: Option<String>,
+        #[serde(rename = "type", default)]
+        content_type: Option<String>,
     }
 
     let mut query_params = vec![format!("cql={}", urlencoding::encode(cql))];
@@ -56,8 +59,8 @@ pub async fn search_cql(
         .iter()
         .map(|r| Row {
             id: r.id.as_str(),
-            title: r.title.as_str(),
-            content_type: r.content_type.as_str(),
+            title: r.title.as_deref().unwrap_or(""),
+            content_type: r.content_type.as_deref().unwrap_or(""),
         })
         .collect();
 

--- a/crates/cli/src/commands/confluence/spaces.rs
+++ b/crates/cli/src/commands/confluence/spaces.rs
@@ -17,14 +17,19 @@ pub async fn list_spaces(
         results: Vec<Space>,
     }
 
+    // Only `id` is guaranteed; the v2 spaces list may omit `type` and can return
+    // null/absent `key`/`name`/`status`, which would otherwise abort the parse.
     #[derive(Deserialize)]
     struct Space {
         id: String,
-        key: String,
-        name: String,
-        #[serde(rename = "type")]
-        space_type: String,
-        status: String,
+        #[serde(default)]
+        key: Option<String>,
+        #[serde(default)]
+        name: Option<String>,
+        #[serde(rename = "type", default)]
+        space_type: Option<String>,
+        #[serde(default)]
+        status: Option<String>,
     }
 
     let query_string = {
@@ -64,10 +69,10 @@ pub async fn list_spaces(
         .iter()
         .map(|s| Row {
             id: s.id.as_str(),
-            key: s.key.as_str(),
-            name: s.name.as_str(),
-            space_type: s.space_type.as_str(),
-            status: s.status.as_str(),
+            key: s.key.as_deref().unwrap_or(""),
+            name: s.name.as_deref().unwrap_or(""),
+            space_type: s.space_type.as_deref().unwrap_or(""),
+            status: s.status.as_deref().unwrap_or(""),
         })
         .collect();
 

--- a/todo.md
+++ b/todo.md
@@ -1,5 +1,29 @@
 # Changes Made
 
+## 2026-06-11 — Bug fixes: HTTP 204 false errors (#45) + Confluence list parse (#49)
+
+### Context
+Issue triage flagged two real defects. #45: mutating Jira/Confluence commands (update,
+transition, assign, deletes) exited non-zero with "error decoding response body" even
+though the write succeeded, because the API returns HTTP 204 No Content and the client
+parsed the empty body as JSON. #49 (trailing note): `confluence page list` failed with
+the same parse error because list structs had required `String` fields the v2 API can
+omit or null. Codex reviewed the fix design (read-only).
+
+### #45 — central fix in `crates/api/src/lib.rs`
+- `request()` success arm now reads body bytes and treats an empty or whitespace-only
+  body as JSON `null` before deserializing (was `response.json::<T>()` unconditionally).
+- Callers discard the body as `let _: Value`, so they receive `Value::Null` and succeed.
+  No call-site changes; fixes all 204-returning endpoints at once.
+- Added 3 wiremock tests: 204 PUT → Ok(Null), empty 200 → Ok(Null), JSON 200 still parses.
+
+### #49 — defensive deserialization on Confluence list structs
+- `Page` (pages.rs), `Space` (spaces.rs), `SearchResult` (search.rs): non-`id` string
+  fields are now `Option<String>` with `#[serde(default)]` (handles both absent AND null;
+  plain serde default does not cover explicit null). Rendered via `.as_deref().unwrap_or("")`.
+
+Verification: `cargo test` (all pass, +3 new), `cargo clippy --all-targets` clean.
+
 ## 2026-04-21 - Week-4 SEO: breadcrumbs on blog/runbook pages
 
 ### Context


### PR DESCRIPTION
Fixes two deserialization bugs surfaced in issue triage.

## #45 — mutating commands report false errors on HTTP 204

`ApiClient::request()` parsed every 2xx response as JSON, so HTTP 204 No Content (returned by `jira issue update`/`transition`/`assign`/`unassign` and most DELETEs) failed with `error decoding response body` and a non-zero exit, even though the write succeeded.

The success arm now reads the body bytes and treats an empty or whitespace-only body as JSON `null` before deserializing. Every affected call site already discards the body as `let _: serde_json::Value`, so it receives `Value::Null` and succeeds. One central change, no call-site churn, covers all 204-returning Jira/Confluence/Bitbucket endpoints.

Closes #45.

## #49 (partial) — `confluence page list` fails to deserialize

The Confluence page/space/search list structs declared required `String` fields (`title`, `type`, `status`) that the v2 API can omit or return as `null`, aborting the whole parse. Those fields are now `Option<String>` with `#[serde(default)]` (handles both absent and explicit null) and render as empty strings.

This fixes the `page list` parse failure noted at the end of #49. The main folder-API feature request in #49 is separate and remains open.

## Tests
- New wiremock tests: 204 PUT returns `Ok(Null)`, empty/whitespace 200 returns `Ok(Null)`, normal JSON 200 still parses.
- `cargo test` (294 tests) and `cargo clippy --all-targets` pass.