### PR TITLE
chore: bump version to 0.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -183,7 +183,7 @@ dependencies = [
 
 [[package]]
 name = "atlassian-cli"
-version = "0.3.3"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "atlassian-cli-api",
@@ -213,7 +213,7 @@ dependencies = [
 
 [[package]]
 name = "atlassian-cli-api"
-version = "0.3.3"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -235,7 +235,7 @@ dependencies = [
 
 [[package]]
 name = "atlassian-cli-auth"
-version = "0.3.3"
+version = "0.4.0"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -257,7 +257,7 @@ dependencies = [
 
 [[package]]
 name = "atlassian-cli-bulk"
-version = "0.3.3"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "criterion",
@@ -270,7 +270,7 @@ dependencies = [
 
 [[package]]
 name = "atlassian-cli-config"
-version = "0.3.3"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "dirs",
@@ -284,7 +284,7 @@ dependencies = [
 
 [[package]]
 name = "atlassian-cli-output"
-version = "0.3.3"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.3.3"
+version = "0.4.0"
 edition = "2021"
 authors = ["atlassian-cli contributors"]
 license = "MIT"

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -22,11 +22,11 @@ serde.workspace = true
 serde_json.workspace = true
 
 # Internal crates
-atlassian-cli-api = { path = "../api", version = "0.3.3" }
-atlassian-cli-auth = { path = "../auth", version = "0.3.3" }
-atlassian-cli-config = { path = "../config", version = "0.3.3" }
-atlassian-cli-output = { path = "../output", version = "0.3.3" }
-atlassian-cli-bulk = { path = "../bulk", version = "0.3.3" }
+atlassian-cli-api = { path = "../api", version = "0.4.0" }
+atlassian-cli-auth = { path = "../auth", version = "0.4.0" }
+atlassian-cli-config = { path = "../config", version = "0.4.0" }
+atlassian-cli-output = { path = "../output", version = "0.4.0" }
+atlassian-cli-bulk = { path = "../bulk", version = "0.4.0" }
 
 # CLI helpers
 url.workspace = true


### PR DESCRIPTION
Release prep for v0.4.0.

**Features**
- Jira: markdown to ADF for `--description` and comments (#39)
- Confluence: v2 Folder API command group (#49)
- Bitbucket: `--custom-pipeline` flag for pipeline trigger (#54)

**Fixes / maintenance**
- Mutating commands no longer report false errors on HTTP 204 (#45)
- Confluence list parsing tolerates missing/null fields (#49)
- Dropped unmaintained `proc-macro-error2`; dependency bumps

Merging this and tagging `v0.4.0` triggers the release (GitHub release, Homebrew, crates.io).