### PR TITLE
seo: add FAQ rich-result blocks to Confluence & Bitbucket pages

### DIFF
--- a/docs/bitbucket/index.html
+++ b/docs/bitbucket/index.html
@@ -66,6 +66,34 @@
       }
     }
     </script>
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "FAQPage",
+      "mainEntity": [
+        {
+          "@type": "Question",
+          "name": "How do I use Bitbucket from the command line?",
+          "acceptedAnswer": { "@type": "Answer", "text": "atlassian-cli is a Bitbucket CLI for pull requests, pipelines, branches, repositories and permissions. After authenticating, run commands like 'atlassian-cli bitbucket --workspace myteam pr list api-service'. A full list of Bitbucket commands is in the docs." }
+        },
+        {
+          "@type": "Question",
+          "name": "Can I trigger Bitbucket Pipelines from the CLI?",
+          "acceptedAnswer": { "@type": "Answer", "text": "Yes, including named custom pipelines. Run 'atlassian-cli bitbucket --workspace myteam pipeline trigger api-service --ref-name main --custom-pipeline <name>'. Custom pipeline triggers were added in version 0.4." }
+        },
+        {
+          "@type": "Question",
+          "name": "Is atlassian-cli the official Bitbucket CLI?",
+          "acceptedAnswer": { "@type": "Answer", "text": "No. atlassian-cli is an independent, open-source tool and is not affiliated with, endorsed by, or maintained by Atlassian. Atlassian ships its own separate official CLI (acli)." }
+        },
+        {
+          "@type": "Question",
+          "name": "Is the Bitbucket CLI free?",
+          "acceptedAnswer": { "@type": "Answer", "text": "Yes. atlassian-cli is free and open source under the MIT License, installable via Homebrew, Cargo, or a prebuilt binary." }
+        }
+      ]
+    }
+    </script>
 
     <link rel="canonical" href="https://atlassiancli.com/bitbucket/" />
     <link rel="stylesheet" href="../styles.css">
@@ -526,6 +554,32 @@ atlassian-cli bitbucket --workspace myteam \
                     <h4>Example Scripts</h4>
                     <p>Production-ready shell scripts for PR automation, branch cleanup, and repo audits.</p>
                 </a>
+            </div>
+        </div>
+    </section>
+
+    <!-- FAQ -->
+    <section class="faq" id="faq">
+        <div class="container">
+            <h2 class="section-title">Bitbucket CLI FAQ</h2>
+            <p class="section-subtitle">Automating Bitbucket from the command line</p>
+            <div class="faq-list">
+                <div class="faq-item">
+                    <h3>How do I use Bitbucket from the command line?</h3>
+                    <p>atlassian-cli is a Bitbucket CLI for pull requests, pipelines, branches, repositories and permissions. After <a href="/docs/auth.html">authenticating</a>, run commands like <code>atlassian-cli bitbucket --workspace myteam pr list api-service</code>. See the full <a href="/docs/commands.html#bb-repos">Bitbucket command reference</a>.</p>
+                </div>
+                <div class="faq-item">
+                    <h3>Can I trigger Bitbucket Pipelines from the CLI?</h3>
+                    <p>Yes, including named custom pipelines: <code>atlassian-cli bitbucket --workspace myteam pipeline trigger api-service --ref-name main --custom-pipeline &lt;name&gt;</code>. Custom pipeline triggers landed in <a href="/blog/atlassian-cli-0-4-release.html">version 0.4</a>.</p>
+                </div>
+                <div class="faq-item">
+                    <h3>Is atlassian-cli the official Bitbucket CLI?</h3>
+                    <p>No. atlassian-cli is an independent, open-source tool and is not affiliated with, endorsed by, or maintained by Atlassian. Atlassian ships its own separate official CLI (<code>acli</code>).</p>
+                </div>
+                <div class="faq-item">
+                    <h3>Is the Bitbucket CLI free?</h3>
+                    <p>Yes. atlassian-cli is free and open source under the MIT License. Get it on <a href="/install/">the install page</a> or <a href="https://github.com/omar16100/atlassian-cli" target="_blank" rel="noopener">GitHub</a>.</p>
+                </div>
             </div>
         </div>
     </section>

