### PR TITLE
docs(site): announce 0.4 on the blog + add a /changelog/ page

### DIFF
--- a/docs/about/index.html
+++ b/docs/about/index.html
@@ -67,6 +67,7 @@
                 <a href="/confluence/" class="nav-link">Confluence CLI</a>
                 <a href="/bitbucket/" class="nav-link">Bitbucket CLI</a>
                 <a href="/docs/" class="nav-link">Docs</a>
+                <a href="/changelog/" class="nav-link">Changelog</a>
                 <a href="/blog/" class="nav-link">Blog</a>
                 <a href="https://github.com/omar16100/atlassian-cli" target="_blank" rel="noopener" class="nav-link">
                     <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor">
@@ -116,13 +117,14 @@
             <div class="footer-content">
                 <div class="footer-left">
                     <span class="footer-logo">atlassian-cli</span>
-                    <span class="footer-version">v0.3.3</span>
+                    <span class="footer-version">v0.4.1</span>
                 </div>
                 <div class="footer-links">
                     <a href="/jira/">Jira CLI</a>
                     <a href="/confluence/">Confluence CLI</a>
                     <a href="/bitbucket/">Bitbucket CLI</a>
                     <a href="/jsm/">JSM CLI</a>
+                    <a href="/changelog/">Changelog</a>
                     <a href="/blog/">Blog</a>
                     <a href="https://github.com/omar16100/atlassian-cli" target="_blank" rel="noopener">GitHub</a>
                 </div>

--- a/docs/bitbucket/index.html
+++ b/docs/bitbucket/index.html
@@ -52,7 +52,7 @@
       "operatingSystem": "macOS, Linux, Windows",
       "url": "https://atlassiancli.com/bitbucket/",
       "downloadUrl": "https://github.com/omar16100/atlassian-cli/releases",
