### PR TITLE
seo: FAQ blocks on Jira/JSM/Install + official-acli disambiguation

### DIFF
--- a/docs/blog/jira-cli-tools-compared.html
+++ b/docs/blog/jira-cli-tools-compared.html
@@ -55,7 +55,7 @@
       "headline": "Best Jira CLI Tools Compared (2026)",
       "description": "An honest comparison of the best Jira CLI tools in 2026. atlassian-cli vs jira-cli vs go-jira vs ACLI — features, install, auth, and verdict.",
       "datePublished": "2026-03-14T00:00:00Z",
-      "dateModified": "2026-03-14T00:00:00Z",
+      "dateModified": "2026-06-14T00:00:00Z",
       "author": {
         "@type": "Person",
         "name": "Omar Shabab",
@@ -654,6 +654,12 @@ jira issue create --project DEV --issuetype Task -s <span class="string">"Summar
         <p><strong>Strengths:</strong> Broadest product coverage, enterprise support and SLAs, extensive scripting capabilities, available on the Atlassian Marketplace.</p>
 
         <p><strong>Honest take:</strong> ACLI is powerful and battle-tested in enterprise environments. The downsides are cost (commercial license), JVM requirement (slower startup, larger footprint), and the learning curve of a massive command surface. If your organization has budget and needs vendor support, ACLI is the safe enterprise pick. For individual developers and small teams, the free open-source tools are typically more practical.</p>
+
+        <h3>Atlassian's official acli</h3>
+
+        <p>Atlassian now ships its own official command-line tool, <a href="https://developer.atlassian.com/cloud/acli/" target="_blank" rel="noopener"><code>acli</code></a> — a separate, first-party product maintained by Atlassian. If you specifically want the vendor-supported, official CLI, <code>acli</code> is the canonical choice and the right starting point.</p>
+
+        <p><strong>How this project differs:</strong> <strong>atlassian-cli</strong> (this site) is an <em>independent, community open-source</em> project. It is not <code>acli</code>, not affiliated with Atlassian, and not a replacement for the official tool — it is a separate MIT-licensed option for people who want a single Rust binary spanning Jira, Confluence, Bitbucket, and JSM, with consistent <code>--format json/csv/yaml</code> output and no runtime dependencies. Pick the official <code>acli</code> for first-party support; pick atlassian-cli if you want a free, unified, scriptable OSS tool. The two can happily coexist.</p>
 
         <h2>Which Tool Should You Choose?</h2>
 

--- a/docs/install/index.html
+++ b/docs/install/index.html
@@ -51,6 +51,34 @@
       }
     }
     </script>
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "FAQPage",
+      "mainEntity": [
+        {
+          "@type": "Question",
+          "name": "How do I install atlassian-cli with Homebrew?",
+          "acceptedAnswer": { "@type": "Answer", "text": "Run 'brew install omar16100/atlassian-cli/atlassian-cli'. This installs the atlassian-cli binary on macOS or Linux. Verify with 'atlassian-cli --version'." }
+        },
+        {
+          "@type": "Question",
+          "name": "How do I install atlassian-cli with Cargo?",
+          "acceptedAnswer": { "@type": "Answer", "text": "If you have the Rust toolchain, run 'cargo install atlassian-cli'. You can also download a prebuilt binary from the GitHub releases page or use the shell installer script." }
+        },
+        {
+          "@type": "Question",
+          "name": "Which platforms does atlassian-cli support?",
+          "acceptedAnswer": { "@type": "Answer", "text": "Prebuilt binaries are available for macOS (Apple Silicon and Intel) and Linux (gnu and musl). It also installs from source via Cargo on any platform with a Rust toolchain." }
+        },
+        {
+          "@type": "Question",
+          "name": "Is atlassian-cli the same as Atlassian's official acli?",
+          "acceptedAnswer": { "@type": "Answer", "text": "No. atlassian-cli is an independent, open-source project and is not Atlassian's official acli. If you specifically want Atlassian's first-party CLI, install acli from Atlassian. atlassian-cli is a separate, free, MIT-licensed tool for Jira, Confluence, Bitbucket and JSM." }
+        }
+      ]
+    }
+    </script>
 
     <link rel="stylesheet" href="../styles.css">
 </head>
