### PR TITLE
docs(site): correct CLI command syntax site-wide

### DIFF
--- a/docs/blog/atlassian-cli-guide.html
+++ b/docs/blog/atlassian-cli-guide.html
@@ -405,12 +405,12 @@ atlassian-cli auth list</code></pre>
         <p>The <a href="/jira/">Jira subcommand</a> covers the full issue lifecycle plus project administration. Here are the commands you will reach for most often.</p>
 
         <pre><code><span class="comment"># Search issues with JQL</span>
-atlassian-cli jira search \
+atlassian-cli jira issue search \
   --jql <span class="string">"project = DEV AND status = 'In Progress'"</span> \
   --limit 20
 
 <span class="comment"># Create an issue</span>
-atlassian-cli jira create \
+atlassian-cli jira issue create \
   --project <span class="string">DEV</span> \
   --issue-type <span class="string">Task</span> \
   --summary <span class="string">"Automate deployment pipeline"</span>
@@ -434,7 +434,7 @@ atlassian-cli confluence search cql \
 
 <span class="comment"># Bulk export an entire space to JSON</span>
 atlassian-cli confluence bulk export \
-  --space <span class="string">DOCS</span> \
+  --cql <span class="string">"space = DOCS"</span> \
   --output <span class="string">backup.json</span> \
   --format json
 
@@ -469,7 +469,7 @@ atlassian-cli bitbucket --workspace <span class="string">myteam</span> bulk dele
         <p>The <a href="/jsm/">JSM subcommand</a> handles service desk listing, request management, and customer operations.</p>
 
         <pre><code><span class="comment"># List service desks</span>
-atlassian-cli jsm servicedesk list --limit 10
+atlassian-cli jsm service-desk list --limit 10
 
 <span class="comment"># Get a specific request</span>
 atlassian-cli jsm request get <span class="string">SD-123</span></code></pre>
@@ -498,12 +498,12 @@ atlassian-cli jira bulk export \
 
         <pre><code><span class="comment"># Export full space to JSON</span>
 atlassian-cli confluence bulk export \
-  --space <span class="string">DOCS</span> \
+  --cql <span class="string">"space = DOCS"</span> \
   --output <span class="string">/backups/confluence-$(date +%Y%m%d).json</span> \
   --format json
 
 <span class="comment"># Check space stats</span>
-atlassian-cli confluence analytics space-stats --space <span class="string">DOCS</span></code></pre>
+atlassian-cli confluence analytics space-stats <span class="string">DOCS</span></code></pre>
 
         <h3>Release Automation</h3>
 

--- a/docs/blog/confluence-cli-guide.html
+++ b/docs/blog/confluence-cli-guide.html
@@ -535,7 +535,7 @@ atlassian-cli confluence space add-permission <span class="string">DEV</span> \
 atlassian-cli confluence page list --space <span class="string">DEV</span> --limit <span class="string">25</span>
 
 <span class="comment"># Get a page by ID</span>
-atlassian-cli confluence page get --id <span class="string">12345</span>
+atlassian-cli confluence page get <span class="string">12345</span>
 
 <span class="comment"># Create a new page</span>
 atlassian-cli confluence page create \
@@ -544,53 +544,55 @@ atlassian-cli confluence page create \
   --body <span class="string">"&lt;p&gt;Page content here&lt;/p&gt;"</span>
 
 <span class="comment"># Update a page title</span>
-atlassian-cli confluence page update --id <span class="string">12345</span> \
+atlassian-cli confluence page update <span class="string">12345</span> \
   --title <span class="string">"Updated Title"</span>
 
 <span class="comment"># Delete a page</span>
-atlassian-cli confluence page delete --id <span class="string">12345</span></code></pre>
+atlassian-cli confluence page delete <span class="string">12345</span></code></pre>
 
         <h3>Labels and comments</h3>
 
         <pre><code><span class="comment"># Add a label to a page</span>
-atlassian-cli confluence page add-label --id <span class="string">12345</span> \
-  --label <span class="string">documentation</span>
+atlassian-cli confluence page add-label <span class="string">12345</span> <span class="string">documentation</span>
 
 <span class="comment"># Remove a label</span>
-atlassian-cli confluence page remove-label --id <span class="string">12345</span> \
-  --label <span class="string">outdated</span>
+atlassian-cli confluence page remove-label <span class="string">12345</span> <span class="string">outdated</span>
 
 <span class="comment"># List comments on a page</span>
-atlassian-cli confluence page comments --id <span class="string">12345</span>
+atlassian-cli confluence page comments <span class="string">12345</span>
 
 <span class="comment"># Add a comment</span>
-atlassian-cli confluence page add-comment --id <span class="string">12345</span> \
-  --body <span class="string">"Reviewed and approved."</span></code></pre>
+atlassian-cli confluence page add-comment <span class="string">12345</span> \
+  <span class="string">"Reviewed and approved."</span></code></pre>
 
         <h3>Versions and restrictions</h3>
 
         <pre><code><span class="comment"># View page version history</span>
-atlassian-cli confluence page versions --id <span class="string">12345</span>
+atlassian-cli confluence page versions <span class="string">12345</span>
 
 <span class="comment"># View page restrictions</span>
-atlassian-cli confluence page get-restrictions --id <span class="string">12345</span>
+atlassian-cli confluence page get-restrictions <span class="string">12345</span>
 
 <span class="comment"># Restrict editing to a specific user</span>
-atlassian-cli confluence page add-restriction --id <span class="string">12345</span> \
+atlassian-cli confluence page add-restriction \
   --operation <span class="string">update</span> \
-  --user <span class="string">user@example.com</span>
+  --subject-type <span class="string">user</span> \
+  --subject-id <span class="string">user@example.com</span> \
+  <span class="string">12345</span>
 
 <span class="comment"># Remove a restriction</span>
-atlassian-cli confluence page remove-restriction --id <span class="string">12345</span> \
+atlassian-cli confluence page remove-restriction \
   --operation <span class="string">update</span> \
-  --user <span class="string">user@example.com</span></code></pre>
+  --subject-type <span class="string">user</span> \
+  --subject-id <span class="string">user@example.com</span> \
+  <span class="string">12345</span></code></pre>
 
         <h3>Attachments</h3>
 
         <p>Upload, download, and manage file attachments on any page:</p>
 
         <pre><code><span class="comment"># List attachments on a page</span>
-atlassian-cli confluence attachment list --page-id <span class="string">12345</span>
+atlassian-cli confluence attachment list <span class="string">12345</span>
 
 <span class="comment"># Upload a file</span>
 atlassian-cli confluence attachment upload \
@@ -603,10 +605,10 @@ atlassian-cli confluence attachment download \
   --output <span class="string">./download.png</span>
 
 <span class="comment"># Get attachment metadata</span>
-atlassian-cli confluence attachment get --id <span class="string">11111</span>
+atlassian-cli confluence attachment get <span class="string">11111</span>
 
 <span class="comment"># Delete an attachment</span>
-atlassian-cli confluence attachment delete --id <span class="string">11111</span></code></pre>
+atlassian-cli confluence attachment delete <span class="string">11111</span></code></pre>
 
         <h3>Blog posts</h3>
 
@@ -622,11 +624,11 @@ atlassian-cli confluence blog create \
   --body <span class="string">"&lt;p&gt;Summary of sprint work&lt;/p&gt;"</span>
 
 <span class="comment"># Update a blog post</span>
-atlassian-cli confluence blog update --id <span class="string">67890</span> \
+atlassian-cli confluence blog update <span class="string">67890</span> \
   --title <span class="string">"Updated Recap"</span>
 
 <span class="comment"># Delete a blog post</span>
-atlassian-cli confluence blog delete --id <span class="string">67890</span></code></pre>
+atlassian-cli confluence blog delete <span class="string">67890</span></code></pre>
 
         <!-- Section 6: Bulk Export & Backup -->
         <h2 id="bulk-export-backup">Bulk Export &amp; Backup</h2>
@@ -637,7 +639,7 @@ atlassian-cli confluence blog delete --id <span class="string">67890</span></cod
 
         <pre><code><span class="comment"># Export all pages from a space to JSON</span>
 atlassian-cli confluence bulk export \
-  --space <span class="string">DEV</span> \
+  --cql <span class="string">"space = DEV"</span> \
   --output <span class="string">backup.json</span> \
   --format <span class="string">json</span>
 
@@ -663,10 +665,10 @@ atlassian-cli confluence bulk add-labels \
         <h3>Bulk delete</h3>
 
         <pre><code><span class="comment"># Preview: delete all pages in a space (dry-run first!)</span>