-      "softwareVersion": "0.3.3",
+      "softwareVersion": "0.4.1",
       "license": "https://opensource.org/licenses/MIT",
       "offers": {
         "@type": "Offer",
@@ -174,6 +174,7 @@
                 <a href="/confluence/" class="nav-link">Confluence CLI</a>
                 <a href="/bitbucket/" class="nav-link" aria-current="page">Bitbucket CLI</a>
                 <a href="/docs/" class="nav-link">Docs</a>
+                <a href="/changelog/" class="nav-link">Changelog</a>
                 <a href="/blog/" class="nav-link">Blog</a>
                 <a href="https://github.com/omar16100/atlassian-cli" target="_blank" rel="noopener" class="nav-link">
                     <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor">
@@ -535,12 +536,13 @@ atlassian-cli bitbucket --workspace myteam \
             <div class="footer-content">
                 <div class="footer-left">
                     <span class="footer-logo">atlassian-cli</span>
-                    <span class="footer-version">v0.3.3</span>
+                    <span class="footer-version">v0.4.1</span>
                 </div>
                 <div class="footer-links">
                     <a href="https://github.com/omar16100/atlassian-cli" target="_blank" rel="noopener">GitHub</a>
                     <a href="/docs/">Documentation</a>
                     <a href="https://github.com/omar16100/atlassian-cli/issues" target="_blank" rel="noopener">Issues</a>
+                    <a href="/changelog/">Changelog</a>
                     <a href="/blog/">Blog</a>
                 </div>
                 <div class="footer-right">

--- a/docs/blog/atlassian-cli-0-4-release.html
+++ b/docs/blog/atlassian-cli-0-4-release.html
@@ -1,0 +1,456 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>What's New in atlassian-cli 0.4: Markdown-to-ADF, Confluence Folders & Custom Pipelines | atlassian-cli Blog</title>
+    <meta name="description" content="atlassian-cli 0.4 adds Markdown to ADF for Jira descriptions and comments, a Confluence v2 Folder API command group, custom Bitbucket pipeline triggers, Jira attachments in issue get, and a fix for false errors on HTTP 204.">
+
+    <!-- Open Graph -->
+    <meta property="og:title" content="What's New in atlassian-cli 0.4: Markdown-to-ADF, Confluence Folders & Custom Pipelines">
+    <meta property="og:description" content="atlassian-cli 0.4 adds Markdown to ADF for Jira descriptions and comments, a Confluence v2 Folder API command group, custom Bitbucket pipeline triggers, Jira attachments in issue get, and a fix for false errors on HTTP 204.">
+    <meta property="og:type" content="article">
+    <meta property="og:url" content="https://atlassiancli.com/blog/atlassian-cli-0-4-release.html">
+    <meta property="article:published_time" content="2026-06-14T00:00:00Z">
+    <meta property="article:author" content="Omar Shabab">
+
+    <!-- Twitter Card -->
+    <meta name="twitter:card" content="summary">
+    <meta name="twitter:title" content="What's New in atlassian-cli 0.4: Markdown-to-ADF, Confluence Folders & Custom Pipelines">
+    <meta name="twitter:description" content="atlassian-cli 0.4 adds Markdown to ADF for Jira descriptions and comments, a Confluence v2 Folder API command group, custom Bitbucket pipeline triggers, and more.">
+
+    <!-- Canonical -->
+    <link rel="canonical" href="https://atlassiancli.com/blog/atlassian-cli-0-4-release.html" />
+
+    <!-- Fonts -->
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet">
+
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-SHR43YZK8C"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      gtag('config', 'G-SHR43YZK8C');
+    </script>
+
+    <!-- Structured Data: Breadcrumb + Article -->
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "BreadcrumbList",
+      "itemListElement": [
+        {"@type": "ListItem", "position": 1, "name": "atlassian-cli", "item": "https://atlassiancli.com/"},
+        {"@type": "ListItem", "position": 2, "name": "Blog", "item": "https://atlassiancli.com/blog/"},
+        {"@type": "ListItem", "position": 3, "name": "What's New in atlassian-cli 0.4", "item": "https://atlassiancli.com/blog/atlassian-cli-0-4-release.html"}
+      ]
+    }
+    </script>
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "Article",
+      "headline": "What's New in atlassian-cli 0.4: Markdown-to-ADF, Confluence Folders & Custom Pipelines",
+      "description": "atlassian-cli 0.4 adds Markdown to ADF for Jira descriptions and comments, a Confluence v2 Folder API command group, custom Bitbucket pipeline triggers, Jira attachments in issue get, and a fix for false errors on HTTP 204.",
+      "datePublished": "2026-06-14T00:00:00Z",
+      "dateModified": "2026-06-14T00:00:00Z",
+      "author": {
+        "@type": "Person",
+        "name": "Omar Shabab",
+        "url": "https://omarshabab.com"
+      },
+      "publisher": {
+        "@type": "Person",
+        "name": "Omar Shabab",
+        "url": "https://omarshabab.com"
+      },
+      "mainEntityOfPage": {
+        "@type": "WebPage",
+        "@id": "https://atlassiancli.com/blog/atlassian-cli-0-4-release.html"
+      },
+      "keywords": ["atlassian cli", "jira markdown adf", "confluence folder cli", "bitbucket custom pipeline", "atlassian cli release", "jira cli", "confluence cli", "bitbucket cli"]
+    }
+    </script>
+
+    <link rel="stylesheet" href="../styles.css">
+
+    <style>
+        /* Article layout */
+        .article-header {
+            padding: 8rem 0 3rem;
+            text-align: center;
+            border-bottom: 1px solid var(--border);
+        }
+
+        .article-meta {
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            gap: 1rem;
+            margin-bottom: 1.5rem;
+            font-size: 0.8rem;
+            color: var(--text-muted);
+            font-family: var(--font-mono);
+        }
+
+        .article-meta-tag {
+            background: rgba(0, 212, 170, 0.08);
+            color: var(--accent-cyan);
+            padding: 0.25rem 0.625rem;
+            border-radius: 4px;
+            font-size: 0.7rem;
+            font-weight: 500;
+        }
+
+        .article-meta-sep {
+            color: var(--border);
+        }
+
+        .article-title {
+            font-size: clamp(1.75rem, 5vw, 2.75rem);
+            font-weight: 600;
+            line-height: 1.2;
+            margin-bottom: 1.25rem;
+            letter-spacing: -0.03em;
+            max-width: 780px;
+            margin-left: auto;
+            margin-right: auto;
+        }
+
+        .article-subtitle {
+            font-size: 1.1rem;
+            color: var(--text-secondary);
+            max-width: 600px;
+            margin: 0 auto;
+            line-height: 1.7;
+        }
+
+        .article-body {
+            max-width: 720px;
+            margin: 0 auto;
+            padding: 3rem 1.5rem 6rem;
+        }
+
+        .article-body h2 {
+            font-size: 1.5rem;
+            font-weight: 600;
+            margin-top: 3rem;
+            margin-bottom: 1rem;
+            letter-spacing: -0.02em;
+        }
+
+        .article-body h3 {
+            font-size: 1.2rem;
+            font-weight: 600;
+            margin-top: 2rem;
+            margin-bottom: 0.75rem;
+        }
+
+        .article-body p {
+            color: var(--text-secondary);
+            line-height: 1.8;
+            margin-bottom: 1.25rem;
+            font-size: 0.95rem;
+        }
+
+        .article-body a {
+            color: var(--accent-cyan);
+            text-decoration: none;
+            border-bottom: 1px solid rgba(0, 212, 170, 0.3);
+            transition: border-color 0.2s;
+        }
+
+        .article-body a:hover {
+            border-color: var(--accent-cyan);
+        }
+
+        .article-body ul, .article-body ol {
+            color: var(--text-secondary);
+            margin-bottom: 1.25rem;
+            padding-left: 1.5rem;
+            font-size: 0.95rem;
+            line-height: 1.8;
+        }
+
+        .article-body li {
+            margin-bottom: 0.375rem;
+        }
+
+        .article-body strong {
+            color: var(--text-primary);
+            font-weight: 600;
+        }
+
+        .article-body code:not(pre code) {
+            background: var(--bg-tertiary);
+            padding: 0.15rem 0.4rem;
+            border-radius: 4px;
+            font-family: var(--font-mono);
+            font-size: 0.825rem;
+            color: var(--accent-cyan);
+            border: 1px solid var(--border);
+        }
+
+        .article-body pre {
+            background: var(--bg-terminal);
+            border: 1px solid var(--border);
+            border-radius: 10px;
+            padding: 1.25rem 1.5rem;
+            overflow-x: auto;
+            font-family: var(--font-mono);
+            font-size: 0.8rem;
+            line-height: 1.8;
+            margin-bottom: 1.5rem;
+        }
+
+        .article-body pre code {
+            color: var(--text-primary);
+        }
+
+        .article-body .comment { color: var(--text-muted); }
+        .article-body .string { color: var(--accent-cyan); }
+
+        .article-cta {
+            margin-top: 3rem;
+            padding: 2rem;
+            background: var(--bg-secondary);
+            border: 1px solid var(--border);
+            border-radius: 12px;
+            text-align: center;
+        }
+
+        .article-cta h3 {
+            margin-top: 0;
+            margin-bottom: 0.75rem;
+        }
+
+        .article-cta p {
+            margin-bottom: 1.25rem;
+        }
+
+        .article-cta-btn {
+            display: inline-flex;
+            align-items: center;
+            gap: 0.5rem;
+            background: var(--accent-cyan);
+            color: #000;
+            padding: 0.625rem 1.25rem;
+            border-radius: 6px;
+            text-decoration: none;
+            font-size: 0.875rem;
+            font-weight: 600;
+            transition: all 0.2s;
+            border-bottom: none;
+        }
+
+        .article-cta-btn:hover {
+            background: #00e6b8;
+            transform: translateY(-1px);
+            border-bottom: none;
+        }
+
+        .breadcrumb {
+            font-size: 0.8rem;
+            color: var(--text-muted);
+            margin-bottom: 1.5rem;
+            font-family: var(--font-mono);
+        }
+
+        .breadcrumb a {
+            color: var(--text-muted);
+            text-decoration: none;
+        }
+
+        .breadcrumb a:hover {
+            color: var(--text-secondary);
+        }
+
+        @media (max-width: 768px) {
+            .article-header {
+                padding: 6rem 0 2rem;
+            }
+
+            .article-body {
+                padding: 2rem 1.5rem 4rem;
+            }
+
+            .article-meta {
+                flex-wrap: wrap;
+                justify-content: center;
+            }
+        }
+    </style>
+</head>
+<body>
+    <!-- Navigation -->
+    <nav class="nav">
+        <div class="nav-container">
+            <a href="/" class="nav-logo">
+                <img src="../assets/logo.svg" alt="atlassian-cli" height="24">
+            </a>
+            <div class="nav-links">
+                <a href="https://github.com/omar16100/atlassian-cli" target="_blank" rel="noopener" class="nav-link">
+                    <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor">
+                        <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"/>
+                    </svg>
+                    GitHub
+                </a>
+                <a href="https://github.com/omar16100/atlassian-cli#readme" target="_blank" rel="noopener" class="nav-link">Docs</a>
+                <a href="/changelog/" class="nav-link">Changelog</a>
+                <a href="/blog/" class="nav-link" style="color: var(--text-primary);">Blog</a>
+                <a href="/install/" class="nav-btn">Install</a>
+            </div>
+        </div>
+    </nav>
+
+    <!-- Article Header -->
+    <header class="article-header">
+        <div class="container">
+            <div class="breadcrumb">
+                <a href="/">Home</a> / <a href="/blog/">Blog</a> / What's New in 0.4
+            </div>
+            <div class="article-meta">
+                <span>June 14, 2026</span>
+                <span class="article-meta-sep">|</span>
+                <span>~5 min read</span>
+                <span class="article-meta-sep">|</span>
+                <span class="article-meta-tag">release</span>
+            </div>
+            <h1 class="article-title">What's New in atlassian-cli 0.4</h1>
+            <p class="article-subtitle">Markdown-to-ADF for Jira, a Confluence Folder API, custom Bitbucket pipelines, and a fix that stops successful writes from looking like errors.</p>
+        </div>
+    </header>
+
+    <!-- Article Body -->
+    <article class="article-body">
+
+        <p>The <strong>0.4</strong> line of <a href="https://github.com/omar16100/atlassian-cli" target="_blank" rel="noopener">atlassian-cli</a> closes several gaps that previously forced people back to raw REST calls. This post covers everything that landed in <strong>0.4.0</strong> and the follow-up <strong>0.4.1</strong>. The full per-version list lives on the <a href="/changelog/">changelog</a>.</p>
+
+        <h2>Upgrade</h2>
+
+        <pre><code><span class="comment"># Homebrew</span>
+brew upgrade atlassian-cli
+
+<span class="comment"># Cargo</span>
+cargo install atlassian-cli
+
+<span class="comment"># Confirm</span>
+atlassian-cli --version</code></pre>
+
+        <p>Prebuilt binaries for Linux and macOS are on the <a href="https://github.com/omar16100/atlassian-cli/releases" target="_blank" rel="noopener">GitHub Releases page</a>.</p>
+
+        <h2>Jira: Markdown turns into real ADF</h2>
+
+        <p>Jira Cloud stores rich text as <a href="https://developer.atlassian.com/cloud/jira/platform/apis/document/structure/" target="_blank" rel="noopener">ADF</a> (Atlassian Document Format). Until now, <code>--description</code> wrapped whatever you passed into a single flat paragraph, so headings, lists, and bold text were lost. In 0.4 the CLI parses Markdown and emits structured ADF for descriptions and comments.</p>
+
+        <pre><code><span class="comment"># A Markdown file with headings, lists, and emphasis...</span>
+atlassian-cli jira issue create \
+  --project <span class="string">DEV</span> \
+  --issue-type <span class="string">Task</span> \
+  --summary <span class="string">"Provision SFTP access"</span> \
+  --description <span class="string">"$(cat notes.md)"</span>
+
+<span class="comment"># ...now renders as headings, bullet lists, bold, links, and code</span>
+<span class="comment"># blocks in Jira instead of one wall of text.</span></code></pre>
+
+        <p>Plain text without any Markdown still becomes a single paragraph, so existing scripts behave exactly as before. Supported nodes include headings, bullet and numbered lists, code blocks, blockquotes, and <code>strong</code>/<code>em</code>/<code>code</code>/<code>link</code> marks. If you need to send raw ADF directly, <code>--field 'description=&lt;json&gt;'</code> still works as the low-level escape hatch.</p>
+
+        <h2>Confluence: a Folder command group</h2>
+
+        <p>The Confluence v2 API treats folders as a distinct content type with their own endpoints, separate from pages. Before 0.4 there was no way to reach them, so folder IDs returned 404 against <code>page get</code>. There is now a dedicated <code>confluence folder</code> group.</p>
+
+        <pre><code><span class="comment"># Fetch folder metadata by ID</span>
+atlassian-cli confluence folder get <span class="string">3309240341</span>
+
+<span class="comment"># Create a folder in a space (the space key is resolved to an ID)</span>
+atlassian-cli confluence folder create \
+  --space <span class="string">DOCS</span> \
+  --title <span class="string">"Architecture"</span> \
+  --parent <span class="string">3302031761</span>
+
+<span class="comment"># Delete (moves the folder to the trash; restorable)</span>
+atlassian-cli confluence folder delete <span class="string">3309240341</span> --force</code></pre>
+
+        <p>The same release also hardened Confluence list parsing (<code>page list</code>, <code>space list</code>, search), so a missing or null field in one row no longer aborts the entire response.</p>
+
+        <h2>Bitbucket: trigger custom pipelines</h2>
+
+        <p>Pipelines defined under <code>definitions &gt; pipelines &gt; custom</code> in <code>bitbucket-pipelines.yml</code> could not be started from the CLI. The <code>pipeline trigger</code> command now takes a <code>--custom-pipeline</code> flag that injects the API selector.</p>
+
+        <pre><code><span class="comment"># Run a named custom pipeline on a branch</span>
+atlassian-cli bitbucket --workspace <span class="string">myteam</span> \
+  pipeline trigger <span class="string">api-service</span> \
+  --ref-name <span class="string">main</span> \
+  --custom-pipeline <span class="string">s3-access-test</span></code></pre>
+
+        <h2>0.4.1: Jira attachments and full comment bodies</h2>
+
+        <p>The 0.4.1 patch closed two more spots that needed raw <code>curl</code>. <code>jira issue get</code> now includes an <code>attachments</code> array (id, filename, MIME type, size, and download URL), and <code>comments list</code> gained a <code>--full</code> flag for the complete body instead of a short preview.</p>
+
+        <pre><code><span class="comment"># Pull attachment metadata straight from issue get</span>
+atlassian-cli jira issue get <span class="string">DEV-428</span> --format json | jq <span class="string">'.attachments'</span>
+
+<span class="comment"># Read full comment bodies, not the 50-character preview</span>
+atlassian-cli jira issue comments list <span class="string">DEV-428</span> --full</code></pre>
+
+        <p>Parsing here is deliberately tolerant: Jira returns the attachment <code>id</code> as a number in some responses and a string in others, and 0.4.1 accepts either, so <code>issue get</code> never fails on an issue that happens to have attachments.</p>
+
+        <h2>The fix worth calling out: HTTP 204 no longer looks like an error</h2>
+
+        <p>This is the one to upgrade for if you automate Jira. Mutating endpoints (<code>issue update</code>, <code>transition</code>, <code>assign</code>, and the Confluence equivalents) return <code>204 No Content</code> on success. The client was trying to parse that empty body as JSON, so the command printed <code>error decoding response body</code> and exited non-zero <em>even though the write succeeded</em>. Scripts that checked the exit code saw failures that were not real.</p>
+
+        <p>0.4 treats an empty 2xx body as success, so exit codes are now reliable across every write command.</p>
+
+        <h2>Housekeeping</h2>
+
+        <ul>
+            <li>Dropped the unmaintained <code>proc-macro-error2</code> transitive dependency (it was flagged by a RustSec advisory) and refreshed the production dependency set.</li>
+            <li>Every release builds and tests on Linux and macOS with a clean security audit before it ships.</li>
+        </ul>
+
+        <h2>Thanks</h2>
+
+        <p>0.4 was shaped by people who filed clear reports and sent pull requests: the HTTP 204 bug, the structured-ADF request, the Folder API ask, the custom-pipeline flag (and its PR), and the attachments and full-comments request all came from the community. Thank you. The per-issue credits are in the <a href="https://github.com/omar16100/atlassian-cli/releases" target="_blank" rel="noopener">release notes</a>.</p>
+
+        <p>For the full list of changes by version, see the <a href="/changelog/">changelog</a>. To go deeper on any command, the <a href="/docs/commands.html">command reference</a> covers the new folder, pipeline, and comment options.</p>
+
+        <div class="article-cta">
+            <h3>Install or upgrade atlassian-cli</h3>
+            <p>One CLI for Jira, Confluence, Bitbucket, and JSM. Open source, MIT licensed.</p>
+            <a href="/install/" class="article-cta-btn">Get Started</a>
+        </div>
+
+    </article>
+
+    <!-- Footer -->
+    <footer class="footer">
+        <div class="container">
+            <div class="footer-content">
+                <div class="footer-left">
+                    <span class="footer-logo">atlassian-cli</span>
+                    <span class="footer-version">v0.4.1</span>
+                </div>
+                <div class="footer-links">
+                    <a href="https://github.com/omar16100/atlassian-cli" target="_blank" rel="noopener">GitHub</a>
+                    <a href="https://github.com/omar16100/atlassian-cli#readme" target="_blank" rel="noopener">Documentation</a>
+                    <a href="/changelog/">Changelog</a>
+                    <a href="https://github.com/omar16100/atlassian-cli/issues" target="_blank" rel="noopener">Issues</a>
+                    <a href="/blog/">Blog</a>
+                </div>
+                <div class="footer-right">
+                    <span class="footer-license">MIT License</span>
+                </div>
+            </div>
+            <div class="footer-credit">
+                Built by <a href="https://omarshabab.com" target="_blank" rel="noopener">Omar Shabab</a>
+            </div>
+            <div class="footer-legal">
+                <p>atlassian-cli is an independent open-source project maintained by <a href="https://omarshabab.com" target="_blank" rel="noopener">Omar Shabab</a>. It is not affiliated with, endorsed by, sponsored by, or maintained by Atlassian.</p>
+                <p>Atlassian, Jira, Confluence, Bitbucket, and Jira Service Management are trademarks of Atlassian Pty Ltd or its affiliates. Product names are used only to identify compatibility.</p>
+            </div>
+        </div>
+    </footer>
+</body>
+</html>

