### PR TITLE
feat(confluence): add v2 Folder API command group

### DIFF
--- a/crates/cli/src/commands/confluence/folders.rs
+++ b/crates/cli/src/commands/confluence/folders.rs
@@ -1,0 +1,139 @@
+use anyhow::{Context, Result};
+use serde::Deserialize;
+use serde_json::{json, Value};
+
+use super::utils::{resolve_space_id, ConfluenceContext};
+use crate::commands::common::{render_success, MutationResult};
+
+/// The fields we read back from a folder create. The full response carries more
+/// (position, authorId, createdAt, version, _links, ...) which we don't need here.
+#[derive(Deserialize)]
+struct CreatedFolder {
+    id: String,
+    #[serde(default)]
+    title: Option<String>,
+}
+
+/// Build the POST body for `POST /wiki/api/v2/folders`. Pure and testable.
+fn build_folder_payload(space_id: &str, title: &str, parent_id: Option<&str>) -> Value {
+    let mut payload = json!({
+        "spaceId": space_id,
+        "title": title,
+    });
+    if let Some(pid) = parent_id {
+        payload["parentId"] = json!(pid);
+    }
+    payload
+}
+
+/// `confluence folder get <FOLDER_ID>` -> GET /wiki/api/v2/folders/{id}
+pub async fn get_folder(ctx: &ConfluenceContext<'_>, folder_id: &str) -> Result<()> {
+    // Render the full response so no fields are dropped, matching `page get`.
+    let folder: Value = ctx
+        .client
+        .get(&format!("/wiki/api/v2/folders/{folder_id}"))
+        .await
+        .with_context(|| format!("Failed to get folder {folder_id}"))?;
+
+    ctx.renderer.render(&folder)
+}
+
+/// `confluence folder create --space <KEY> --title <TITLE> [--parent <ID>]`
+/// -> POST /wiki/api/v2/folders
+///
+/// The v2 API expects a numeric `spaceId`, so the space key is resolved first.
+/// `parentId` may reference either a page or another folder.
+pub async fn create_folder(
+    ctx: &ConfluenceContext<'_>,
+    space_key: &str,
+    title: &str,
+    parent_id: Option<&str>,
+) -> Result<()> {
+    let space_id = resolve_space_id(ctx, space_key).await?;
+    let payload = build_folder_payload(&space_id, title, parent_id);
+
+    let folder: CreatedFolder = ctx
+        .client
+        .post("/wiki/api/v2/folders", &payload)
+        .await
+        .with_context(|| format!("Failed to create folder '{title}' in space {space_key}"))?;
+
+    let created_title = folder.title.as_deref().unwrap_or(title);
+    tracing::info!(id = %folder.id, title = %created_title, "Folder created successfully");
+    render_success(
+        ctx.renderer,
+        &format!("✅ Created folder: {created_title} (ID: {})", folder.id),
+        &MutationResult::with_id(format!("Created folder: {created_title}"), &folder.id),
+    )
+}
+
+/// `confluence folder delete <FOLDER_ID>` -> DELETE /wiki/api/v2/folders/{id}
+///
+/// Confluence moves the folder to the trash (it can be restored), rather than
+/// erasing it immediately.
+pub async fn delete_folder(
+    ctx: &ConfluenceContext<'_>,
+    folder_id: &str,
+    force: bool,
+) -> Result<()> {
+    if !force {
+        println!("⚠️  This will move folder {folder_id} to the trash. Use --force to confirm.");
+        return Ok(());
+    }
+
+    ctx.client
+        .delete_no_content(&format!("/wiki/api/v2/folders/{folder_id}"))
+        .await
+        .with_context(|| format!("Failed to delete folder {folder_id}"))?;
+
+    tracing::info!(%folder_id, "Folder moved to trash");
+    render_success(
+        ctx.renderer,
+        &format!("✅ Moved folder to trash: {folder_id}"),
+        &MutationResult::with_id(format!("Moved folder to trash: {folder_id}"), folder_id),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn payload_without_parent_has_space_and_title_only() {
+        let payload = build_folder_payload("3302031364", "Architecture", None);
+        assert_eq!(payload["spaceId"], "3302031364");
+        assert_eq!(payload["title"], "Architecture");
+        assert!(payload.get("parentId").is_none());
+    }
+
+    #[test]
+    fn payload_with_parent_includes_parent_id() {
+        let payload = build_folder_payload("3302031364", "Sub", Some("3302031761"));
+        assert_eq!(payload["parentId"], "3302031761");
+    }
+
+    #[test]
+    fn created_folder_extracts_id_and_title_ignoring_extra_fields() {
+        let json = r#"{
+            "id": "3309240341",
+            "type": "folder",
+            "title": "Architecture documentation",
+            "parentId": "3302031761",
+            "parentType": "page",
+            "spaceId": "3302031364",
+            "status": "current",
+            "authorId": "abc",
+            "_links": {"webui": "/x"}
+        }"#;
+        let folder: CreatedFolder = serde_json::from_str(json).unwrap();
+        assert_eq!(folder.id, "3309240341");
+        assert_eq!(folder.title.as_deref(), Some("Architecture documentation"));
+    }
+
+    #[test]
+    fn created_folder_tolerates_missing_title() {
+        let folder: CreatedFolder = serde_json::from_str(r#"{"id": "1"}"#).unwrap();
+        assert_eq!(folder.id, "1");
+        assert!(folder.title.is_none());
+    }
+}

--- a/crates/cli/src/commands/confluence/mod.rs
+++ b/crates/cli/src/commands/confluence/mod.rs
@@ -7,6 +7,7 @@ use clap::{Args, Subcommand};
 mod analytics;
 mod attachments;
 mod bulk;
+mod folders;
 mod pages;
 mod search;
 mod spaces;
@@ -29,6 +30,10 @@ enum ConfluenceCommands {
     /// Page operations
     #[command(subcommand)]
     Page(PageCommands),
+
+    /// Folder operations (v2 Folder API)
+    #[command(subcommand)]
+    Folder(FolderCommands),
 
     /// Blog post operations
     #[command(subcommand)]
@@ -123,6 +128,41 @@ enum SpaceCommands {
         /// Subject identifier (user ID or group name)
         #[arg(long)]
         subject_id: String,
+    },
+}
+
+#[derive(Subcommand, Debug, Clone)]
+enum FolderCommands {
+    /// Get folder details by ID
+    #[command(
+        long_about = "Get folder details by ID.\n\nExamples:\n  confluence folder get 3309240341"
+    )]
+    Get {
+        /// Folder ID
+        folder_id: String,
+    },
+    /// Create a new folder
+    #[command(
+        long_about = "Create a folder in a space.\n\nExamples:\n  confluence folder create --space TEAM --title \"Architecture\"\n  confluence folder create --space TEAM --title \"Diagrams\" --parent 3302031761"
+    )]
+    Create {
+        /// Space key (e.g., TEAM)
+        #[arg(long)]
+        space: String,
+        /// Folder title
+        #[arg(long)]
+        title: String,
+        /// Parent folder or page ID
+        #[arg(long)]
+        parent: Option<String>,
+    },
+    /// Delete a folder
+    Delete {
+        /// Folder ID
+        folder_id: String,
+        /// Force deletion without confirmation
+        #[arg(long)]
+        force: bool,
     },
 }
 