-atlassian-cli confluence bulk delete --space <span class="string">OLD</span> --dry-run
+atlassian-cli confluence bulk delete --cql <span class="string">"space = OLD"</span> --dry-run
 
 <span class="comment"># Execute the deletion</span>
-atlassian-cli confluence bulk delete --space <span class="string">OLD</span></code></pre>
+atlassian-cli confluence bulk delete --cql <span class="string">"space = OLD"</span></code></pre>
 
         <h3>Backup script example</h3>
 
@@ -682,7 +684,7 @@ mkdir -p "$BACKUP_DIR"
 for SPACE in DEV OPS DOCS ENG; do
   echo "Exporting space: $SPACE"
   atlassian-cli confluence bulk export \
-    --space "$SPACE" \
+    --cql "space = $SPACE" \
     --output "$BACKUP_DIR/${SPACE}.json" \
     --format json
 done
@@ -709,7 +711,7 @@ atlassian-cli confluence page create \
   --body <span class="string">"$BODY"</span>
 
 <span class="comment"># Or update an existing page</span>
-atlassian-cli confluence page update --id <span class="string">12345</span> \
+atlassian-cli confluence page update <span class="string">12345</span> \
   --title <span class="string">"Project README"</span></code></pre>
 
         <p>In CI/CD, this pattern runs on every merge to <code>main</code>, keeping your Confluence documentation automatically in sync with the codebase. The same approach works for publishing ADRs (Architecture Decision Records), runbooks, or any documentation that lives in Git.</p>
@@ -731,10 +733,10 @@ atlassian-cli confluence search cql \
   --format json
 
 <span class="comment"># Space-level analytics</span>
-atlassian-cli confluence analytics space-stats --space <span class="string">DEV</span>
+atlassian-cli confluence analytics space-stats <span class="string">DEV</span>
 
 <span class="comment"># Page view stats for a specific page</span>
-atlassian-cli confluence analytics page-views --id <span class="string">12345</span> \
+atlassian-cli confluence analytics page-views <span class="string">12345</span> \
   --from <span class="string">2025-01-01</span></code></pre>
 
         <h3>Migration between spaces</h3>
@@ -743,7 +745,7 @@ atlassian-cli confluence analytics page-views --id <span class="string">12345</s
 
         <pre><code><span class="comment"># Export source space</span>
 atlassian-cli confluence bulk export \
-  --space <span class="string">OLD_DOCS</span> \
+  --cql <span class="string">"space = OLD_DOCS"</span> \
   --output <span class="string">migration.json</span> \
   --format <span class="string">json</span>
 

--- a/docs/blog/jira-bulk-operations.html
+++ b/docs/blog/jira-bulk-operations.html
@@ -519,7 +519,7 @@ atlassian-cli jira bulk export \
         <p>You can also pipe search results directly into other tools without writing to a file:</p>
 
         <pre><code><span class="comment"># Count bugs by priority using jq</span>
-atlassian-cli jira search \
+atlassian-cli jira issue search \
   --jql <span class="string">"project = DEV AND type = Bug"</span> \
   --format json | jq <span class="string">'group_by(.fields.priority.name) | map({priority: .[0].fields.priority.name, count: length})'</span></code></pre>
 
@@ -608,7 +608,7 @@ atlassian-cli jira bulk export \
   --format <span class="string">json</span>
 
 <span class="comment"># Step 4: Count remaining open issues</span>
-atlassian-cli jira search \
+atlassian-cli jira issue search \
   --profile "$PROFILE" \
   --jql <span class="string">"project = $PROJECT AND status != Done AND status != Closed"</span> \
   --format json | jq <span class="string">'. | length'</span>

--- a/docs/blog/jira-cli-commands-cheat-sheet.html
+++ b/docs/blog/jira-cli-commands-cheat-sheet.html
@@ -513,29 +513,29 @@
                 </thead>
                 <tbody>
                     <tr>
-                        <td><code>jira search</code></td>
+                        <td><code>jira issue search</code></td>
                         <td>Search with any JQL query</td>
-                        <td><code>atlassian-cli jira search --jql "project = DEV order by created desc" --limit 5</code></td>
+                        <td><code>atlassian-cli jira issue search --jql "project = DEV order by created desc" --limit 5</code></td>
                     </tr>
                     <tr>
-                        <td><code>jira search</code></td>
+                        <td><code>jira issue search</code></td>
                         <td>Open bugs assigned to you</td>
-                        <td><code>atlassian-cli jira search --jql "assignee = currentUser() AND type = Bug AND status != Done"</code></td>
+                        <td><code>atlassian-cli jira issue search --jql "assignee = currentUser() AND type = Bug AND status != Done"</code></td>
                     </tr>
                     <tr>
-                        <td><code>jira search</code></td>
+                        <td><code>jira issue search</code></td>
                         <td>Unassigned issues in sprint</td>
-                        <td><code>atlassian-cli jira search --jql "sprint in openSprints() AND assignee is EMPTY"</code></td>
+                        <td><code>atlassian-cli jira issue search --jql "sprint in openSprints() AND assignee is EMPTY"</code></td>
                     </tr>
                     <tr>
-                        <td><code>jira search</code></td>
+                        <td><code>jira issue search</code></td>
                         <td>Recently updated issues</td>
-                        <td><code>atlassian-cli jira search --jql "project = DEV AND updated >= -1d" --format json</code></td>
+                        <td><code>atlassian-cli jira issue search --jql "project = DEV AND updated >= -1d" --format json</code></td>
                     </tr>
                     <tr>
-                        <td><code>jira search</code></td>
+                        <td><code>jira issue search</code></td>
                         <td>Issues by label</td>
-                        <td><code>atlassian-cli jira search --jql "project = DEV AND labels = 'urgent'"</code></td>
+                        <td><code>atlassian-cli jira issue search --jql "project = DEV AND labels = 'urgent'"</code></td>
                     </tr>
                 </tbody>
             </table>
@@ -557,34 +557,34 @@
                 </thead>
                 <tbody>
                     <tr>
-                        <td><code>jira get</code></td>
+                        <td><code>jira issue get</code></td>
                         <td>Get issue details</td>
-                        <td><code>atlassian-cli jira get DEV-123</code></td>
+                        <td><code>atlassian-cli jira issue get DEV-123</code></td>
                     </tr>
                     <tr>
-                        <td><code>jira get</code></td>
+                        <td><code>jira issue get</code></td>
                         <td>Get issue as JSON</td>
-                        <td><code>atlassian-cli jira get DEV-123 --format json</code></td>
+                        <td><code>atlassian-cli jira issue get DEV-123 --format json</code></td>
                     </tr>
                     <tr>
-                        <td><code>jira create</code></td>
+                        <td><code>jira issue create</code></td>
                         <td>Create a bug</td>
-                        <td><code>atlassian-cli jira create --project DEV --issue-type Bug --summary "Login page returns 500"</code></td>
+                        <td><code>atlassian-cli jira issue create --project DEV --issue-type Bug --summary "Login page returns 500"</code></td>
                     </tr>
                     <tr>
-                        <td><code>jira create</code></td>
+                        <td><code>jira issue create</code></td>
                         <td>Create a task</td>
-                        <td><code>atlassian-cli jira create --project DEV --issue-type Task --summary "Update API docs"</code></td>
+                        <td><code>atlassian-cli jira issue create --project DEV --issue-type Task --summary "Update API docs"</code></td>
                     </tr>
                     <tr>
-                        <td><code>jira update</code></td>
+                        <td><code>jira issue update</code></td>
                         <td>Update issue summary</td>
-                        <td><code>atlassian-cli jira update DEV-123 --summary "Updated summary"</code></td>
+                        <td><code>atlassian-cli jira issue update DEV-123 --summary "Updated summary"</code></td>
                     </tr>
                     <tr>
-                        <td><code>jira delete</code></td>
+                        <td><code>jira issue delete</code></td>
                         <td>Delete an issue</td>
-                        <td><code>atlassian-cli jira delete DEV-123</code></td>
+                        <td><code>atlassian-cli jira issue delete DEV-123</code></td>
                     </tr>
                 </tbody>
             </table>
@@ -606,19 +606,19 @@
                 </thead>
                 <tbody>
                     <tr>
-                        <td><code>jira transition</code></td>
+                        <td><code>jira issue transition</code></td>
                         <td>Move to "In Progress"</td>