--- a/docs/blog/atlassian-cli-guide.html
+++ b/docs/blog/atlassian-cli-guide.html
@@ -572,7 +572,7 @@ atlassian-cli jira bulk transition \
             <div class="footer-content">
                 <div class="footer-left">
                     <span class="footer-logo">atlassian-cli</span>
-                    <span class="footer-version">v0.3.3</span>
+                    <span class="footer-version">v0.4.1</span>
                 </div>
                 <div class="footer-links">
                     <a href="https://github.com/omar16100/atlassian-cli" target="_blank" rel="noopener">GitHub</a>

--- a/docs/blog/bitbucket-cli-guide.html
+++ b/docs/blog/bitbucket-cli-guide.html
@@ -851,7 +851,7 @@ atlassian-cli bitbucket --workspace myteam commit browse <span class="string">ap
             <div class="footer-content">
                 <div class="footer-left">
                     <span class="footer-logo">atlassian-cli</span>
-                    <span class="footer-version">v0.3.3</span>
+                    <span class="footer-version">v0.4.1</span>
                 </div>
                 <div class="footer-links">
                     <a href="https://github.com/omar16100/atlassian-cli" target="_blank" rel="noopener">GitHub</a>

--- a/docs/blog/confluence-cli-guide.html
+++ b/docs/blog/confluence-cli-guide.html
@@ -783,7 +783,7 @@ atlassian-cli confluence space create \
             <div class="footer-content">
                 <div class="footer-left">
                     <span class="footer-logo">atlassian-cli</span>
-                    <span class="footer-version">v0.3.3</span>
+                    <span class="footer-version">v0.4.1</span>
                 </div>
                 <div class="footer-links">
                     <a href="https://github.com/omar16100/atlassian-cli" target="_blank" rel="noopener">GitHub</a>

--- a/docs/blog/index.html
+++ b/docs/blog/index.html
@@ -233,6 +233,7 @@
                     GitHub
                 </a>
                 <a href="https://github.com/omar16100/atlassian-cli#readme" target="_blank" rel="noopener" class="nav-link">Docs</a>
+                <a href="/changelog/" class="nav-link">Changelog</a>
                 <a href="/blog/" class="nav-link" style="color: var(--text-primary);">Blog</a>
                 <a href="/install/" class="nav-btn">Install</a>
             </div>
@@ -251,6 +252,16 @@
     <section>
         <div class="container">
             <div class="blog-grid">
+
+                <!-- Release announcement -->
+                <a href="/blog/atlassian-cli-0-4-release.html" style="text-decoration: none; color: inherit;">
+                <article class="blog-card">
+                    <span class="blog-card-badge published">Published</span>
+                    <h2 class="blog-card-title">What's New in atlassian-cli 0.4</h2>
+                    <p class="blog-card-desc">Markdown-to-ADF for Jira descriptions and comments, a Confluence v2 Folder API, custom Bitbucket pipeline triggers, attachments in issue get, and a fix for false errors on HTTP 204.</p>
+                    <span class="blog-card-target">release</span>
+                </article>
+                </a>
 
                 <!-- Card 1 -->
                 <a href="/blog/jira-cli-complete-guide.html" style="text-decoration: none; color: inherit;">
@@ -356,7 +367,7 @@
             <div class="footer-content">
                 <div class="footer-left">
                     <span class="footer-logo">atlassian-cli</span>
-                    <span class="footer-version">v0.3.3</span>
+                    <span class="footer-version">v0.4.1</span>
                 </div>
                 <div class="footer-links">
                     <a href="https://github.com/omar16100/atlassian-cli" target="_blank" rel="noopener">GitHub</a>

--- a/docs/blog/jira-bulk-operations.html
+++ b/docs/blog/jira-bulk-operations.html
@@ -663,7 +663,7 @@ echo <span class="string">"Sprint cleanup complete."</span></code></pre>
             <div class="footer-content">
                 <div class="footer-left">
                     <span class="footer-logo">atlassian-cli</span>
-                    <span class="footer-version">v0.3.3</span>
+                    <span class="footer-version">v0.4.1</span>
                 </div>
                 <div class="footer-links">
                     <a href="https://github.com/omar16100/atlassian-cli" target="_blank" rel="noopener">GitHub</a>

--- a/docs/blog/jira-cli-commands-cheat-sheet.html
+++ b/docs/blog/jira-cli-commands-cheat-sheet.html
@@ -875,7 +875,7 @@ atlassian-cli jira bulk export \
             <div class="footer-content">
                 <div class="footer-left">
                     <span class="footer-logo">atlassian-cli</span>