@@ -137,6 +165,32 @@ atlassian-cli auth test --profile <span class="string">work</span></code></pre>
                 <li><strong>cargo install is slow</strong> — use prebuilt binaries or Homebrew; Cargo compiles from source.</li>
                 <li><strong>authentication fails</strong> — Atlassian Cloud requires an <a href="https://id.atlassian.com/manage-profile/security/api-tokens" target="_blank" rel="noopener">API token</a>, not your account password.</li>
             </ul>
+        </div>
+    </section>
+
+    <!-- FAQ -->
+    <section class="faq" id="faq">
+        <div class="container">
+            <h2 class="section-title">Install FAQ</h2>
+            <p class="section-subtitle">Getting atlassian-cli onto your machine</p>
+            <div class="faq-list">
+                <div class="faq-item">
+                    <h3>How do I install atlassian-cli with Homebrew?</h3>
+                    <p>Run <code>brew install omar16100/atlassian-cli/atlassian-cli</code> on macOS or Linux, then verify with <code>atlassian-cli --version</code>.</p>
+                </div>
+                <div class="faq-item">
+                    <h3>How do I install atlassian-cli with Cargo?</h3>
+                    <p>With the Rust toolchain installed, run <code>cargo install atlassian-cli</code>. You can also grab a prebuilt binary from <a href="https://github.com/omar16100/atlassian-cli/releases" target="_blank" rel="noopener">GitHub releases</a> or use the shell installer script above.</p>
+                </div>
+                <div class="faq-item">
+                    <h3>Which platforms does atlassian-cli support?</h3>
+                    <p>Prebuilt binaries cover macOS (Apple Silicon and Intel) and Linux (gnu and musl). It also builds from source via Cargo on any platform with a Rust toolchain.</p>
+                </div>
+                <div class="faq-item">
+                    <h3>Is atlassian-cli the same as Atlassian's official acli?</h3>
+                    <p>No. atlassian-cli is an independent, open-source project and is not Atlassian's official <code>acli</code>. If you specifically want Atlassian's first-party CLI, install <code>acli</code> from Atlassian. atlassian-cli is a separate, free, MIT-licensed tool for Jira, Confluence, Bitbucket and JSM.</p>
+                </div>
+            </div>
         </div>
     </section>
 

--- a/docs/jira/index.html
+++ b/docs/jira/index.html
@@ -49,6 +49,34 @@
       "author": { "@type": "Person", "name": "Omar Shabab", "url": "https://omarshabab.com" }
     }
     </script>
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "FAQPage",
+      "mainEntity": [
+        {
+          "@type": "Question",
+          "name": "How do I use Jira from the command line?",
+          "acceptedAnswer": { "@type": "Answer", "text": "atlassian-cli is a Jira CLI for issues, projects, bulk operations, workflows and automation. After authenticating, run commands like 'atlassian-cli jira issue search --jql \"project = DEV AND status = Open\"' or 'atlassian-cli jira issue create --project DEV --issue-type Task --summary \"...\"'. A full command reference is available in the docs." }
+        },
+        {
+          "@type": "Question",
+          "name": "Can I write Jira descriptions in Markdown from the CLI?",
+          "acceptedAnswer": { "@type": "Answer", "text": "Yes. Since version 0.4, the --description flag and comments convert Markdown (headings, lists, bold, code, links) into Atlassian Document Format (ADF), so formatting is preserved in Jira." }
+        },
+        {
+          "@type": "Question",
+          "name": "Is atlassian-cli the same as jira-cli or the official Atlassian acli?",
+          "acceptedAnswer": { "@type": "Answer", "text": "No. atlassian-cli is an independent, open-source tool that covers Jira, Confluence, Bitbucket and JSM in one binary. It is not affiliated with Atlassian (which ships its own official acli) and is a separate project from jira-cli." }
+        },
+        {
+          "@type": "Question",
+          "name": "Is the Jira CLI free?",
+          "acceptedAnswer": { "@type": "Answer", "text": "Yes. atlassian-cli is free and open source under the MIT License, installable via Homebrew, Cargo, or a prebuilt binary." }
+        }
+      ]
+    }
+    </script>
     <link rel="stylesheet" href="../styles.css">
     <link rel="stylesheet" href="../product.css">
 </head>