-                        <td><code>atlassian-cli jira transition DEV-123 --transition "In Progress"</code></td>
+                        <td><code>atlassian-cli jira issue transition DEV-123 --transition "In Progress"</code></td>
                     </tr>
                     <tr>
-                        <td><code>jira transition</code></td>
+                        <td><code>jira issue transition</code></td>
                         <td>Move to "Done"</td>
-                        <td><code>atlassian-cli jira transition DEV-123 --transition "Done"</code></td>
+                        <td><code>atlassian-cli jira issue transition DEV-123 --transition "Done"</code></td>
                     </tr>
                     <tr>
-                        <td><code>jira assign</code></td>
+                        <td><code>jira issue assign</code></td>
                         <td>Assign to a user</td>
-                        <td><code>atlassian-cli jira assign DEV-123 --assignee user@example.com</code></td>
+                        <td><code>atlassian-cli jira issue assign DEV-123 --assignee user@example.com</code></td>
                     </tr>
                 </tbody>
             </table>
@@ -742,42 +742,42 @@
                     <tr>
                         <td><code>jira workflows export</code></td>
                         <td>Export a workflow definition</td>
-                        <td><code>atlassian-cli jira workflows export --name "Software Simplified Workflow"</code></td>
+                        <td><code>atlassian-cli jira workflows export "Software Simplified Workflow"</code></td>
                     </tr>
                     <tr>
                         <td><code>jira components list</code></td>
                         <td>List project components</td>
-                        <td><code>atlassian-cli jira components list --project DEV</code></td>
+                        <td><code>atlassian-cli jira components list DEV</code></td>
                     </tr>
                     <tr>
                         <td><code>jira versions list</code></td>
                         <td>List project versions</td>
-                        <td><code>atlassian-cli jira versions list --project DEV</code></td>
+                        <td><code>atlassian-cli jira versions list DEV</code></td>
                     </tr>
                     <tr>
                         <td><code>jira roles list</code></td>
                         <td>List project roles</td>
-                        <td><code>atlassian-cli jira roles list --project DEV</code></td>
+                        <td><code>atlassian-cli jira roles list DEV</code></td>
                     </tr>
                     <tr>
                         <td><code>jira roles get</code></td>
                         <td>Get role details</td>
-                        <td><code>atlassian-cli jira roles get --project DEV --role-id 10002</code></td>
+                        <td><code>atlassian-cli jira roles get DEV 10002</code></td>
                     </tr>
                     <tr>
                         <td><code>jira roles actors</code></td>
                         <td>List role actors (members)</td>
-                        <td><code>atlassian-cli jira roles actors --project DEV --role-id 10002</code></td>
+                        <td><code>atlassian-cli jira roles actors DEV 10002</code></td>
                     </tr>
                     <tr>
                         <td><code>jira roles add-actor</code></td>
                         <td>Add a user to a role</td>
-                        <td><code>atlassian-cli jira roles add-actor --project DEV --role-id 10002 --user user@example.com</code></td>
+                        <td><code>atlassian-cli jira roles add-actor DEV 10002 --user user@example.com</code></td>
                     </tr>
                     <tr>
                         <td><code>jira roles remove-actor</code></td>
                         <td>Remove a user from a role</td>
-                        <td><code>atlassian-cli jira roles remove-actor --project DEV --role-id 10002 --user user@example.com</code></td>
+                        <td><code>atlassian-cli jira roles remove-actor DEV 10002 --user user@example.com</code></td>
                     </tr>
                 </tbody>
             </table>
@@ -830,12 +830,12 @@
         <p>Examples of piping output for scripting:</p>
 
         <pre><code><span class="comment"># Get issue keys and pipe to another command</span>
-atlassian-cli jira search \
+atlassian-cli jira issue search \
   --jql <span class="string">"project = DEV AND status = Open"</span> \
   --format quiet
 
 <span class="comment"># Export to JSON and filter with jq</span>
-atlassian-cli jira search \
+atlassian-cli jira issue search \
   --jql <span class="string">"project = DEV"</span> \
   --format json | jq <span class="string">'.[].key'</span>
 

--- a/docs/blog/jira-cli-complete-guide.html
+++ b/docs/blog/jira-cli-complete-guide.html
@@ -513,7 +513,7 @@
         <!-- Section 1: What is a Jira CLI? -->
         <h2 id="what-is-jira-cli">What is a Jira CLI?</h2>
 
-        <p>A <strong>Jira CLI</strong> (command-line interface) is a tool that lets you interact with Jira directly from your terminal. Instead of clicking through the Jira web UI to search issues, create tickets, or transition workflows, you run commands like <code>atlassian-cli jira search --jql "project = DEV"</code> and get results instantly.</p>
+        <p>A <strong>Jira CLI</strong> (command-line interface) is a tool that lets you interact with Jira directly from your terminal. Instead of clicking through the Jira web UI to search issues, create tickets, or transition workflows, you run commands like <code>atlassian-cli jira issue search --jql "project = DEV"</code> and get results instantly.</p>
 
         <p>Jira CLI tools are used by <strong>DevOps engineers</strong> who need to automate ticket creation in pipelines, <strong>platform engineers</strong> managing thousands of issues across projects, and <strong>Jira admins</strong> performing bulk operations that would take hours in the browser. If your workflow involves Jira and a terminal, a Jira CLI eliminates context-switching and unlocks automation that the web UI simply cannot provide.</p>
 
@@ -637,7 +637,7 @@ atlassian-cli auth list</code></pre>
 
         <p>Search for recent issues in a project:</p>
 
-        <pre><code>atlassian-cli jira search --jql <span class="string">"project = DEV order by created desc"</span> --limit <span class="string">5</span></code></pre>
+        <pre><code>atlassian-cli jira issue search --jql <span class="string">"project = DEV order by created desc"</span> --limit <span class="string">5</span></code></pre>
 
         <p>This returns a formatted table by default. Add <code>--format json</code> for machine-readable output, or <code>--format csv</code> for spreadsheets.</p>
 
@@ -646,19 +646,19 @@ atlassian-cli auth list</code></pre>
 
         <h3>Search issues with JQL</h3>
 
-        <p>JQL (Jira Query Language) is the most powerful way to find issues. The <code>jira search</code> command accepts any valid JQL string:</p>
+        <p>JQL (Jira Query Language) is the most powerful way to find issues. The <code>jira issue search</code> command accepts any valid JQL string:</p>
 
         <pre><code><span class="comment"># Open bugs assigned to you</span>
-atlassian-cli jira search \
+atlassian-cli jira issue search \
   --jql <span class="string">"assignee = currentUser() AND type = Bug AND status != Done"</span>
 
 <span class="comment"># Issues updated in the last 24 hours</span>
-atlassian-cli jira search \
+atlassian-cli jira issue search \
   --jql <span class="string">"project = DEV AND updated >= -1d"</span> \
   --format json
 
 <span class="comment"># Unassigned issues in the current sprint</span>
-atlassian-cli jira search \
+atlassian-cli jira issue search \
   --jql <span class="string">"sprint in openSprints() AND assignee is EMPTY"</span></code></pre>
 
         <h3>Create an issue</h3>
@@ -666,13 +666,13 @@ atlassian-cli jira search \
         <p>Create issues directly from the terminal. Specify the project, issue type, and summary as flags:</p>
 
         <pre><code><span class="comment"># Create a bug</span>
-atlassian-cli jira create \
+atlassian-cli jira issue create \
   --project <span class="string">DEV</span> \
   --issue-type <span class="string">Bug</span> \
   --summary <span class="string">"Login page returns 500 on invalid email"</span>
 
 <span class="comment"># Create a task</span>
-atlassian-cli jira create \
+atlassian-cli jira issue create \
   --project <span class="string">DEV</span> \
   --issue-type <span class="string">Task</span> \
   --summary <span class="string">"Update API documentation for v2 endpoints"</span></code></pre>
@@ -682,23 +682,23 @@ atlassian-cli jira create \
         <p>Move issues through your workflow and update fields without opening the browser:</p>
 
         <pre><code><span class="comment"># Transition an issue to "In Progress"</span>
-atlassian-cli jira transition <span class="string">DEV-123</span> --transition <span class="string">"In Progress"</span>
+atlassian-cli jira issue transition <span class="string">DEV-123</span> --transition <span class="string">"In Progress"</span>
 
 <span class="comment"># Update the summary</span>
-atlassian-cli jira update <span class="string">DEV-123</span> --summary <span class="string">"Updated: Login page error handling"</span>
+atlassian-cli jira issue update <span class="string">DEV-123</span> --summary <span class="string">"Updated: Login page error handling"</span>
 
 <span class="comment"># Assign to a team member</span>