-                    <span class="footer-version">v0.3.3</span>
+                    <span class="footer-version">v0.4.1</span>
                 </div>
                 <div class="footer-links">
                     <a href="https://github.com/omar16100/atlassian-cli" target="_blank" rel="noopener">GitHub</a>

--- a/docs/blog/jira-cli-complete-guide.html
+++ b/docs/blog/jira-cli-complete-guide.html
@@ -830,7 +830,7 @@ jobs:
             <div class="footer-content">
                 <div class="footer-left">
                     <span class="footer-logo">atlassian-cli</span>
-                    <span class="footer-version">v0.3.3</span>
+                    <span class="footer-version">v0.4.1</span>
                 </div>
                 <div class="footer-links">
                     <a href="https://github.com/omar16100/atlassian-cli" target="_blank" rel="noopener">GitHub</a>

--- a/docs/blog/jira-cli-tools-compared.html
+++ b/docs/blog/jira-cli-tools-compared.html
@@ -724,7 +724,7 @@ jira create --project DEV --issuetype Task -s <span class="string">"Summary"</sp
             <div class="footer-content">
                 <div class="footer-left">
                     <span class="footer-logo">atlassian-cli</span>
-                    <span class="footer-version">v0.3.3</span>
+                    <span class="footer-version">v0.4.1</span>
                 </div>
                 <div class="footer-links">
                     <a href="https://github.com/omar16100/atlassian-cli" target="_blank" rel="noopener">GitHub</a>

--- a/docs/blog/jsm-cli-guide.html
+++ b/docs/blog/jsm-cli-guide.html
@@ -754,7 +754,7 @@ echo <span class="string">"Onboarded: $CUSTOMER_NAME ($CUSTOMER_EMAIL)"</span></
             <div class="footer-content">
                 <div class="footer-left">
                     <span class="footer-logo">atlassian-cli</span>
-                    <span class="footer-version">v0.3.3</span>
+                    <span class="footer-version">v0.4.1</span>
                 </div>
                 <div class="footer-links">
                     <a href="https://github.com/omar16100/atlassian-cli" target="_blank" rel="noopener">GitHub</a>

--- a/docs/changelog/index.html
+++ b/docs/changelog/index.html
@@ -1,0 +1,283 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Changelog | atlassian-cli</title>
+    <meta name="description" content="Release changelog for atlassian-cli, the open-source CLI for Jira, Confluence, Bitbucket and JSM Cloud. Features, fixes, and version history by release.">
+    <meta property="og:site_name" content="atlassian-cli">
+    <meta property="og:title" content="atlassian-cli Changelog">
+    <meta property="og:description" content="Features, fixes, and version history for atlassian-cli by release.">
+    <meta property="og:type" content="website">
+    <meta property="og:url" content="https://atlassiancli.com/changelog/">
+    <meta name="twitter:card" content="summary">
+    <meta name="twitter:title" content="atlassian-cli Changelog">
+    <meta name="twitter:description" content="Features, fixes, and version history for atlassian-cli by release.">
+    <link rel="canonical" href="https://atlassiancli.com/changelog/" />
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet">
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-SHR43YZK8C"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      gtag('config', 'G-SHR43YZK8C');
+    </script>
+
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "BreadcrumbList",
+      "itemListElement": [
+        {"@type": "ListItem", "position": 1, "name": "atlassian-cli", "item": "https://atlassiancli.com/"},
+        {"@type": "ListItem", "position": 2, "name": "Changelog", "item": "https://atlassiancli.com/changelog/"}
+      ]
+    }
+    </script>
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "CollectionPage",
+      "name": "atlassian-cli Changelog",
+      "url": "https://atlassiancli.com/changelog/",
+      "description": "Features, fixes, and version history for atlassian-cli by release.",
+      "mainEntity": {
+        "@type": "ItemList",
+        "itemListOrder": "https://schema.org/ItemListOrderDescending",
+        "itemListElement": [
+          {"@type": "ListItem", "position": 1, "name": "v0.4.1", "url": "https://github.com/omar16100/atlassian-cli/releases/tag/v0.4.1"},
+          {"@type": "ListItem", "position": 2, "name": "v0.4.0", "url": "https://github.com/omar16100/atlassian-cli/releases/tag/v0.4.0"},
+          {"@type": "ListItem", "position": 3, "name": "v0.3.3", "url": "https://github.com/omar16100/atlassian-cli/releases/tag/v0.3.3"}
+        ]
+      }
+    }
+    </script>
+
+    <link rel="stylesheet" href="../styles.css">
+
+    <style>
+        .changelog-list {
+            max-width: 760px;
+            margin: 0 auto;
+        }
+
+        .release {
+            padding: 2rem 0;
+            border-bottom: 1px solid var(--border);
+        }
+
+        .release:last-child {
+            border-bottom: none;
+        }
+
+        .release-head {
+            display: flex;
+            align-items: baseline;
+            flex-wrap: wrap;
+            gap: 0.75rem;
+            margin-bottom: 1rem;
+        }
+
+        .release-version {
+            font-size: 1.4rem;
+            font-weight: 600;
+            letter-spacing: -0.02em;
+            font-family: var(--font-mono);
+            color: var(--text-primary);
+        }
+
+        .release-date {
+            font-size: 0.8rem;
+            color: var(--text-muted);
+            font-family: var(--font-mono);
+        }
+
+        .release-link {
+            font-size: 0.8rem;
+            color: var(--accent-cyan);
+            text-decoration: none;
+            border-bottom: 1px solid rgba(0, 212, 170, 0.3);
+            margin-left: auto;
+        }
+
+        .release-link:hover {
+            border-color: var(--accent-cyan);
+        }
+
+        .release ul {
+            color: var(--text-secondary);
+            padding-left: 1.25rem;
+            line-height: 1.8;
+            font-size: 0.95rem;
+            margin: 0;
+        }
+
+        .release li {
+            margin-bottom: 0.45rem;
+        }
+
+        .release li strong {
+            color: var(--text-primary);
+            font-weight: 600;
+        }
+
+        .release code {
+            background: var(--bg-tertiary);
+            padding: 0.1rem 0.35rem;
+            border-radius: 4px;
+            font-family: var(--font-mono);
+            font-size: 0.8rem;
+            color: var(--accent-cyan);
+            border: 1px solid var(--border);
+        }
+
+        .release-tag-label {
+            font-size: 0.65rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            padding: 0.2rem 0.5rem;
+            border-radius: 4px;
+            background: rgba(0, 212, 170, 0.08);
+            color: var(--accent-cyan);
+        }
+
+        .changelog-earlier {
+            margin-top: 1.5rem;
+        }
+
+        .changelog-earlier a {
+            color: var(--accent-cyan);
+            text-decoration: none;
+            border-bottom: 1px solid rgba(0, 212, 170, 0.3);
+            font-family: var(--font-mono);
+            font-size: 0.85rem;
+        }
+
+        .changelog-earlier a:hover { border-color: var(--accent-cyan); }
+    </style>
+</head>
+<body>
+    <!-- Navigation -->
+    <nav class="nav">
+        <div class="nav-container">
+            <a href="/" class="nav-logo">
+                <img src="../assets/logo.svg" alt="atlassian-cli" height="24">
+            </a>
+            <div class="nav-links">
+                <a href="/jira/" class="nav-link">Jira CLI</a>
+                <a href="/confluence/" class="nav-link">Confluence CLI</a>
+                <a href="/bitbucket/" class="nav-link">Bitbucket CLI</a>
+                <a href="/docs/" class="nav-link">Docs</a>
+                <a href="/changelog/" class="nav-link" style="color: var(--text-primary);">Changelog</a>
+                <a href="/blog/" class="nav-link">Blog</a>
+                <a href="https://github.com/omar16100/atlassian-cli" target="_blank" rel="noopener" class="nav-link">
+                    <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor">
+                        <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"/>
+                    </svg>
+                    GitHub
+                </a>
+                <a href="/install/" class="nav-btn">Install</a>
+            </div>
+        </div>
+    </nav>
+
+    <!-- Hero -->
+    <section class="hero" style="padding-top: 6rem;">
+        <div class="hero-container">
+            <div class="hero-badge">Changelog</div>
+            <h1 class="hero-title">atlassian-cli <span class="hero-highlight">Changelog</span></h1>
+            <p class="hero-subtitle">Features, fixes, and version history. Each release is also published on <a href="https://github.com/omar16100/atlassian-cli/releases" target="_blank" rel="noopener" style="color: var(--accent-cyan);">GitHub Releases</a> and <a href="https://crates.io/crates/atlassian-cli" target="_blank" rel="noopener" style="color: var(--accent-cyan);">crates.io</a>.</p>
+        </div>
+    </section>
+
+    <!-- Releases -->
+    <section class="install" style="padding-top: 2rem;">
+        <div class="container">
+            <div class="changelog-list">
+
+                <div class="release">
+                    <div class="release-head">
+                        <span class="release-version">0.4.1</span>
+                        <span class="release-date">June 14, 2026</span>
+                        <a class="release-link" href="https://github.com/omar16100/atlassian-cli/releases/tag/v0.4.1" target="_blank" rel="noopener">GitHub release →</a>
+                    </div>
+                    <ul>
+                        <li><strong>Jira attachments in <code>issue get</code></strong> — the output now includes an <code>attachments</code> array (id, filename, MIME type, size, download URL) in JSON, table, and markdown. Tolerant of Jira returning the attachment id as either a number or a string.</li>
+                        <li><strong><code>jira issue comments list --full</code></strong> — returns the complete comment body instead of the 50-character preview.</li>
+                    </ul>
+                </div>
+
+                <div class="release">
+                    <div class="release-head">
+                        <span class="release-version">0.4.0</span>
+                        <span class="release-date">June 12, 2026</span>
+                        <span class="release-tag-label">features</span>
+                        <a class="release-link" href="https://github.com/omar16100/atlassian-cli/releases/tag/v0.4.0" target="_blank" rel="noopener">GitHub release →</a>
+                    </div>
+                    <ul>
+                        <li><strong>Jira: Markdown to ADF</strong> — <code>issue create</code>/<code>update --description</code> and comment bodies convert Markdown (headings, lists, bold, italic, inline code, links, code blocks) into structured Atlassian Document Format. Plain text still becomes a single paragraph.</li>
+                        <li><strong>Confluence: v2 Folder API</strong> — new <code>confluence folder get | create | delete</code> command group for <code>/wiki/api/v2/folders</code>.</li>
+                        <li><strong>Bitbucket: custom pipelines</strong> — <code>pipeline trigger --custom-pipeline &lt;name&gt;</code> runs a named custom pipeline.</li>
+                        <li><strong>Fix:</strong> mutating commands (<code>issue update</code>, <code>transition</code>, <code>assign</code>, and Confluence equivalents) no longer report false errors on an HTTP 204 No Content response. Exit codes are now reliable.</li>
+                        <li><strong>Hardening:</strong> Confluence list parsing tolerates missing or null fields; dropped the unmaintained <code>proc-macro-error2</code> dependency and refreshed the dependency set.</li>
+                    </ul>
+                </div>
+
+                <div class="release">
+                    <div class="release-head">
+                        <span class="release-version">0.3.3</span>
+                        <span class="release-date">May 2026</span>
+                        <a class="release-link" href="https://github.com/omar16100/atlassian-cli/releases/tag/v0.3.3" target="_blank" rel="noopener">GitHub release →</a>
+                    </div>
+                    <ul>
+                        <li>Jira custom field support via <code>--field</code>, ADF markdown extraction in <code>issue get</code>, and a range of Bitbucket and Confluence improvements across the 0.3 line.</li>
+                    </ul>
+                </div>
+
+                <div class="release">
+                    <div class="release-head">
+                        <span class="release-version">Earlier releases</span>
+                    </div>
+                    <p style="color: var(--text-secondary); font-size: 0.95rem; line-height: 1.8; margin-bottom: 0.5rem;">Full notes for every prior version (0.3.2 back to 0.1.0) are on GitHub:</p>
+                    <div class="changelog-earlier">
+                        <a href="https://github.com/omar16100/atlassian-cli/releases" target="_blank" rel="noopener">View all releases on GitHub →</a>
+                    </div>
+                </div>
+
+            </div>
+        </div>
+    </section>
+
+    <!-- Footer -->
+    <footer class="footer">
+        <div class="container">
+            <div class="footer-content">
+                <div class="footer-left">
+                    <span class="footer-logo">atlassian-cli</span>
+                    <span class="footer-version">v0.4.1</span>
+                </div>
+                <div class="footer-links">
+                    <a href="/jira/">Jira CLI</a>
+                    <a href="/confluence/">Confluence CLI</a>
+                    <a href="/bitbucket/">Bitbucket CLI</a>
+                    <a href="/changelog/">Changelog</a>
+                    <a href="/blog/">Blog</a>
+                    <a href="https://github.com/omar16100/atlassian-cli" target="_blank" rel="noopener">GitHub</a>
+                </div>
+                <div class="footer-right">
+                    <span class="footer-license">MIT License</span>
+                </div>
+            </div>
+            <div class="footer-credit">
+                Built by <a href="https://omarshabab.com" target="_blank" rel="noopener">Omar Shabab</a>
+            </div>
+            <div class="footer-legal">
+                <p>atlassian-cli is an independent open-source project maintained by <a href="https://omarshabab.com" target="_blank" rel="noopener">Omar Shabab</a>. It is not affiliated with, endorsed by, sponsored by, or maintained by Atlassian.</p>
+                <p>Atlassian, Jira, Confluence, Bitbucket, and Jira Service Management are trademarks of Atlassian Pty Ltd or its affiliates. Product names are used only to identify compatibility.</p>
+            </div>
+        </div>
+    </footer>
+</body>
+</html>