@@ -385,6 +413,32 @@ atlassian-cli jira issue search \
                 <a href="/confluence/">Confluence CLI</a>
                 <a href="/bitbucket/">Bitbucket CLI</a>
                 <a href="/jsm/">JSM CLI</a>
+            </div>
+        </div>
+    </section>
+
+    <!-- FAQ -->
+    <section class="faq" id="faq">
+        <div class="container">
+            <h2 class="section-title">Jira CLI FAQ</h2>
+            <p class="section-subtitle">Working with Jira from the command line</p>
+            <div class="faq-list">
+                <div class="faq-item">
+                    <h3>How do I use Jira from the command line?</h3>
+                    <p>atlassian-cli is a Jira CLI for issues, projects, bulk operations, workflows and automation. After <a href="/docs/auth.html">authenticating</a>, run commands like <code>atlassian-cli jira issue search --jql "project = DEV AND status = Open"</code> or <code>atlassian-cli jira issue create --project DEV --issue-type Task --summary "..."</code>. See the full <a href="/docs/commands.html#jira-issues">Jira command reference</a>.</p>
+                </div>
+                <div class="faq-item">
+                    <h3>Can I write Jira descriptions in Markdown from the CLI?</h3>
+                    <p>Yes. Since <a href="/blog/atlassian-cli-0-4-release.html">version 0.4</a>, <code>--description</code> and comments convert Markdown (headings, lists, bold, code, links) into Atlassian Document Format (ADF), so formatting is preserved in Jira.</p>
+                </div>
+                <div class="faq-item">
+                    <h3>Is atlassian-cli the same as jira-cli or Atlassian's official acli?</h3>
+                    <p>No. atlassian-cli is an independent, open-source tool that covers Jira, Confluence, Bitbucket and JSM in one binary. It is not affiliated with Atlassian (which ships its own official <code>acli</code>) and is a separate project from <a href="/blog/jira-cli-tools-compared.html">jira-cli</a>.</p>
+                </div>
+                <div class="faq-item">
+                    <h3>Is the Jira CLI free?</h3>
+                    <p>Yes. atlassian-cli is free and open source under the MIT License. Get it on <a href="/install/">the install page</a> or <a href="https://github.com/omar16100/atlassian-cli" target="_blank" rel="noopener">GitHub</a>.</p>
+                </div>
             </div>
         </div>
     </section>

--- a/docs/jsm/index.html
+++ b/docs/jsm/index.html
@@ -66,6 +66,34 @@
       }
     }
     </script>
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "FAQPage",
+      "mainEntity": [
+        {
+          "@type": "Question",
+          "name": "How do I manage Jira Service Management from the command line?",
+          "acceptedAnswer": { "@type": "Answer", "text": "atlassian-cli is a JSM CLI for service desks, customer requests, queues, SLAs, approvals, organizations and request types. After authenticating, run commands like 'atlassian-cli jsm request list --servicedesk-id 10' or 'atlassian-cli jsm request create --servicedesk-id 10 --request-type-id 7 --summary \"...\"'. A full command reference is available in the docs." }
+        },
+        {
+          "@type": "Question",
+          "name": "Can I create and transition JSM requests from the CLI?",
+          "acceptedAnswer": { "@type": "Answer", "text": "Yes. Use 'atlassian-cli jsm request create' to raise a request, 'jsm request transition' to move it through its workflow, and 'jsm request add-comment' to reply, all scriptable for automation." }
+        },
+        {
+          "@type": "Question",
+          "name": "Is atlassian-cli the official Jira Service Management CLI?",
+          "acceptedAnswer": { "@type": "Answer", "text": "No. atlassian-cli is an independent, open-source tool and is not affiliated with, endorsed by, or maintained by Atlassian. Atlassian ships its own separate official CLI (acli)." }
+        },
+        {
+          "@type": "Question",
+          "name": "Is the JSM CLI free?",
+          "acceptedAnswer": { "@type": "Answer", "text": "Yes. atlassian-cli is free and open source under the MIT License, installable via Homebrew, Cargo, or a prebuilt binary." }
+        }
+      ]
+    }
+    </script>
 
     <link rel="canonical" href="https://atlassiancli.com/jsm/" />
     <link rel="stylesheet" href="../styles.css">