-atlassian-cli jira assign <span class="string">DEV-123</span> --assignee <span class="string">user@example.com</span></code></pre>
+atlassian-cli jira issue assign <span class="string">DEV-123</span> --assignee <span class="string">user@example.com</span></code></pre>
 
         <h3>View issue details</h3>
 
         <p>Get full details on any issue including status, assignee, and description:</p>
 
         <pre><code><span class="comment"># Get issue details</span>
-atlassian-cli jira get <span class="string">DEV-123</span>
+atlassian-cli jira issue get <span class="string">DEV-123</span>
 
 <span class="comment"># JSON output for scripting</span>
-atlassian-cli jira get <span class="string">DEV-123</span> --format json</code></pre>
+atlassian-cli jira issue get <span class="string">DEV-123</span> --format json</code></pre>
 
         <h3>Projects, fields, and workflows</h3>
 

--- a/docs/blog/jira-cli-tools-compared.html
+++ b/docs/blog/jira-cli-tools-compared.html
@@ -595,7 +595,7 @@
         <p><strong>Jira strengths:</strong> Full issue CRUD, JQL search, bulk operations (transition, assign, label, export, import) with concurrent execution and dry-run mode, automation rules management, webhook CRUD, audit log access, project role management, custom fields, and workflow export.</p>
 
         <pre><code><span class="comment"># Search with JQL, output as JSON</span>
-atlassian-cli jira search \
+atlassian-cli jira issue search \
   --jql <span class="string">"project = DEV AND status = 'In Progress'"</span> \
   --format json
 
@@ -641,7 +641,7 @@ jira list --query <span class="string">"project = DEV"</span>
 jira view DEV-123
 
 <span class="comment"># Create an issue</span>
-jira create --project DEV --issuetype Task -s <span class="string">"Summary"</span></code></pre>
+jira issue create --project DEV --issuetype Task -s <span class="string">"Summary"</span></code></pre>
 
         <p><strong>Strengths:</strong> Lightweight, simple, template-based output customization, works with Jira Server.</p>
 

--- a/docs/blog/jsm-cli-guide.html
+++ b/docs/blog/jsm-cli-guide.html
@@ -502,19 +502,19 @@ atlassian-cli auth test --profile <span class="string">work</span></code></pre>
         <!-- Section 3: Service Desk Operations -->
         <h2 id="service-desk-ops">Service Desk Operations</h2>
 
-        <p>The <code>jsm servicedesk</code> subcommand lets you list and inspect your service desks. This is typically the first thing you run to discover desk IDs, which are required for filtering requests and managing customers.</p>
+        <p>The <code>jsm service-desk</code> subcommand lets you list and inspect your service desks. This is typically the first thing you run to discover desk IDs, which are required for filtering requests and managing customers.</p>
 
         <pre><code><span class="comment"># List all service desks</span>
-atlassian-cli jsm servicedesk list --limit <span class="string">10</span>
+atlassian-cli jsm service-desk list --limit <span class="string">10</span>
 
 <span class="comment"># Get details for a specific service desk (by ID)</span>
-atlassian-cli jsm servicedesk get <span class="string">1</span>
+atlassian-cli jsm service-desk get <span class="string">1</span>
 
 <span class="comment"># List organizations attached to a service desk</span>
-atlassian-cli jsm servicedesk organizations <span class="string">1</span>
+atlassian-cli jsm service-desk organizations <span class="string">1</span>
 
 <span class="comment"># List customers of a service desk</span>
-atlassian-cli jsm servicedesk customers <span class="string">1</span> --limit <span class="string">25</span></code></pre>
+atlassian-cli jsm service-desk customers <span class="string">1</span> --limit <span class="string">25</span></code></pre>
 
         <p>The <code>servicedesk get</code> command returns the desk name, project key, project ID, and portal URL. Use <code>--format json</code> to pipe the output into <code>jq</code> or downstream scripts.</p>
 
@@ -571,7 +571,7 @@ atlassian-cli jsm request comments <span class="string">SD-123</span></code></pr
         <!-- Section 5: Customer Management -->
         <h2 id="customer-management">Customer Management</h2>
 
-        <p>The <code>jsm customer</code> and <code>jsm servicedesk</code> subcommands handle customer lifecycle: creating portal users, adding them to service desks, and managing organizations.</p>
+        <p>The <code>jsm customer</code> and <code>jsm service-desk</code> subcommands handle customer lifecycle: creating portal users, adding them to service desks, and managing organizations.</p>
 
         <pre><code><span class="comment"># Create a new customer</span>
 atlassian-cli jsm customer create \
@@ -579,11 +579,11 @@ atlassian-cli jsm customer create \
   --display-name <span class="string">"Jane Doe"</span>
 
 <span class="comment"># Add customer to a service desk</span>
-atlassian-cli jsm servicedesk add-customer <span class="string">1</span> \
+atlassian-cli jsm service-desk add-customer <span class="string">1</span> \
   --account-id <span class="string">5b10a2844c20165700ede21g</span>
 
 <span class="comment"># Remove customer from a service desk</span>
-atlassian-cli jsm servicedesk remove-customer <span class="string">1</span> \
+atlassian-cli jsm service-desk remove-customer <span class="string">1</span> \
   --account-id <span class="string">5b10a2844c20165700ede21g</span>
 
 <span class="comment"># List organizations</span>
@@ -597,7 +597,7 @@ atlassian-cli jsm organization add-user <span class="string">5</span> \
   --account-id <span class="string">5b10a2844c20165700ede21g</span>
 
 <span class="comment"># Add organization to a service desk</span>
-atlassian-cli jsm servicedesk add-organization <span class="string">1</span> --org-id <span class="string">5</span></code></pre>
+atlassian-cli jsm service-desk add-organization <span class="string">1</span> --org-id <span class="string">5</span></code></pre>
 
         <p>This enables fully scripted customer onboarding: create the customer, assign them to an organization, and grant access to the appropriate service desk -- all in a single shell script.</p>
 
@@ -703,9 +703,9 @@ atlassian-cli jsm organization add-user <span class="string">5</span> \
   --account-id <span class="string">"$ACCOUNT_ID"</span>
 
 <span class="comment"># Grant access to IT Help Desk and HR Service Desk</span>
-atlassian-cli jsm servicedesk add-customer <span class="string">1</span> \
+atlassian-cli jsm service-desk add-customer <span class="string">1</span> \
   --account-id <span class="string">"$ACCOUNT_ID"</span>
-atlassian-cli jsm servicedesk add-customer <span class="string">2</span> \
+atlassian-cli jsm service-desk add-customer <span class="string">2</span> \
   --account-id <span class="string">"$ACCOUNT_ID"</span>
 
 echo <span class="string">"Onboarded: $CUSTOMER_NAME ($CUSTOMER_EMAIL)"</span></code></pre>

--- a/docs/confluence/index.html
+++ b/docs/confluence/index.html
@@ -339,13 +339,13 @@ atlassian-cli confluence search cql \
             <h2 class="section-title">Frequently asked questions</h2>
             <div style="margin-top: 2rem; color: var(--text-secondary); line-height: 1.7;">
                 <h3 style="color: var(--text-primary); margin-top: 1.5rem;">How do I back up a Confluence space?</h3>
-                <p>Run <code>atlassian-cli confluence bulk export --space DEV --format json --output backup.json</code>. That pulls every page in the space into one JSON file you can store in S3 / Git / anywhere. Attach the matching attachments via the <code>attachment</code> group. End-to-end script in the <a href="/runbooks/confluence-backup.html">Confluence backup runbook</a>.</p>
+                <p>Run <code>atlassian-cli confluence bulk export --cql "space = DEV" --format json --output backup.json</code>. That pulls every page in the space into one JSON file you can store in S3 / Git / anywhere. Attach the matching attachments via the <code>attachment</code> group. End-to-end script in the <a href="/runbooks/confluence-backup.html">Confluence backup runbook</a>.</p>
 
                 <h3 style="color: var(--text-primary); margin-top: 1.5rem;">Can I sync Markdown files into Confluence?</h3>
                 <p>Yes. The usual pattern is: render Markdown to Confluence storage format with pandoc, then pass the HTML to <code>confluence page create</code> or <code>confluence page update</code>. The <a href="/runbooks/confluence-markdown-sync.html">markdown → Confluence runbook</a> contains a production-ready script with idempotent upserts keyed by page title.</p>
 
                 <h3 style="color: var(--text-primary); margin-top: 1.5rem;">What is CQL and how do I use it?</h3>