@@ -632,6 +672,17 @@ pub async fn execute(
                     &subject_id,
                 )
                 .await
+            }
+        },
+        ConfluenceCommands::Folder(cmd) => match cmd {
+            FolderCommands::Get { folder_id } => folders::get_folder(&ctx, &folder_id).await,
+            FolderCommands::Create {
+                space,
+                title,
+                parent,
+            } => folders::create_folder(&ctx, &space, &title, parent.as_deref()).await,
+            FolderCommands::Delete { folder_id, force } => {
+                folders::delete_folder(&ctx, &folder_id, force).await
             }
         },
         ConfluenceCommands::Blog(cmd) => match cmd {

--- a/crates/cli/src/commands/confluence/utils.rs
+++ b/crates/cli/src/commands/confluence/utils.rs
@@ -1,6 +1,9 @@
-use anyhow::Context;
+use anyhow::{anyhow, Context};
 use atlassian_cli_api::ApiClient;
 use atlassian_cli_output::OutputRenderer;
+use serde::Deserialize;
+
+use crate::query::UrlParamsBuilder;
 
 pub struct ConfluenceContext<'a> {
     pub client: ApiClient,
@@ -16,4 +19,33 @@ impl ConfluenceContext<'_> {
             .context("Failed to verify Confluence access. Run: atlassian-cli auth test")?;
         Ok(())
     }