--- a/docs/confluence/index.html
+++ b/docs/confluence/index.html
@@ -43,7 +43,7 @@
       "operatingSystem": "macOS, Linux, Windows",
       "url": "https://atlassiancli.com/confluence/",
       "downloadUrl": "https://github.com/omar16100/atlassian-cli/releases",
-      "softwareVersion": "0.3.3",
+      "softwareVersion": "0.4.1",
       "license": "https://opensource.org/licenses/MIT",
       "offers": { "@type": "Offer", "price": "0", "priceCurrency": "USD" },
       "author": { "@type": "Person", "name": "Omar Shabab", "url": "https://omarshabab.com" }
@@ -64,6 +64,7 @@
                 <a href="/confluence/" class="nav-link" aria-current="page">Confluence CLI</a>
                 <a href="/bitbucket/" class="nav-link">Bitbucket CLI</a>
                 <a href="/docs/" class="nav-link">Docs</a>
+                <a href="/changelog/" class="nav-link">Changelog</a>
                 <a href="/blog/" class="nav-link">Blog</a>
                 <a href="https://github.com/omar16100/atlassian-cli" target="_blank" rel="noopener" class="nav-link">
                     <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor">
@@ -406,12 +407,13 @@ atlassian-cli confluence search cql \
             <div class="footer-content">
                 <div class="footer-left">
                     <span class="footer-logo">atlassian-cli</span>
-                    <span class="footer-version">v0.3.3</span>
+                    <span class="footer-version">v0.4.1</span>
                 </div>
                 <div class="footer-links">
                     <a href="https://github.com/omar16100/atlassian-cli" target="_blank" rel="noopener">GitHub</a>
                     <a href="/docs/">Documentation</a>
                     <a href="https://github.com/omar16100/atlassian-cli/issues" target="_blank" rel="noopener">Issues</a>
+                    <a href="/changelog/">Changelog</a>
                     <a href="/blog/">Blog</a>
                 </div>
                 <div class="footer-right">

--- a/docs/docs/auth.html
+++ b/docs/docs/auth.html
@@ -248,7 +248,7 @@ atlassian-cli auth logout --profile work --bitbucket             <span class="co
             <div class="footer-content">
                 <div class="footer-left">
                     <span class="footer-logo">atlassian-cli</span>
-                    <span class="footer-version">v0.3.3</span>
+                    <span class="footer-version">v0.4.1</span>
                 </div>
                 <div class="footer-links">
                     <a href="/install/">Install</a>

--- a/docs/docs/commands.html
+++ b/docs/docs/commands.html
@@ -108,6 +108,7 @@
                 <li><a href="#conf-spaces">Spaces</a></li>
                 <li><a href="#conf-pages">Pages</a></li>
                 <li><a href="#conf-blog">Blog posts</a></li>
+                <li><a href="#conf-folders">Folders</a></li>
                 <li><a href="#conf-attach">Attachments</a></li>
                 <li><a href="#conf-bulk">Bulk operations</a></li>
                 <li><a href="#conf-analytics">Analytics</a></li>
@@ -273,6 +274,11 @@ atlassian-cli confluence blog create --space DEV --title <span class="string">"S
 atlassian-cli confluence blog update --id 67890 --title <span class="string">"Updated Recap"</span>
 atlassian-cli confluence blog delete --id 67890</code></pre>
 
+            <h2 id="conf-folders">Confluence — Folders <span style="font-size:0.7rem;color:var(--accent-cyan);">new in 0.4</span></h2>
+            <pre class="code-block"><code>atlassian-cli confluence folder get 3309240341
+atlassian-cli confluence folder create --space DOCS --title <span class="string">"Architecture"</span> --parent 3302031761
+atlassian-cli confluence folder delete 3309240341 --force</code></pre>
+
             <h2 id="conf-attach">Confluence — Attachments</h2>
             <pre class="code-block"><code>atlassian-cli confluence attachment list --page-id 12345
 atlassian-cli confluence attachment get --id 11111
@@ -329,6 +335,10 @@ atlassian-cli bitbucket --workspace myteam project delete PROJ --force</code></p
             <h2 id="bb-pipelines">Bitbucket — Pipelines</h2>
             <pre class="code-block"><code>atlassian-cli bitbucket --workspace myteam pipeline list api-service
 atlassian-cli bitbucket --workspace myteam pipeline trigger api-service --ref-name main