-                <p>Confluence Query Language. Same shape as Jira's JQL but with Confluence-specific fields: <code>space = DEV</code>, <code>type = page</code>, <code>label = onboarding</code>, <code>lastmodified &gt;= "2026-01-01"</code>. Combine clauses with <code>AND</code> / <code>OR</code>. The CLI accepts CQL directly: <code>atlassian-cli confluence search cql --cql "space = DEV AND type = page AND label = onboarding"</code>.</p>
+                <p>Confluence Query Language. Same shape as Jira's JQL but with Confluence-specific fields: <code>space = DEV</code>, <code>type = page</code>, <code>label = onboarding</code>, <code>lastmodified &gt;= "2026-01-01"</code>. Combine clauses with <code>AND</code> / <code>OR</code>. The CLI accepts CQL directly: <code>atlassian-cli confluence search cql "space = DEV AND type = page AND label = onboarding"</code>.</p>
 
                 <h3 style="color: var(--text-primary); margin-top: 1.5rem;">Is there dry-run mode for bulk operations?</h3>
                 <p>Yes. Every <code>confluence bulk</code> subcommand accepts <code>--dry-run</code>, which prints the exact list of pages that <em>would</em> be affected without calling the mutating API. Run it first, sanity-check the list, then re-run without the flag.</p>

--- a/docs/docs/auth.html
+++ b/docs/docs/auth.html
@@ -136,7 +136,7 @@
 
             <h3>3. Verify</h3>
             <pre class="code-block"><code>atlassian-cli auth test --profile work
-atlassian-cli jira search --jql <span class="string">"project = DEV"</span> --limit 1</code></pre>
+atlassian-cli jira issue search --jql <span class="string">"project = DEV"</span> --limit 1</code></pre>
 
             <h2 id="bitbucket">Bitbucket authentication</h2>
             <p>Bitbucket Cloud supports two token flows. Both are current — pick the one that matches your account model.</p>
@@ -179,8 +179,8 @@ atlassian-cli bitbucket whoami --profile bb-ci</code></pre>
             <pre class="code-block"><code>atlassian-cli auth list</code></pre>
 
             <h3>Switch profile per command</h3>
-            <pre class="code-block"><code>atlassian-cli jira search --profile personal --jql <span class="string">"project = PERS"</span>
-atlassian-cli jira search --profile work --jql <span class="string">"project = DEV"</span></code></pre>
+            <pre class="code-block"><code>atlassian-cli jira issue search --profile personal --jql <span class="string">"project = PERS"</span>
+atlassian-cli jira issue search --profile work --jql <span class="string">"project = DEV"</span></code></pre>
 
             <h3>Change the default</h3>
             <p>Re-run <code>auth login</code> with <code>--default</code> for the profile you want to promote:</p>
@@ -214,7 +214,7 @@ atlassian-cli auth logout --profile work --bitbucket             <span class="co
     atlassian-cli auth login \
       --profile ci --base-url https://mycompany.atlassian.net \
       --email bot@mycompany.com --default
-    atlassian-cli jira search --jql <span class="string">"project = REL"</span> --format json</code></pre>
+    atlassian-cli jira issue search --jql <span class="string">"project = REL"</span> --format json</code></pre>
             <p>See the <a href="/runbooks/jira-bulk-transition.html">Jira bulk transition runbook</a> for a full CI example.</p>
 
             <h2 id="storage">Where credentials are stored</h2>

--- a/docs/docs/commands.html
+++ b/docs/docs/commands.html
@@ -158,16 +158,16 @@
 
             <h2 id="output-formats">Output formats</h2>
             <pre class="code-block"><code><span class="comment"># Human-readable table (default)</span>
-atlassian-cli jira search --jql <span class="string">"project = DEV"</span>
+atlassian-cli jira issue search --jql <span class="string">"project = DEV"</span>
 
 <span class="comment"># Machine-readable JSON — pipe to jq, feed other tools</span>
-atlassian-cli jira search --jql <span class="string">"project = DEV"</span> --format json | jq <span class="string">'.[].key'</span>
+atlassian-cli jira issue search --jql <span class="string">"project = DEV"</span> --format json | jq <span class="string">'.[].key'</span>
 
 <span class="comment"># CSV — open in a spreadsheet</span>
-atlassian-cli jira search --jql <span class="string">"project = DEV"</span> --format csv --output issues.csv
+atlassian-cli jira issue search --jql <span class="string">"project = DEV"</span> --format csv --output issues.csv
 
 <span class="comment"># YAML — good for configuration diffs</span>
-atlassian-cli jira workflows export --name <span class="string">"Software Simplified Workflow"</span> --format yaml
+atlassian-cli jira workflows export <span class="string">"Software Simplified Workflow"</span> --format yaml
 
 <span class="comment"># Quiet — exit code only; useful in CI gating</span>
 atlassian-cli auth test --profile prod --format quiet &amp;&amp; echo OK</code></pre>
@@ -185,37 +185,37 @@ atlassian-cli auth logout --profile old --bitbucket        <span class="comment"
             <div class="note">To change which profile is default, re-run <code>auth login --default</code> for the profile you want as default, or edit <code>default_profile:</code> in <code>~/.atlassian-cli/config.yaml</code> directly.</div>
 
             <h2 id="jira-issues">Jira — Issues</h2>
-            <pre class="code-block"><code>atlassian-cli jira search --jql <span class="string">"project = DEV order by created desc"</span> --limit 5
-atlassian-cli jira get DEV-123
-atlassian-cli jira create --project DEV --issue-type Task --summary <span class="string">"Test task"</span>
+            <pre class="code-block"><code>atlassian-cli jira issue search --jql <span class="string">"project = DEV order by created desc"</span> --limit 5
+atlassian-cli jira issue get DEV-123
+atlassian-cli jira issue create --project DEV --issue-type Task --summary <span class="string">"Test task"</span>
 
 <span class="comment"># Custom fields — discover IDs via `jira fields list`</span>
-atlassian-cli jira create --project DEV --issue-type Task --summary <span class="string">"cf test"</span> \
+atlassian-cli jira issue create --project DEV --issue-type Task --summary <span class="string">"cf test"</span> \
   --field <span class="string">'customfield_10010={"value":"Internal"}'</span> \
   --field <span class="string">'customfield_10020={"formula":"a=b"}'</span>
 
-atlassian-cli jira update DEV-123 --summary <span class="string">"Updated summary"</span>
-atlassian-cli jira transition DEV-123 --transition <span class="string">"In Progress"</span>
-atlassian-cli jira assign DEV-123 --assignee user@example.com
-atlassian-cli jira delete DEV-123</code></pre>
+atlassian-cli jira issue update DEV-123 --summary <span class="string">"Updated summary"</span>
+atlassian-cli jira issue transition DEV-123 --transition <span class="string">"In Progress"</span>
+atlassian-cli jira issue assign DEV-123 --assignee user@example.com
+atlassian-cli jira issue delete DEV-123</code></pre>
 
             <h2 id="jira-projects">Jira — Projects</h2>
             <pre class="code-block"><code>atlassian-cli jira project list
 atlassian-cli jira project get DEV
-atlassian-cli jira components list --project DEV
-atlassian-cli jira versions list --project DEV</code></pre>
+atlassian-cli jira components list DEV
+atlassian-cli jira versions list DEV</code></pre>
 
             <h2 id="jira-roles">Jira — Roles</h2>
-            <pre class="code-block"><code>atlassian-cli jira roles list --project DEV
-atlassian-cli jira roles get --project DEV --role-id 10002
-atlassian-cli jira roles actors --project DEV --role-id 10002
-atlassian-cli jira roles add-actor --project DEV --role-id 10002 --user user@example.com
-atlassian-cli jira roles remove-actor --project DEV --role-id 10002 --user user@example.com</code></pre>
+            <pre class="code-block"><code>atlassian-cli jira roles list DEV
+atlassian-cli jira roles get DEV 10002
+atlassian-cli jira roles actors DEV 10002
+atlassian-cli jira roles add-actor DEV 10002 --user user@example.com
+atlassian-cli jira roles remove-actor DEV 10002 --user user@example.com</code></pre>
 
             <h2 id="jira-fields">Jira — Fields &amp; workflows</h2>
             <pre class="code-block"><code>atlassian-cli jira fields list
 atlassian-cli jira workflows list
