### PR TITLE
chore(deps): drop unmaintained proc-macro-error2 via tabled default-features

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1832,9 +1832,9 @@ dependencies = [
 
 [[package]]
 name = "papergrid"
-version = "0.17.0"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6978128c8b51d8f4080631ceb2302ab51e32cc6e8615f735ee2f83fd269ae3f1"
+checksum = "d0984e668274d34691bc2b262ef0d115de5fa9973bcdee7ae32213f93099153e"
 dependencies = [
  "bytecount",
  "fnv",
@@ -2029,28 +2029,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn",
-]
-
-[[package]]
-name = "proc-macro-error-attr2"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
-dependencies = [
- "proc-macro2",
- "quote",
-]
-
-[[package]]
-name = "proc-macro-error2"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
-dependencies = [
- "proc-macro-error-attr2",
- "proc-macro2",
- "quote",
  "syn",
 ]
 
@@ -2799,26 +2777,12 @@ dependencies = [
 
 [[package]]
 name = "tabled"
-version = "0.20.0"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e39a2ee1fbcd360805a771e1b300f78cc88fec7b8d3e2f71cd37bbf23e725c7d"
+checksum = "b5dc662e6da844ad6e428ad16b57967c9d33c82e16bb1c258326c0c078605dff"
 dependencies = [
  "papergrid",
- "tabled_derive",
  "testing_table",
-]
-
-[[package]]
-name = "tabled_derive"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ea5d1b13ca6cff1f9231ffd62f15eefd72543dab5e468735f1a456728a02846"
-dependencies = [
- "heck",
- "proc-macro-error2",
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,10 @@ serde_json = "1.0"
 serde_yaml = "0.9"
 
 # Output formatting
-tabled = "0.20"
+# default-features disabled to drop the `derive` feature (tabled_derive ->
+# proc-macro-error2, which is unmaintained per RUSTSEC-2026-0173). We only use
+# tabled's Builder + Style, not #[derive(Tabled)].
+tabled = { version = "0.21", default-features = false, features = ["std"] }
 colored = "3.1"
 indicatif = "0.18"
 

--- a/todo.md
+++ b/todo.md
@@ -1,5 +1,22 @@
 # Changes Made
 
+## 2026-06-12 — Drop unmaintained proc-macro-error2; fixes Security Audit (#53)
+
+### Context
+CI `cargo deny check advisories` failed repo-wide on RUSTSEC-2026-0173
+(`proc-macro-error2` unmaintained), pulled transitively via `tabled` ->
+`tabled_derive`. This blocked the dependabot dep-bump PR #53 and every other PR.
+
+### Change
+- `Cargo.toml`: `tabled = { version = "0.21", default-features = false, features = ["std"] }`.
+  The repo only uses `tabled::builder::Builder` and `tabled::settings::Style`, never
+  `#[derive(Tabled)]`, so disabling the default `derive` feature drops `tabled_derive`
+  and `proc-macro-error2` entirely. Proper removal, not a deny.toml suppression. Also
+  takes the tabled 0.20 -> 0.21 bump from #53.
+- Verified: `cargo tree -i proc-macro-error2` and `tabled_derive` both empty;
+  `cargo deny check advisories` = ok; full `cargo test` + `cargo clippy` clean;
+  table render output unchanged.
+
 ## 2026-06-11 — Bug fixes: HTTP 204 false errors (#45) + Confluence list parse (#49)
 
 ### Context


### PR DESCRIPTION
The CI **Security Audit** job (`cargo deny check advisories`) fails repo-wide on `RUSTSEC-2026-0173`: `proc-macro-error2` is unmaintained. It is pulled in transitively through `tabled` -> `tabled_derive`.

This repo only uses `tabled::builder::Builder` and `tabled::settings::Style`, never `#[derive(Tabled)]`, so building `tabled` with `default-features = false` (keeping only `std`) drops `tabled_derive` and `proc-macro-error2` from the tree entirely. This is a real removal rather than a `deny.toml` suppression, and it also takes the `tabled` 0.20 -> 0.21 bump that #53 wanted.

After this:
- `cargo tree -i proc-macro-error2` -> no match
- `cargo tree -i tabled_derive` -> no match
- `cargo deny check advisories` -> ok

Unblocks #53 (dependabot can rebase to drop the now-satisfied tabled and merge the remaining bumps).

## Tests
`cargo test` (all pass), `cargo clippy --all-targets` clean, table render output unchanged.