+
+<span class="comment"># Trigger a named custom pipeline from bitbucket-pipelines.yml (new in 0.4)</span>
+atlassian-cli bitbucket --workspace myteam pipeline trigger api-service --ref-name main --custom-pipeline s3-access-test
+
 atlassian-cli bitbucket --workspace myteam pipeline stop api-service {uuid}</code></pre>
 
             <h2 id="bb-webhooks">Bitbucket — Webhooks &amp; SSH keys</h2>
@@ -424,7 +434,7 @@ atlassian-cli jsm feedback delete SD-123</code></pre>
             <div class="footer-content">
                 <div class="footer-left">
                     <span class="footer-logo">atlassian-cli</span>
-                    <span class="footer-version">v0.3.3</span>
+                    <span class="footer-version">v0.4.1</span>
                 </div>
                 <div class="footer-links">
                     <a href="/install/">Install</a>

--- a/docs/docs/index.html
+++ b/docs/docs/index.html
@@ -54,6 +54,7 @@
                 <a href="/confluence/" class="nav-link">Confluence CLI</a>
                 <a href="/bitbucket/" class="nav-link">Bitbucket CLI</a>
                 <a href="/docs/" class="nav-link" aria-current="page">Docs</a>
+                <a href="/changelog/" class="nav-link">Changelog</a>
                 <a href="/blog/" class="nav-link">Blog</a>
                 <a href="https://github.com/omar16100/atlassian-cli" target="_blank" rel="noopener" class="nav-link">GitHub</a>
                 <a href="/install/" class="nav-btn">Install</a>
@@ -85,6 +86,10 @@
                 <a href="/install/" class="docs-card">
                     <h3>Install</h3>
                     <p>Install via Homebrew, Cargo, or a prebuilt binary. macOS, Linux, and Windows supported. Verify, configure, and run your first command.</p>
+                </a>
+                <a href="/changelog/" class="docs-card">
+                    <h3>Changelog</h3>
+                    <p>Features, fixes, and version history by release, from the latest 0.4 line back through earlier versions.</p>
                 </a>
             </div>
 
@@ -136,7 +141,7 @@
             <div class="footer-content">
                 <div class="footer-left">
                     <span class="footer-logo">atlassian-cli</span>
-                    <span class="footer-version">v0.3.3</span>
+                    <span class="footer-version">v0.4.1</span>
                 </div>
                 <div class="footer-links">
                     <a href="/install/">Install</a>
@@ -144,6 +149,7 @@
                     <a href="/jira/">Jira CLI</a>
                     <a href="/confluence/">Confluence CLI</a>
                     <a href="/bitbucket/">Bitbucket CLI</a>
+                    <a href="/changelog/">Changelog</a>
                     <a href="/blog/">Blog</a>
                     <a href="https://github.com/omar16100/atlassian-cli" target="_blank" rel="noopener">GitHub</a>
                 </div>

--- a/docs/index.html
+++ b/docs/index.html
@@ -54,7 +54,7 @@
       "operatingSystem": "macOS, Linux, Windows",
       "url": "https://atlassiancli.com/",
       "downloadUrl": "https://github.com/omar16100/atlassian-cli/releases",