-atlassian-cli jira workflows export --name <span class="string">"Software Simplified Workflow"</span></code></pre>
+atlassian-cli jira workflows export <span class="string">"Software Simplified Workflow"</span></code></pre>
 
             <h2 id="jira-bulk">Jira — Bulk operations</h2>
             <pre class="code-block"><code><span class="comment"># Dry-run first — always</span>
@@ -239,9 +239,9 @@ atlassian-cli jira webhooks list
 atlassian-cli jira audit list --from 2025-01-01 --limit 100</code></pre>
 
             <h2 id="conf-search">Confluence — Search</h2>
-            <pre class="code-block"><code>atlassian-cli confluence search cql --cql <span class="string">"space = DEV and type = page"</span> --limit 5
-atlassian-cli confluence search text --query <span class="string">"meeting notes"</span> --limit 10
-atlassian-cli confluence search in-space --space DEV --query <span class="string">"api docs"</span></code></pre>
+            <pre class="code-block"><code>atlassian-cli confluence search cql <span class="string">"space = DEV and type = page"</span> --limit 5
+atlassian-cli confluence search text <span class="string">"meeting notes"</span> --limit 10
+atlassian-cli confluence search in-space DEV <span class="string">"api docs"</span></code></pre>
 
             <h2 id="conf-spaces">Confluence — Spaces</h2>
             <pre class="code-block"><code>atlassian-cli confluence space list --limit 10
@@ -250,29 +250,29 @@ atlassian-cli confluence space create --key DOCS --name <span class="string">"Do
 atlassian-cli confluence space update DEV --name <span class="string">"Development Space"</span>
 atlassian-cli confluence space delete OLD --force
 atlassian-cli confluence space permissions DEV
-atlassian-cli confluence space add-permission DEV --principal user@example.com --operation read</code></pre>
+atlassian-cli confluence space add-permission --permission read --subject-type user --subject-id user@example.com DEV</code></pre>
 
             <h2 id="conf-pages">Confluence — Pages</h2>
             <pre class="code-block"><code>atlassian-cli confluence page list --space DEV --limit 25
-atlassian-cli confluence page get --id 12345
+atlassian-cli confluence page get 12345
 atlassian-cli confluence page create --space DEV --title <span class="string">"New Page"</span> --body <span class="string">"&lt;p&gt;Content&lt;/p&gt;"</span>
-atlassian-cli confluence page update --id 12345 --title <span class="string">"Updated Title"</span>
-atlassian-cli confluence page delete --id 12345
-atlassian-cli confluence page versions --id 12345
-atlassian-cli confluence page add-label --id 12345 --label documentation
-atlassian-cli confluence page remove-label --id 12345 --label outdated
-atlassian-cli confluence page comments --id 12345
-atlassian-cli confluence page add-comment --id 12345 --body <span class="string">"Great work!"</span>
-atlassian-cli confluence page get-restrictions --id 12345
-atlassian-cli confluence page add-restriction --id 12345 --operation update --user user@example.com
-atlassian-cli confluence page remove-restriction --id 12345 --operation update --user user@example.com</code></pre>
+atlassian-cli confluence page update 12345 --title <span class="string">"Updated Title"</span>
+atlassian-cli confluence page delete 12345
+atlassian-cli confluence page versions 12345
+atlassian-cli confluence page add-label 12345 documentation
+atlassian-cli confluence page remove-label 12345 outdated
+atlassian-cli confluence page comments 12345
+atlassian-cli confluence page add-comment 12345 <span class="string">"Great work!"</span>
+atlassian-cli confluence page get-restrictions 12345
+atlassian-cli confluence page add-restriction --operation update --subject-type user --subject-id user@example.com 12345
+atlassian-cli confluence page remove-restriction --operation update --subject-type user --subject-id user@example.com 12345</code></pre>
 
             <h2 id="conf-blog">Confluence — Blog posts</h2>
             <pre class="code-block"><code>atlassian-cli confluence blog list --space DEV --limit 10
-atlassian-cli confluence blog get --id 67890
+atlassian-cli confluence blog get 67890
 atlassian-cli confluence blog create --space DEV --title <span class="string">"Sprint Recap"</span> --body <span class="string">"&lt;p&gt;Summary&lt;/p&gt;"</span>
-atlassian-cli confluence blog update --id 67890 --title <span class="string">"Updated Recap"</span>
-atlassian-cli confluence blog delete --id 67890</code></pre>
+atlassian-cli confluence blog update 67890 --title <span class="string">"Updated Recap"</span>
+atlassian-cli confluence blog delete 67890</code></pre>
 
             <h2 id="conf-folders">Confluence — Folders <span style="font-size:0.7rem;color:var(--accent-cyan);">new in 0.4</span></h2>
             <pre class="code-block"><code>atlassian-cli confluence folder get 3309240341
@@ -280,21 +280,21 @@ atlassian-cli confluence folder create --space DOCS --title <span class="string"
 atlassian-cli confluence folder delete 3309240341 --force</code></pre>
 
             <h2 id="conf-attach">Confluence — Attachments</h2>
-            <pre class="code-block"><code>atlassian-cli confluence attachment list --page-id 12345
-atlassian-cli confluence attachment get --id 11111
-atlassian-cli confluence attachment upload --page-id 12345 --file ./diagram.png
-atlassian-cli confluence attachment download --id 11111 --output ./download.png
-atlassian-cli confluence attachment delete --id 11111</code></pre>
+            <pre class="code-block"><code>atlassian-cli confluence attachment list 12345
+atlassian-cli confluence attachment get 11111
+atlassian-cli confluence attachment upload --file ./diagram.png 12345
+atlassian-cli confluence attachment download --output ./download.png 11111
+atlassian-cli confluence attachment delete 11111</code></pre>
 
             <h2 id="conf-bulk">Confluence — Bulk operations</h2>
-            <pre class="code-block"><code>atlassian-cli confluence bulk delete --space OLD --dry-run
+            <pre class="code-block"><code>atlassian-cli confluence bulk delete --cql "space = OLD" --dry-run
 atlassian-cli confluence bulk add-labels --cql <span class="string">"space = DEV"</span> --labels docs,reviewed --dry-run
-atlassian-cli confluence bulk export --space DEV --output backup.json --format json</code></pre>
+atlassian-cli confluence bulk export --cql "space = DEV" --output backup.json --format json</code></pre>
             <p>For a full markdown-to-Confluence pipeline see the <a href="/runbooks/confluence-markdown-sync.html">Markdown sync runbook</a>.</p>
 
             <h2 id="conf-analytics">Confluence — Analytics</h2>
-            <pre class="code-block"><code>atlassian-cli confluence analytics page-views --id 12345 --from 2025-01-01
-atlassian-cli confluence analytics space-stats --space DEV</code></pre>
+            <pre class="code-block"><code>atlassian-cli confluence analytics page-views 12345 --from 2025-01-01
+atlassian-cli confluence analytics space-stats DEV</code></pre>
 
             <h2 id="bb-user">Bitbucket — User info</h2>
             <div class="note"><code>bb</code> is an alias for <code>bitbucket</code>. Both work in every command below.</div>