@@ -419,6 +447,32 @@ atlassian-cli jsm request list --limit 5</code></pre>
                     <h4>Jira CLI</h4>
                     <p>Combine JSM with Jira CLI for cross-product automation — issues, projects, and bulk operations.</p>
                 </a>
+            </div>
+        </div>
+    </section>
+
+    <!-- FAQ -->
+    <section class="faq" id="faq">
+        <div class="container">
+            <h2 class="section-title">JSM CLI FAQ</h2>
+            <p class="section-subtitle">Jira Service Management from the command line</p>
+            <div class="faq-list">
+                <div class="faq-item">
+                    <h3>How do I manage Jira Service Management from the command line?</h3>
+                    <p>atlassian-cli is a JSM CLI for service desks, customer requests, queues, SLAs, approvals, organizations and request types. After <a href="/docs/auth.html">authenticating</a>, run commands like <code>atlassian-cli jsm request list --servicedesk-id 10</code> or <code>atlassian-cli jsm request create --servicedesk-id 10 --request-type-id 7 --summary "..."</code>. See the full <a href="/docs/commands.html#jsm-requests">JSM command reference</a>.</p>
+                </div>
+                <div class="faq-item">
+                    <h3>Can I create and transition JSM requests from the CLI?</h3>
+                    <p>Yes. Use <code>atlassian-cli jsm request create</code> to raise a request, <code>jsm request transition</code> to move it through its workflow, and <code>jsm request add-comment</code> to reply — all scriptable for automation.</p>
+                </div>
+                <div class="faq-item">
+                    <h3>Is atlassian-cli the official Jira Service Management CLI?</h3>
+                    <p>No. atlassian-cli is an independent, open-source tool and is not affiliated with, endorsed by, or maintained by Atlassian. Atlassian ships its own separate official CLI (<code>acli</code>).</p>
+                </div>
+                <div class="faq-item">
+                    <h3>Is the JSM CLI free?</h3>
+                    <p>Yes. atlassian-cli is free and open source under the MIT License. Get it on <a href="/install/">the install page</a> or <a href="https://github.com/omar16100/atlassian-cli" target="_blank" rel="noopener">GitHub</a>.</p>
+                </div>
             </div>
         </div>
     </section>


### PR DESCRIPTION
Second on-page SEO batch from the keyword analysis (after the Confluence/Bitbucket FAQs in #68).

- **FAQ section + `FAQPage` schema** on `/jira/`, `/jsm/`, and `/install/`, targeting their query clusters and surfacing 0.4 features, with internal links to the release post + command reference.
- **Comparison page** (`jira-cli-tools-compared`): added a factual *"Atlassian's official acli"* subsection that presents `acli` as the first-party choice and positions atlassian-cli as the independent, MIT-licensed multi-product alternative. Captures `acli` disambiguation intent **and** reinforces the not-affiliated stance. `dateModified` bumped.
- `/install/` FAQ explicitly distinguishes atlassian-cli from the official `acli`, so `brew install`/`install` searchers are not misled.
- Sitemap `lastmod` refreshed.

Respects the positioning constraint throughout: independent/unaffiliated, no claims of officialness, defers to `acli` as the official tool. Validated: all JSON-LD parses, FAQ visible content matches schema, pages serve 200.