--- a/docs/confluence/index.html
+++ b/docs/confluence/index.html
@@ -49,6 +49,34 @@
       "author": { "@type": "Person", "name": "Omar Shabab", "url": "https://omarshabab.com" }
     }
     </script>
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "FAQPage",
+      "mainEntity": [
+        {
+          "@type": "Question",
+          "name": "How do I manage Confluence from the command line?",
+          "acceptedAnswer": { "@type": "Answer", "text": "atlassian-cli is a Confluence CLI for pages, spaces, folders, blog posts, CQL search, bulk export and attachments. After authenticating, run commands like 'atlassian-cli confluence page list --space DEV' or 'atlassian-cli confluence search cql \"space = DEV\"'. A full command reference is available in the docs." }
+        },
+        {
+          "@type": "Question",
+          "name": "Does the Confluence CLI support the v2 Folder API and Markdown?",
+          "acceptedAnswer": { "@type": "Answer", "text": "Yes. Version 0.4 added a 'confluence folder' command group for the Confluence v2 Folder API, plus Markdown-to-ADF conversion for Jira descriptions and comments." }
+        },
+        {
+          "@type": "Question",
+          "name": "Is atlassian-cli the official Confluence CLI?",
+          "acceptedAnswer": { "@type": "Answer", "text": "No. atlassian-cli is an independent, open-source tool and is not affiliated with, endorsed by, or maintained by Atlassian. Atlassian ships its own separate official CLI (acli)." }
+        },
+        {
+          "@type": "Question",
+          "name": "Is the Confluence CLI free?",
+          "acceptedAnswer": { "@type": "Answer", "text": "Yes. atlassian-cli is free and open source under the MIT License, installable via Homebrew, Cargo, or a prebuilt binary." }
+        }
+      ]
+    }
+    </script>
     <link rel="stylesheet" href="../styles.css">
     <link rel="stylesheet" href="../product.css">
 </head>
@@ -397,6 +425,32 @@ atlassian-cli confluence search cql \
                 <a href="/jira/">Jira CLI</a>
                 <a href="/bitbucket/">Bitbucket CLI</a>
                 <a href="/jsm/">JSM CLI</a>
+            </div>
+        </div>
+    </section>
+
+    <!-- FAQ -->
+    <section class="faq" id="faq">
+        <div class="container">
+            <h2 class="section-title">Confluence CLI FAQ</h2>
+            <p class="section-subtitle">Managing Confluence from the command line</p>
+            <div class="faq-list">
+                <div class="faq-item">
+                    <h3>How do I manage Confluence from the command line?</h3>
+                    <p>atlassian-cli is a Confluence CLI for pages, spaces, folders, blog posts, CQL search, bulk export and attachments. After <a href="/docs/auth.html">authenticating</a>, run commands like <code>atlassian-cli confluence page list --space DEV</code> or <code>atlassian-cli confluence search cql "space = DEV"</code>. See the full <a href="/docs/commands.html#conf-pages">Confluence command reference</a>.</p>
+                </div>
+                <div class="faq-item">
+                    <h3>Does the Confluence CLI support the v2 Folder API and Markdown?</h3>
+                    <p>Yes. Version 0.4 added a <code>confluence folder</code> command group for the Confluence v2 Folder API, plus Markdown-to-ADF conversion. See <a href="/blog/atlassian-cli-0-4-release.html">what's new in 0.4</a> or the <a href="/changelog/">changelog</a>.</p>
+                </div>
+                <div class="faq-item">
+                    <h3>Is atlassian-cli the official Confluence CLI?</h3>
+                    <p>No. atlassian-cli is an independent, open-source tool and is not affiliated with, endorsed by, or maintained by Atlassian. Atlassian ships its own separate official CLI (<code>acli</code>).</p>
+                </div>
+                <div class="faq-item">
+                    <h3>Is the Confluence CLI free?</h3>
+                    <p>Yes. atlassian-cli is free and open source under the MIT License. Get it on <a href="/install/">the install page</a> or <a href="https://github.com/omar16100/atlassian-cli" target="_blank" rel="noopener">GitHub</a>.</p>
+                </div>
             </div>
         </div>
     </section>


### PR DESCRIPTION
On-page SEO fast win from the DataForSEO/GSC analysis. The Confluence and Bitbucket keyword clusters are our most winnable terms (low difficulty, very low backlink barrier) but the product pages rank pos 16-20 and lacked the FAQ rich-result markup the homepage already has.

- Visible FAQ section + matching `FAQPage` JSON-LD on `/confluence/` and `/bitbucket/`, targeting `confluence cli` / `confluence command line` and `bitbucket cli` / `bitbucket cli commands`.
- Surfaces the 0.4 features (Confluence folders, Markdown-to-ADF, `--custom-pipeline`) with internal links to the new release post + changelog (freshness + internal linking).
- Maintains independent/unaffiliated positioning (explicitly distinct from Atlassian's official `acli`).
- Sitemap `lastmod` refreshed.

Validated: all JSON-LD parses, FAQ visible content matches the schema, pages serve 200.