-      "softwareVersion": "0.3.3",
+      "softwareVersion": "0.4.1",
       "license": "https://opensource.org/licenses/MIT",
       "isAccessibleForFree": true,
       "offers": {
@@ -135,6 +135,7 @@
                 <a href="/confluence/" class="nav-link">Confluence CLI</a>
                 <a href="/bitbucket/" class="nav-link">Bitbucket CLI</a>
                 <a href="/docs/" class="nav-link">Docs</a>
+                <a href="/changelog/" class="nav-link">Changelog</a>
                 <a href="/blog/" class="nav-link">Blog</a>
                 <a href="https://github.com/omar16100/atlassian-cli" target="_blank" rel="noopener" class="nav-link">
                     <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor">
@@ -548,7 +549,7 @@ atlassian-cli auth test --bitbucket --profile <span class="string">bb-ci</span><
             <div class="footer-content">
                 <div class="footer-left">
                     <span class="footer-logo">atlassian-cli</span>
-                    <span class="footer-version">v0.3.3</span>
+                    <span class="footer-version">v0.4.1</span>
                 </div>
                 <div class="footer-links">
                     <a href="/install/">Install</a>
@@ -559,6 +560,7 @@ atlassian-cli auth test --bitbucket --profile <span class="string">bb-ci</span><
                     <a href="/confluence/">Confluence CLI</a>
                     <a href="/bitbucket/">Bitbucket CLI</a>
                     <a href="/jsm/">JSM CLI</a>
+                    <a href="/changelog/">Changelog</a>
                     <a href="/blog/">Blog</a>
                     <a href="/runbooks/confluence-markdown-sync.html">Markdown &rarr; Confluence runbook</a>
                     <a href="/runbooks/jira-bulk-transition.html">Jira bulk transition runbook</a>

--- a/docs/install/index.html
+++ b/docs/install/index.html
@@ -66,6 +66,7 @@
                 <a href="/confluence/" class="nav-link">Confluence CLI</a>
                 <a href="/bitbucket/" class="nav-link">Bitbucket CLI</a>
                 <a href="/docs/" class="nav-link">Docs</a>
+                <a href="/changelog/" class="nav-link">Changelog</a>
                 <a href="/blog/" class="nav-link">Blog</a>
                 <a href="https://github.com/omar16100/atlassian-cli" target="_blank" rel="noopener" class="nav-link">
                     <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor">
@@ -109,7 +110,7 @@
             <h2 class="section-title" id="verify" style="margin-top: 3rem;">Verify the install</h2>
             <pre class="code-block"><code>atlassian-cli --version
 atlassian-cli --help</code></pre>
-            <p>You should see the version number (currently <strong>0.3.3</strong>) and the top-level help text.</p>
+            <p>You should see the version number (currently <strong>0.4.1</strong>) and the top-level help text.</p>
 
             <h2 class="section-title" id="first-run" style="margin-top: 3rem;">First-time setup</h2>
             <p class="section-subtitle">Configure a profile once, reuse it everywhere.</p>
@@ -145,13 +146,14 @@ atlassian-cli auth test --profile <span class="string">work</span></code></pre>
             <div class="footer-content">
                 <div class="footer-left">
                     <span class="footer-logo">atlassian-cli</span>
-                    <span class="footer-version">v0.3.3</span>
+                    <span class="footer-version">v0.4.1</span>
                 </div>
                 <div class="footer-links">
                     <a href="/jira/">Jira CLI</a>
                     <a href="/confluence/">Confluence CLI</a>
                     <a href="/bitbucket/">Bitbucket CLI</a>
                     <a href="/jsm/">JSM CLI</a>
+                    <a href="/changelog/">Changelog</a>
                     <a href="/blog/">Blog</a>
                     <a href="https://github.com/omar16100/atlassian-cli" target="_blank" rel="noopener">GitHub</a>
                 </div>

--- a/docs/jira/index.html
+++ b/docs/jira/index.html
@@ -43,7 +43,7 @@
       "operatingSystem": "macOS, Linux, Windows",
       "url": "https://atlassiancli.com/jira/",
       "downloadUrl": "https://github.com/omar16100/atlassian-cli/releases",
-      "softwareVersion": "0.3.3",
+      "softwareVersion": "0.4.1",
       "license": "https://opensource.org/licenses/MIT",
       "offers": { "@type": "Offer", "price": "0", "priceCurrency": "USD" },
       "author": { "@type": "Person", "name": "Omar Shabab", "url": "https://omarshabab.com" }
@@ -64,6 +64,7 @@
                 <a href="/confluence/" class="nav-link">Confluence CLI</a>
                 <a href="/bitbucket/" class="nav-link">Bitbucket CLI</a>
                 <a href="/docs/" class="nav-link">Docs</a>
+                <a href="/changelog/" class="nav-link">Changelog</a>
                 <a href="/blog/" class="nav-link">Blog</a>
                 <a href="https://github.com/omar16100/atlassian-cli" target="_blank" rel="noopener" class="nav-link">
                     <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor">
@@ -394,12 +395,13 @@ atlassian-cli jira search \
             <div class="footer-content">
                 <div class="footer-left">
                     <span class="footer-logo">atlassian-cli</span>
-                    <span class="footer-version">v0.3.3</span>
+                    <span class="footer-version">v0.4.1</span>
                 </div>
                 <div class="footer-links">
                     <a href="https://github.com/omar16100/atlassian-cli" target="_blank" rel="noopener">GitHub</a>
                     <a href="/docs/">Documentation</a>
                     <a href="https://github.com/omar16100/atlassian-cli/issues" target="_blank" rel="noopener">Issues</a>
+                    <a href="/changelog/">Changelog</a>
                     <a href="/blog/">Blog</a>
                 </div>
                 <div class="footer-right">

--- a/docs/jsm/index.html
+++ b/docs/jsm/index.html
@@ -52,7 +52,7 @@
       "operatingSystem": "macOS, Linux, Windows",
       "url": "https://atlassiancli.com/jsm/",
       "downloadUrl": "https://github.com/omar16100/atlassian-cli/releases",
-      "softwareVersion": "0.3.3",
+      "softwareVersion": "0.4.1",
       "license": "https://opensource.org/licenses/MIT",
       "offers": {
         "@type": "Offer",
@@ -174,6 +174,7 @@
                 <a href="/confluence/" class="nav-link">Confluence CLI</a>
                 <a href="/bitbucket/" class="nav-link">Bitbucket CLI</a>
                 <a href="/docs/" class="nav-link">Docs</a>
+                <a href="/changelog/" class="nav-link">Changelog</a>
                 <a href="/blog/" class="nav-link">Blog</a>
                 <a href="https://github.com/omar16100/atlassian-cli" target="_blank" rel="noopener" class="nav-link">
                     <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor">
@@ -428,12 +429,13 @@ atlassian-cli jsm request list --limit 5</code></pre>
             <div class="footer-content">
                 <div class="footer-left">
                     <span class="footer-logo">atlassian-cli</span>
-                    <span class="footer-version">v0.3.3</span>
+                    <span class="footer-version">v0.4.1</span>
                 </div>
                 <div class="footer-links">
                     <a href="https://github.com/omar16100/atlassian-cli" target="_blank" rel="noopener">GitHub</a>
                     <a href="/docs/">Documentation</a>
                     <a href="https://github.com/omar16100/atlassian-cli/issues" target="_blank" rel="noopener">Issues</a>
+                    <a href="/changelog/">Changelog</a>
                     <a href="/blog/">Blog</a>
                 </div>
                 <div class="footer-right">

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -50,12 +50,14 @@ atlassian-cli is an independent open-source project. It is NOT affiliated with, 
 ## Links
 
 - Website: https://atlassiancli.com
+- Changelog: https://atlassiancli.com/changelog/
 - GitHub: https://github.com/omar16100/atlassian-cli
 - Crates.io: https://crates.io/crates/atlassian-cli
 
 ## Version
 
-Current version: 0.3.3
+Current version: 0.4.1
+Recent (0.4): Markdown-to-ADF for Jira descriptions and comments, a Confluence v2 Folder API command group (confluence folder get/create/delete), Bitbucket custom pipeline triggers (pipeline trigger --custom-pipeline), Jira attachments in issue get, comments list --full, and a fix for false errors on HTTP 204 responses.
 License: MIT
 Author: Omar Shabab (https://omarshabab.com)
 

--- a/docs/runbooks/bitbucket-branch-cleanup.html
+++ b/docs/runbooks/bitbucket-branch-cleanup.html
@@ -578,7 +578,7 @@ main <span class="string">"$@"</span></code></pre>
             <div class="footer-content">
                 <div class="footer-left">
                     <span class="footer-logo">atlassian-cli</span>
-                    <span class="footer-version">v0.3.3</span>
+                    <span class="footer-version">v0.4.1</span>
                 </div>
                 <div class="footer-links">
                     <a href="https://github.com/omar16100/atlassian-cli" target="_blank" rel="noopener">GitHub</a>

--- a/docs/runbooks/bitbucket-pr-automation.html
+++ b/docs/runbooks/bitbucket-pr-automation.html
@@ -644,7 +644,7 @@ main <span class="string">"$@"</span></code></pre>
             <div class="footer-content">
                 <div class="footer-left">
                     <span class="footer-logo">atlassian-cli</span>
-                    <span class="footer-version">v0.3.3</span>
+                    <span class="footer-version">v0.4.1</span>
                 </div>
                 <div class="footer-links">
                     <a href="https://github.com/omar16100/atlassian-cli" target="_blank" rel="noopener">GitHub</a>

--- a/docs/runbooks/bitbucket-repo-audit.html
+++ b/docs/runbooks/bitbucket-repo-audit.html
@@ -522,7 +522,7 @@ main</code></pre>
             <div class="footer-content">
                 <div class="footer-left">
                     <span class="footer-logo">atlassian-cli</span>
-                    <span class="footer-version">v0.3.3</span>
+                    <span class="footer-version">v0.4.1</span>
                 </div>
                 <div class="footer-links">
                     <a href="https://github.com/omar16100/atlassian-cli" target="_blank" rel="noopener">GitHub</a>

--- a/docs/runbooks/confluence-backup.html
+++ b/docs/runbooks/confluence-backup.html
@@ -539,7 +539,7 @@ main</code></pre>
             <div class="footer-content">
                 <div class="footer-left">
                     <span class="footer-logo">atlassian-cli</span>
-                    <span class="footer-version">v0.3.3</span>
+                    <span class="footer-version">v0.4.1</span>
                 </div>
                 <div class="footer-links">
                     <a href="https://github.com/omar16100/atlassian-cli" target="_blank" rel="noopener">GitHub</a>

--- a/docs/runbooks/confluence-bulk-cleanup.html
+++ b/docs/runbooks/confluence-bulk-cleanup.html
@@ -569,7 +569,7 @@ main <span class="string">"$@"</span></code></pre>
             <div class="footer-content">
                 <div class="footer-left">
                     <span class="footer-logo">atlassian-cli</span>
-                    <span class="footer-version">v0.3.3</span>
+                    <span class="footer-version">v0.4.1</span>
                 </div>
                 <div class="footer-links">
                     <a href="https://github.com/omar16100/atlassian-cli" target="_blank" rel="noopener">GitHub</a>

--- a/docs/runbooks/confluence-markdown-sync.html
+++ b/docs/runbooks/confluence-markdown-sync.html
@@ -644,7 +644,7 @@ jobs:
             <div class="footer-content">
                 <div class="footer-left">
                     <span class="footer-logo">atlassian-cli</span>
-                    <span class="footer-version">v0.3.3</span>
+                    <span class="footer-version">v0.4.1</span>
                 </div>
                 <div class="footer-links">
                     <a href="https://github.com/omar16100/atlassian-cli" target="_blank" rel="noopener">GitHub</a>

--- a/docs/runbooks/confluence-space-report.html
+++ b/docs/runbooks/confluence-space-report.html
@@ -559,7 +559,7 @@ main</code></pre>
             <div class="footer-content">
                 <div class="footer-left">
                     <span class="footer-logo">atlassian-cli</span>
-                    <span class="footer-version">v0.3.3</span>
+                    <span class="footer-version">v0.4.1</span>
                 </div>
                 <div class="footer-links">
                     <a href="https://github.com/omar16100/atlassian-cli" target="_blank" rel="noopener">GitHub</a>

--- a/docs/runbooks/jira-bulk-transition.html
+++ b/docs/runbooks/jira-bulk-transition.html
@@ -529,7 +529,7 @@ main <span class="string">"$@"</span></code></pre>
             <div class="footer-content">
                 <div class="footer-left">
                     <span class="footer-logo">atlassian-cli</span>
-                    <span class="footer-version">v0.3.3</span>
+                    <span class="footer-version">v0.4.1</span>
                 </div>
                 <div class="footer-links">
                     <a href="https://github.com/omar16100/atlassian-cli" target="_blank" rel="noopener">GitHub</a>

--- a/docs/runbooks/jira-project-cleanup.html
+++ b/docs/runbooks/jira-project-cleanup.html
@@ -598,7 +598,7 @@ main <span class="string">"$@"</span></code></pre>
             <div class="footer-content">
                 <div class="footer-left">
                     <span class="footer-logo">atlassian-cli</span>
-                    <span class="footer-version">v0.3.3</span>
+                    <span class="footer-version">v0.4.1</span>
                 </div>
                 <div class="footer-links">
                     <a href="https://github.com/omar16100/atlassian-cli" target="_blank" rel="noopener">GitHub</a>

--- a/docs/runbooks/jira-sprint-report.html
+++ b/docs/runbooks/jira-sprint-report.html
@@ -575,7 +575,7 @@ main <span class="string">"$@"</span></code></pre>
             <div class="footer-content">
                 <div class="footer-left">
                     <span class="footer-logo">atlassian-cli</span>
-                    <span class="footer-version">v0.3.3</span>
+                    <span class="footer-version">v0.4.1</span>
                 </div>
                 <div class="footer-links">
                     <a href="https://github.com/omar16100/atlassian-cli" target="_blank" rel="noopener">GitHub</a>

--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -3,7 +3,7 @@
   <!-- Homepage -->
   <url>
     <loc>https://atlassiancli.com/</loc>
-    <lastmod>2026-05-16</lastmod>
+    <lastmod>2026-06-14</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>
@@ -11,25 +11,25 @@
   <!-- Product Pages -->
   <url>
     <loc>https://atlassiancli.com/jira/</loc>
-    <lastmod>2026-05-16</lastmod>
+    <lastmod>2026-06-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://atlassiancli.com/confluence/</loc>
-    <lastmod>2026-05-16</lastmod>
+    <lastmod>2026-06-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://atlassiancli.com/bitbucket/</loc>
-    <lastmod>2026-05-16</lastmod>
+    <lastmod>2026-06-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://atlassiancli.com/jsm/</loc>
-    <lastmod>2026-05-16</lastmod>
+    <lastmod>2026-06-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.9</priority>
   </url>
@@ -37,7 +37,7 @@
   <!-- Install hub -->
   <url>
     <loc>https://atlassiancli.com/install/</loc>
-    <lastmod>2026-05-16</lastmod>
+    <lastmod>2026-06-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.9</priority>
   </url>
@@ -45,19 +45,19 @@
   <!-- First-party docs -->
   <url>
     <loc>https://atlassiancli.com/docs/</loc>
-    <lastmod>2026-05-16</lastmod>
+    <lastmod>2026-06-14</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://atlassiancli.com/docs/auth.html</loc>
-    <lastmod>2026-05-16</lastmod>
+    <lastmod>2026-06-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://atlassiancli.com/docs/commands.html</loc>
-    <lastmod>2026-05-16</lastmod>
+    <lastmod>2026-06-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
@@ -65,63 +65,77 @@
   <!-- About / independence -->
   <url>
     <loc>https://atlassiancli.com/about/</loc>
-    <lastmod>2026-05-16</lastmod>
+    <lastmod>2026-06-14</lastmod>
     <changefreq>yearly</changefreq>
     <priority>0.5</priority>
+  </url>
+
+  <!-- Changelog -->
+  <url>
+    <loc>https://atlassiancli.com/changelog/</loc>
+    <lastmod>2026-06-14</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.7</priority>
   </url>
 
   <!-- Blog -->
   <url>
     <loc>https://atlassiancli.com/blog/</loc>
-    <lastmod>2026-05-16</lastmod>
+    <lastmod>2026-06-14</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
+    <loc>https://atlassiancli.com/blog/atlassian-cli-0-4-release.html</loc>
+    <lastmod>2026-06-14</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
     <loc>https://atlassiancli.com/blog/jira-cli-complete-guide.html</loc>
-    <lastmod>2026-05-16</lastmod>
+    <lastmod>2026-06-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://atlassiancli.com/blog/atlassian-cli-guide.html</loc>
-    <lastmod>2026-05-16</lastmod>
+    <lastmod>2026-06-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://atlassiancli.com/blog/jira-cli-tools-compared.html</loc>
-    <lastmod>2026-05-16</lastmod>
+    <lastmod>2026-06-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://atlassiancli.com/blog/confluence-cli-guide.html</loc>
-    <lastmod>2026-05-16</lastmod>
+    <lastmod>2026-06-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://atlassiancli.com/blog/jira-cli-commands-cheat-sheet.html</loc>
-    <lastmod>2026-05-16</lastmod>
+    <lastmod>2026-06-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://atlassiancli.com/blog/jira-bulk-operations.html</loc>
-    <lastmod>2026-05-16</lastmod>
+    <lastmod>2026-06-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://atlassiancli.com/blog/bitbucket-cli-guide.html</loc>
-    <lastmod>2026-05-16</lastmod>
+    <lastmod>2026-06-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://atlassiancli.com/blog/jsm-cli-guide.html</loc>
-    <lastmod>2026-05-16</lastmod>
+    <lastmod>2026-06-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
@@ -129,19 +143,19 @@
   <!-- Runbooks: Jira -->
   <url>
     <loc>https://atlassiancli.com/runbooks/jira-bulk-transition.html</loc>
-    <lastmod>2026-05-16</lastmod>
+    <lastmod>2026-06-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://atlassiancli.com/runbooks/jira-project-cleanup.html</loc>
-    <lastmod>2026-05-16</lastmod>
+    <lastmod>2026-06-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://atlassiancli.com/runbooks/jira-sprint-report.html</loc>
-    <lastmod>2026-05-16</lastmod>
+    <lastmod>2026-06-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
@@ -149,25 +163,25 @@
   <!-- Runbooks: Confluence -->
   <url>
     <loc>https://atlassiancli.com/runbooks/confluence-backup.html</loc>
-    <lastmod>2026-05-16</lastmod>
+    <lastmod>2026-06-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://atlassiancli.com/runbooks/confluence-bulk-cleanup.html</loc>
-    <lastmod>2026-05-16</lastmod>
+    <lastmod>2026-06-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://atlassiancli.com/runbooks/confluence-markdown-sync.html</loc>
-    <lastmod>2026-05-16</lastmod>
+    <lastmod>2026-06-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://atlassiancli.com/runbooks/confluence-space-report.html</loc>
-    <lastmod>2026-05-16</lastmod>
+    <lastmod>2026-06-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
@@ -175,19 +189,19 @@
   <!-- Runbooks: Bitbucket -->
   <url>
     <loc>https://atlassiancli.com/runbooks/bitbucket-branch-cleanup.html</loc>
-    <lastmod>2026-05-16</lastmod>
+    <lastmod>2026-06-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://atlassiancli.com/runbooks/bitbucket-pr-automation.html</loc>
-    <lastmod>2026-05-16</lastmod>
+    <lastmod>2026-06-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://atlassiancli.com/runbooks/bitbucket-repo-audit.html</loc>
-    <lastmod>2026-05-16</lastmod>
+    <lastmod>2026-06-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
@@ -195,7 +209,7 @@
   <!-- AI Context -->
   <url>
     <loc>https://atlassiancli.com/llms.txt</loc>
-    <lastmod>2026-05-16</lastmod>
+    <lastmod>2026-06-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.3</priority>
   </url>

--- a/todo.md
+++ b/todo.md
@@ -1,5 +1,33 @@
 # Changes Made
 
+## 2026-06-14 — Site: 0.4 release announcement + changelog page
+
+### Context
+v0.4.0 and v0.4.1 shipped but were never announced on atlassiancli.com, the site had
+no changelog page, and every page still showed v0.3.3.
+
+### Change (docs/ only — the published site)
+- New `docs/blog/atlassian-cli-0-4-release.html` — combined "What's New in 0.4" post
+  (markdown->ADF, Confluence folders, custom pipelines, 0.4.1 attachments + comments
+  --full, the HTTP 204 fix). Mirrors the existing blog template; correct `jira issue`
+  command syntax.
+- New `docs/changelog/index.html` (`/changelog/`) — version blocks (0.4.1, 0.4.0, 0.3.3,
+  link-out for older), CollectionPage/ItemList JSON-LD.
+- Wired in: new blog card on `/blog/`, sitemap entries + refreshed lastmods, Changelog
+  link in the nav + footer of all primary pages and a docs landing card, `/changelog/`
+  added to llms.txt.
+- Version sweep 0.3.3 -> 0.4.1 across all 31 footer badges + 5 softwareVersion schemas +
+  llms.txt + install prose (exact strings only; historical versions in the changelog
+  preserved).
+- `docs/docs/commands.html`: added Confluence Folders section + `--custom-pipeline`.
+- Verified: all pages serve 200 locally, sitemap valid (xmllint), all JSON-LD parses,
+  canonical == og:url.
+
+### Known follow-up (not done here)
+`docs/docs/commands.html` and the older `docs/blog/*.html` use a stale `jira <verb>`
+syntax (e.g. `jira create`) that should be `jira issue <verb>`. Out of scope for the
+announcement; worth a separate cleanup pass.
+
 ## 2026-06-12 — Confluence v2 Folder API command group (#49)
 
 ### Context


### PR DESCRIPTION
Announces the 0.4 release on atlassiancli.com and adds a changelog page. The site was still showing v0.3.3 and had never announced 0.4.0 or 0.4.1.

## New pages
- **`/blog/atlassian-cli-0-4-release.html`** — "What's New in atlassian-cli 0.4", a combined post covering 0.4.0 (markdown to ADF, Confluence Folder API, custom Bitbucket pipelines, the HTTP 204 fix) and 0.4.1 (attachments in `issue get`, `comments list --full`). Uses the existing blog template and correct `jira issue …` command syntax.
- **`/changelog/`** — version blocks (0.4.1, 0.4.0, 0.3.3, link-out for older), `CollectionPage`/`ItemList` JSON-LD, linked from nav + footers + a docs card + the sitemap + llms.txt.

## Wiring & housekeeping
- New blog card on `/blog/`; sitemap entries for both pages + refreshed `lastmod`s.
- Documented the new commands in `/docs/commands.html` (Confluence Folders, `pipeline trigger --custom-pipeline`).
- Swept the stale `v0.3.3` strings to `v0.4.1` across all footer badges, `softwareVersion` schemas, `llms.txt`, and install copy (exact strings only — historical versions on the changelog are preserved).

## Verification
All pages serve 200 locally, `sitemap.xml` validates (xmllint), every JSON-LD block parses, canonical == og:url, and the new pages use the correct `jira issue` syntax.

## Known follow-up (not in this PR)
`/docs/commands.html` and the older `/blog/*` posts use a stale `jira <verb>` syntax (e.g. `jira create`) that should be `jira issue <verb>`. Worth a separate cleanup pass.

Note: codex review of the final content was attempted but its usage limit was hit; the checks above were run manually instead.