+}
+
+/// Resolve a Confluence space key to its numeric v2 space ID via
+/// `GET /wiki/api/v2/spaces?keys=<key>`. Errors if no space matches.
+pub(crate) async fn resolve_space_id(
+    ctx: &ConfluenceContext<'_>,
+    key: &str,
+) -> anyhow::Result<String> {
+    #[derive(Deserialize)]
+    struct SpacesResponse {
+        results: Vec<SpaceRef>,
+    }
+    #[derive(Deserialize)]
+    struct SpaceRef {
+        id: String,
+    }
+
+    let query = UrlParamsBuilder::new().add("keys", key).finish();
+    let resp: SpacesResponse = ctx
+        .client
+        .get(&format!("/wiki/api/v2/spaces?{query}"))
+        .await
+        .with_context(|| format!("Failed to look up space '{key}'"))?;
+
+    resp.results
+        .into_iter()
+        .next()
+        .map(|s| s.id)
+        .ok_or_else(|| anyhow!("No Confluence space found with key '{key}'"))
 }

--- a/todo.md
+++ b/todo.md
@@ -1,5 +1,27 @@
 # Changes Made
 
+## 2026-06-12 — Confluence v2 Folder API command group (#49)
+
+### Context
+Confluence v2 treats folders as a distinct content type with their own endpoints,
+but the CLI had no `confluence folder` command, so folder IDs 404'd against
+`page get`. Issue #49 asked for get/create/delete.
+
+### Change
+- New `crates/cli/src/commands/confluence/folders.rs`:
+  - `folder get <ID>` -> GET /wiki/api/v2/folders/{id} (renders full response Value).
+  - `folder create --space <KEY> --title <T> [--parent <ID>]` -> POST
+    /wiki/api/v2/folders. Resolves the space key to a numeric spaceId first.
+  - `folder delete <ID> [--force]` -> DELETE /wiki/api/v2/folders/{id} via
+    `delete_no_content` (moves to trash; copy reflects that).
+  - Pure `build_folder_payload`; 4 unit tests.
+- New `resolve_space_id(ctx, key)` helper in `confluence/utils.rs`
+  (GET /wiki/api/v2/spaces?keys=<key> -> results[0].id).
+- Wired `Folder(FolderCommands)` group + dispatch in `confluence/mod.rs`.
+- Codex-reviewed (no blockers); applied both should-fixes: `get` preserves the full
+  response, delete copy says "move to trash" not "permanently delete".
+- The `page list` parse bug also referenced in #49 shipped earlier in #56.
+
 ## 2026-06-12 — Markdown to ADF for Jira descriptions/comments (#39)
 
 ### Context


### PR DESCRIPTION
Closes #49.

Confluence v2 treats folders as a distinct content type with their own endpoints, but the CLI had no `confluence folder` command, so folder IDs returned 404 against `page get`. This adds the group requested in #49.

## Commands
- `confluence folder get <FOLDER_ID>` -> `GET /wiki/api/v2/folders/{id}` (renders the full response, so no fields are dropped)
- `confluence folder create --space <KEY> --title <TITLE> [--parent <ID>]` -> `POST /wiki/api/v2/folders`. The space **key** is resolved to a numeric `spaceId` first (the v2 create body needs `spaceId`); `--parent` may be a page or folder ID.
- `confluence folder delete <FOLDER_ID> [--force]` -> `DELETE /wiki/api/v2/folders/{id}` via `delete_no_content`. Confluence moves the folder to the trash (restorable), and the copy reflects that.

## Notes
- New reusable `resolve_space_id` helper in `confluence/utils.rs` (`GET /wiki/api/v2/spaces?keys=<key>`).
- Pure `build_folder_payload` plus 4 unit tests (payload with/without parent, response parsing tolerant of missing/extra fields).
- I did **not** add the implicit `page get` -> folder 404-fallback that the issue floated, to keep `page get` behavior predictable in scripts; `folder get` is explicit.
- The `confluence page list` parse failure also noted in #49 was fixed earlier in #56.

## Review & tests
Codex-reviewed (no blockers); both should-fixes applied (full-response `get`, trash wording). Full `cargo test` (213 bin tests) and `cargo clippy --all-targets` pass.