### PR TITLE
chore: bump version to 0.4.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -183,7 +183,7 @@ dependencies = [
 
 [[package]]
 name = "atlassian-cli"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "atlassian-cli-api",
@@ -213,7 +213,7 @@ dependencies = [
 
 [[package]]
 name = "atlassian-cli-api"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -235,7 +235,7 @@ dependencies = [
 
 [[package]]
 name = "atlassian-cli-auth"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -257,7 +257,7 @@ dependencies = [
 
 [[package]]
 name = "atlassian-cli-bulk"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "criterion",
@@ -270,7 +270,7 @@ dependencies = [
 
 [[package]]
 name = "atlassian-cli-config"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "dirs",
@@ -284,7 +284,7 @@ dependencies = [
 
 [[package]]
 name = "atlassian-cli-output"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.4.0"
+version = "0.4.1"
 edition = "2021"
 authors = ["atlassian-cli contributors"]
 license = "MIT"

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -22,11 +22,11 @@ serde.workspace = true
 serde_json.workspace = true
 
 # Internal crates
-atlassian-cli-api = { path = "../api", version = "0.4.0" }
-atlassian-cli-auth = { path = "../auth", version = "0.4.0" }
-atlassian-cli-config = { path = "../config", version = "0.4.0" }
-atlassian-cli-output = { path = "../output", version = "0.4.0" }
-atlassian-cli-bulk = { path = "../bulk", version = "0.4.0" }
+atlassian-cli-api = { path = "../api", version = "0.4.1" }
+atlassian-cli-auth = { path = "../auth", version = "0.4.1" }
+atlassian-cli-config = { path = "../config", version = "0.4.1" }
+atlassian-cli-output = { path = "../output", version = "0.4.1" }
+atlassian-cli-bulk = { path = "../bulk", version = "0.4.1" }
 
 # CLI helpers
 url.workspace = true


### PR DESCRIPTION
Release prep for v0.4.1 (patch).

**Since 0.4.0**
- `jira issue get` now exposes an `attachments` array (id, filename, mimeType, size, content URL), tolerant of Jira returning the attachment `id` as a number or a string (#63, #64)
- `jira issue comments list --full` returns the complete comment body instead of the 50-char preview (#63, #64)

Merging this and tagging `v0.4.1` triggers the release (GitHub release, Homebrew, crates.io).