--- a/docs/examples/bitbucket/pr-automation.sh
+++ b/docs/examples/bitbucket/pr-automation.sh
@@ -105,7 +105,7 @@ parse_args() {
 get_open_prs() {
     log "Fetching open pull requests..."
 
-    atlassian-cli bitbucket pullrequest list \
+    atlassian-cli bitbucket pr list \
         --profile "$PROFILE" \
         "$WORKSPACE" \
         "$REPO" \
@@ -128,7 +128,7 @@ is_trusted_author() {
 get_approval_count() {
     local pr_id="$1"
 
-    atlassian-cli bitbucket pullrequest get \
+    atlassian-cli bitbucket pr get \
         --profile "$PROFILE" \
         "$WORKSPACE" \
         "$REPO" \
@@ -149,7 +149,7 @@ approve_pr() {
 
     log "Approving PR #$pr_id: $title"
 
-    atlassian-cli bitbucket pullrequest approve \
+    atlassian-cli bitbucket pr approve \
         --profile "$PROFILE" \
         "$WORKSPACE" \
         "$REPO" \
@@ -168,7 +168,7 @@ merge_pr() {
 
     log "Merging PR #$pr_id: $title"
 
-    atlassian-cli bitbucket pullrequest merge \
+    atlassian-cli bitbucket pr merge \
         --profile "$PROFILE" \
         "$WORKSPACE" \
         "$REPO" \

--- a/docs/examples/bitbucket/repo-audit.sh
+++ b/docs/examples/bitbucket/repo-audit.sh
@@ -50,7 +50,7 @@ get_all_repos() {
 get_repo_permissions() {
     local repo="$1"
 
-    atlassian-cli bitbucket permissions list \
+    atlassian-cli bitbucket permission list \
         --profile "$PROFILE" \
         "$WORKSPACE" \
         "$repo" \

--- a/docs/examples/jira/bulk-transition.sh
+++ b/docs/examples/jira/bulk-transition.sh
@@ -95,7 +95,7 @@ preview_issues() {
     log "Query: $JQL"
 
     local issues
-    issues=$(atlassian-cli jira search \
+    issues=$(atlassian-cli jira issue search \
         --profile "$PROFILE" \
         --jql "$JQL" \
         --output json 2>/dev/null || echo "[]")

--- a/docs/examples/jira/project-cleanup.sh
+++ b/docs/examples/jira/project-cleanup.sh
@@ -122,7 +122,7 @@ preview_issues() {
     log "JQL: $jql"
 
     local issues
-    issues=$(atlassian-cli jira search \
+    issues=$(atlassian-cli jira issue search \
         --profile "$PROFILE" \
         --jql "$jql" \
         --output json 2>/dev/null || echo "[]")
@@ -188,7 +188,7 @@ generate_report() {
     log "Generating cleanup report..."
 
     local issues
-    issues=$(atlassian-cli jira search \
+    issues=$(atlassian-cli jira issue search \
         --profile "$PROFILE" \
         --jql "$jql" \
         --output json)

--- a/docs/examples/jira/sprint-report.sh
+++ b/docs/examples/jira/sprint-report.sh
@@ -117,7 +117,7 @@ fetch_issues() {
     log "Fetching sprint issues..."
     log "JQL: $jql"
 
-    atlassian-cli jira search \
+    atlassian-cli jira issue search \
         --profile "$PROFILE" \
         --jql "$jql" \
         --output json

--- a/docs/index.html
+++ b/docs/index.html
@@ -169,7 +169,7 @@
                 <div class="terminal-body">
                     <div class="terminal-line" data-delay="0">
                         <span class="terminal-prompt">$</span>
-                        <span class="terminal-text" data-text="atlassian-cli jira search --jql &quot;project = DEV&quot;"></span>
+                        <span class="terminal-text" data-text="atlassian-cli jira issue search --jql &quot;project = DEV&quot;"></span>
                     </div>
                     <div class="terminal-line" data-delay="2000">
                         <span class="terminal-prompt">$</span>
@@ -177,7 +177,7 @@
                     </div>
                     <div class="terminal-line" data-delay="4000">
                         <span class="terminal-prompt">$</span>
-                        <span class="terminal-text" data-text="atlassian-cli bitbucket pr merge --auto-complete"></span>
+                        <span class="terminal-text" data-text="atlassian-cli bitbucket --workspace myteam pr merge api-service 42"></span>
                     </div>
                 </div>
             </div>
@@ -409,7 +409,7 @@ atlassian-cli confluence bulk export \
   --format json
 
 <span class="comment"># Get space metadata</span>
-atlassian-cli confluence space get DOCS --output json
+atlassian-cli confluence space get DOCS --format json
 
 <span class="comment"># List attachments for a page</span>
 atlassian-cli confluence attachment list 123456</code></pre>

--- a/docs/jira/index.html
+++ b/docs/jira/index.html
@@ -181,17 +181,17 @@
                         </button>
                     </div>
                     <pre class="code-block" id="code-search"><code><span class="comment"># Search issues by project and status</span>
-atlassian-cli jira search \
+atlassian-cli jira issue search \
   --jql <span class="string">"project = DEV AND status = 'In Progress'"</span> \
   --format json
 
 <span class="comment"># Search with assignee filter, table output</span>
-atlassian-cli jira search \
+atlassian-cli jira issue search \
   --jql <span class="string">"assignee = currentUser() AND sprint in openSprints()"</span> \
   --format table
 
 <span class="comment"># Export results as CSV</span>
-atlassian-cli jira search \
+atlassian-cli jira issue search \
   --jql <span class="string">"project = DEV AND created >= -7d"</span> \
   --format csv > new_issues.csv</code></pre>
                 </div>
@@ -224,19 +224,19 @@ atlassian-cli jira bulk transition \
                         </button>
                     </div>
                     <pre class="code-block" id="code-sprint"><code><span class="comment"># Fetch active sprint issues as JSON</span>
-atlassian-cli jira search \
+atlassian-cli jira issue search \
   --profile prod \
   --jql <span class="string">"project = PROJ AND Sprint in openSprints()"</span> \
   --format json
 
 <span class="comment"># Export sprint data to CSV for reporting</span>
-atlassian-cli jira search \
+atlassian-cli jira issue search \
   --profile prod \
   --jql <span class="string">"project = PROJ AND Sprint = 42"</span> \
   --format csv > sprint-42.csv
 
 <span class="comment"># Pipe to jq for cycle time analysis</span>
-atlassian-cli jira search \
+atlassian-cli jira issue search \
   --jql <span class="string">"project = PROJ AND Sprint = 42"</span> \
   --format json | \
   jq <span class="string">'[.[] | {key, status: .fields.status.name, points: .fields.customfield_10016}]'</span></code></pre>
@@ -268,7 +268,7 @@ atlassian-cli auth login \
 atlassian-cli auth test --profile <span class="string">work</span></code></pre>
                 <h4>3. Start using</h4>
                 <pre class="code-block"><code><span class="comment"># Search your issues</span>
-atlassian-cli jira search \
+atlassian-cli jira issue search \
   --profile <span class="string">work</span> \
   --jql <span class="string">"assignee = currentUser()"</span></code></pre>
             </div>
@@ -289,7 +289,7 @@ atlassian-cli jira search \
                 </thead>
                 <tbody style="color: var(--text-secondary);">
                     <tr style="border-bottom: 1px solid var(--border);">
-                        <td style="padding: 0.75rem 0.5rem; vertical-align: top;"><a href="/docs/commands.html#jira-issues"><code>jira search / get / create / update / transition / assign / delete</code></a></td>
+                        <td style="padding: 0.75rem 0.5rem; vertical-align: top;"><a href="/docs/commands.html#jira-issues"><code>jira issue search / get / create / update / transition / assign / delete</code></a></td>
                         <td style="padding: 0.75rem 0.5rem;">Issue CRUD. JQL search with any field, assignee/status filters, custom field payloads via <code>--field 'customfield_XXXXX=...'</code>.</td>
                     </tr>
                     <tr style="border-bottom: 1px solid var(--border);">

--- a/docs/jsm/index.html
+++ b/docs/jsm/index.html
@@ -339,7 +339,7 @@ atlassian-cli jsm request get SD-456 \
   --format json
 
 <span class="comment"># Combine with Jira for cross-product views</span>
-atlassian-cli jira search \
+atlassian-cli jira issue search \
   --jql <span class="string">"project = SD ORDER BY created DESC"</span> \
   --limit 10</code></pre>
                 </div>

--- a/docs/runbooks/bitbucket-pr-automation.html
+++ b/docs/runbooks/bitbucket-pr-automation.html
@@ -415,7 +415,7 @@ parse_args() {
 get_open_prs() {
     log <span class="string">"Fetching open pull requests..."</span>
 
-    atlassian-cli bitbucket pullrequest list \
+    atlassian-cli bitbucket pr list \
         --profile <span class="string">"$PROFILE"</span> \
         <span class="string">"$WORKSPACE"</span> \
         <span class="string">"$REPO"</span> \
@@ -438,7 +438,7 @@ is_trusted_author() {
 get_approval_count() {
     local pr_id=<span class="string">"$1"</span>
 
-    atlassian-cli bitbucket pullrequest get \
+    atlassian-cli bitbucket pr get \
         --profile <span class="string">"$PROFILE"</span> \
         <span class="string">"$WORKSPACE"</span> \
         <span class="string">"$REPO"</span> \
@@ -459,7 +459,7 @@ approve_pr() {
 
     log <span class="string">"Approving PR #$pr_id: $title"</span>
 
-    atlassian-cli bitbucket pullrequest approve \
+    atlassian-cli bitbucket pr approve \
         --profile <span class="string">"$PROFILE"</span> \
         <span class="string">"$WORKSPACE"</span> \
         <span class="string">"$REPO"</span> \
@@ -478,7 +478,7 @@ merge_pr() {
 
     log <span class="string">"Merging PR #$pr_id: $title"</span>
 
-    atlassian-cli bitbucket pullrequest merge \
+    atlassian-cli bitbucket pr merge \
         --profile <span class="string">"$PROFILE"</span> \
         <span class="string">"$WORKSPACE"</span> \
         <span class="string">"$REPO"</span> \
@@ -606,7 +606,7 @@ main <span class="string">"$@"</span></code></pre>
         </div>
         <div class="step-item">
             <span class="step-number">2</span>
-            <p><strong>Fetch open PRs.</strong> The script calls <code>bitbucket pullrequest list --state OPEN</code> to retrieve all open pull requests for the target repository as JSON, then generates a summary with total and approval counts.</p>
+            <p><strong>Fetch open PRs.</strong> The script calls <code>bitbucket pr list --state OPEN</code> to retrieve all open pull requests for the target repository as JSON, then generates a summary with total and approval counts.</p>
         </div>
         <div class="step-item">
             <span class="step-number">3</span>

--- a/docs/runbooks/bitbucket-repo-audit.html
+++ b/docs/runbooks/bitbucket-repo-audit.html
@@ -294,7 +294,7 @@
 ./repo-audit.sh myworkspace prod repos_audit.csv
 
 <span class="comment"># Quick one-liner with atlassian-cli directly</span>
-atlassian-cli bitbucket repo list myworkspace --output json | \
+atlassian-cli bitbucket --workspace myworkspace repo list --format json | \
   jq -r <span class="string">'.[] | [.slug, .language, .size] | @csv'</span></code></pre>
 
         <h2>Full Runbook Script</h2>
@@ -359,7 +359,7 @@ get_all_repos() {
 get_repo_permissions() {
     local repo=<span class="string">"$1"</span>
 
-    atlassian-cli bitbucket permissions list \
+    atlassian-cli bitbucket permission list \
         --profile <span class="string">"$PROFILE"</span> \
         <span class="string">"$WORKSPACE"</span> \
         <span class="string">"$repo"</span> \

--- a/docs/runbooks/jira-bulk-transition.html
+++ b/docs/runbooks/jira-bulk-transition.html
@@ -401,7 +401,7 @@ preview_issues() {
     log <span class="string">"Query: $JQL"</span>
 
     local issues
-    issues=$(atlassian-cli jira search \
+    issues=$(atlassian-cli jira issue search \
         --profile <span class="string">"$PROFILE"</span> \
         --jql <span class="string">"$JQL"</span> \
         --output json 2&gt;/dev/null || echo <span class="string">"[]"</span>)
@@ -491,7 +491,7 @@ main <span class="string">"$@"</span></code></pre>
         </div>
         <div class="step-item">
             <span class="step-number">2</span>
-            <p><strong>Preview matching issues.</strong> A <code>jira search</code> call finds all issues matching your JQL. The first 10 results are displayed with their key, summary, and current status so you can verify the query is correct.</p>
+            <p><strong>Preview matching issues.</strong> A <code>jira issue search</code> call finds all issues matching your JQL. The first 10 results are displayed with their key, summary, and current status so you can verify the query is correct.</p>
         </div>
         <div class="step-item">
             <span class="step-number">3</span>

--- a/docs/runbooks/jira-project-cleanup.html
+++ b/docs/runbooks/jira-project-cleanup.html
@@ -429,7 +429,7 @@ preview_issues() {
     log <span class="string">"JQL: $jql"</span>
 
     local issues
-    issues=$(atlassian-cli jira search \
+    issues=$(atlassian-cli jira issue search \
         --profile <span class="string">"$PROFILE"</span> \
         --jql <span class="string">"$jql"</span> \
         --output json 2&gt;/dev/null || echo <span class="string">"[]"</span>)
@@ -495,7 +495,7 @@ generate_report() {
     log <span class="string">"Generating cleanup report..."</span>
 
     local issues
-    issues=$(atlassian-cli jira search \
+    issues=$(atlassian-cli jira issue search \
         --profile <span class="string">"$PROFILE"</span> \
         --jql <span class="string">"$jql"</span> \
         --output json)

--- a/docs/runbooks/jira-sprint-report.html
+++ b/docs/runbooks/jira-sprint-report.html
@@ -419,7 +419,7 @@ fetch_issues() {
     log <span class="string">"Fetching sprint issues..."</span>
     log <span class="string">"JQL: $jql"</span>
 
-    atlassian-cli jira search \
+    atlassian-cli jira issue search \
         --profile <span class="string">"$PROFILE"</span> \
         --jql <span class="string">"$jql"</span> \
         --output json
@@ -537,7 +537,7 @@ main <span class="string">"$@"</span></code></pre>
         </div>
         <div class="step-item">
             <span class="step-number">2</span>
-            <p><strong>Fetch all sprint issues.</strong> The CLI's <code>jira search</code> command retrieves every issue in the sprint as JSON, including fields like story points (<code>customfield_10016</code>), assignee, status, and resolution date.</p>
+            <p><strong>Fetch all sprint issues.</strong> The CLI's <code>jira issue search</code> command retrieves every issue in the sprint as JSON, including fields like story points (<code>customfield_10016</code>), assignee, status, and resolution date.</p>
         </div>
         <div class="step-item">
             <span class="step-number">3</span>

--- a/todo.md
+++ b/todo.md
@@ -1,5 +1,35 @@
 # Changes Made
 
+## 2026-06-14 — Site-wide CLI command-syntax cleanup (docs accuracy)
+
+### Context
+The docs (commands.html, blog posts, runbooks, example .sh) were written against an
+older CLI and used many invalid command forms. Verified every form against the built
+binary's --help and corrected them.
+
+### Fixed (all verified against the binary)
+- `jira <verb>` -> `jira issue <verb>` (search/get/create/update/delete/transition/
+  assign/unassign), including bare `<code>` prose refs.
+- `bitbucket pullrequest` -> `bitbucket pr`; `bitbucket permissions` -> `permission`.
+- `jsm servicedesk` -> `jsm service-desk` (commands + prose; left `--servicedesk-id`).
+- Confluence positional IDs: `page/blog/attachment <verb> --id N` -> positional `N`;
+  `attachment list --page-id N` -> `N`; add-label/remove-label/add-comment now positional;
+  add/remove-restriction -> `--operation --subject-type --subject-id <PAGE_ID>`;
+  space add-permission -> `--permission --subject-type --subject-id <KEY>`.
+- `confluence search cql/text/in-space` use positional QUERY/SPACE, not --cql/--query/--space.
+- `confluence bulk export/delete --space X` -> `--cql "space = X"` (incl. multi-line/span).
+- `confluence analytics page-views/space-stats` use positional ID/KEY.
+- jira roles/components/versions use positional `<PROJECT>`/`<ROLE_ID>` not --project/--role-id;
+  `jira workflows export` uses positional `<NAME>`.
+- `--output json` -> `--format json` on repo list / space get; fixed an invalid
+  `pr merge --auto-complete` hero snippet.
+
+### Verification
+Built a flag-audit script (/tmp/flagcheck.py) that resolves each documented command's
+path against the binary and checks every --flag exists. All 42 command paths valid;
+remaining audit hits are false positives (global --profile, one prose `pr create:` line).
+Structural-pattern greps all return 0.
+
 ## 2026-06-14 — Site: 0.4 release announcement + changelog page
 
 ### Context


### PR DESCRIPTION
The published docs (command reference, blog posts, runbooks, example scripts) used an older CLI interface with many invalid command forms. Every example was verified against the built binary's `--help` and corrected.

## Fixed
- `jira <verb>` -> `jira issue <verb>` (search/get/create/update/delete/transition/assign/unassign), incl. inline prose
- `bitbucket pullrequest` -> `pr`; `bitbucket permissions` -> `permission`
- `jsm servicedesk` -> `jsm service-desk`
- Confluence: positional IDs (not `--id`/`--page-id`); `add/remove-restriction` and `space add-permission` use `--operation`/`--permission` + `--subject-type`/`--subject-id`; `search cql/text/in-space` use positional QUERY/SPACE; `bulk export/delete` use `--cql` not `--space`; `analytics` use positional ids
- jira `roles`/`components`/`versions` use positional `<PROJECT>`/`<ROLE_ID>`; `workflows export` uses positional `<NAME>`
- `--output json` -> `--format json`; fixed an invalid `pr merge --auto-complete` hero snippet

## Verification
A flag-audit script resolves each documented command path against the binary and checks every `--flag` exists. All 42 command paths valid; remaining audit hits are false positives (global `--profile`, one prose `pr create:` line). Structural-pattern greps all return 0. All pages serve 200 locally.