### PR TITLE
feat(jira): --sprint flag + show sprint in issue get (#72)

### DIFF
--- a/crates/cli/src/commands/jira/issues.rs
+++ b/crates/cli/src/commands/jira/issues.rs
@@ -226,6 +226,13 @@ pub async fn view_issue(ctx: &JiraContext<'_>, key: &str) -> Result<()> {
             .unwrap_or_default();
 
         let attachments_md = attachments_markdown(&issue.fields.attachment);
+        let sprint_md = issue
+            .fields
+            .sprint
+            .as_ref()
+            .and_then(extract_active_sprint)
+            .map(|s| format!("| Sprint | {s} |\n"))
+            .unwrap_or_default();
 
         let md = format!(
             "# {key}: {summary}\n\n\
@@ -234,7 +241,8 @@ pub async fn view_issue(ctx: &JiraContext<'_>, key: &str) -> Result<()> {
              | Status | {status} |\n\
              | Type | {issue_type} |\n\
              | Assignee | {assignee} |\n\
-             | Reporter | {reporter} |\n\n\
+             | Reporter | {reporter} |\n\
+             {sprint_md}\n\
              ## Description\n\n\
              {description}{attachments_md}"
         );
@@ -250,6 +258,8 @@ pub async fn view_issue(ctx: &JiraContext<'_>, key: &str) -> Result<()> {
         assignee: &'a str,
         reporter: &'a str,
         issue_type: &'a str,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        sprint: Option<String>,
         attachments: &'a Vec<AttachmentField>,
     }
 
@@ -262,6 +272,7 @@ pub async fn view_issue(ctx: &JiraContext<'_>, key: &str) -> Result<()> {
             .as_ref()
             .map(|s| s.name.as_str())
             .unwrap_or(""),
+        sprint: issue.fields.sprint.as_ref().and_then(extract_active_sprint),
         description: issue
             .fields
             .description
@@ -351,6 +362,7 @@ pub async fn create_issue(
     assignee: Option<&str>,
     priority: Option<&str>,
     custom_fields: &HashMap<String, Value>,
+    sprint: Option<&str>,
 ) -> Result<()> {
     let payload = build_create_payload(
         project,
@@ -373,6 +385,10 @@ pub async fn create_issue(
         .post("/rest/api/3/issue", &payload)
         .await
         .context("Failed to create issue")?;
+
+    if let Some(sprint_id) = sprint {
+        add_to_sprint(ctx, &response.key, sprint_id).await?;
+    }
 
     tracing::info!(key = %response.key, id = %response.id, "Issue created successfully");
     render_success(
@@ -418,6 +434,45 @@ pub(crate) fn build_update_payload(
     Ok(json!({ "fields": fields }))
 }
 
+/// Build the body for `POST /rest/agile/1.0/sprint/{id}/issue`. Pure, testable.
+fn build_sprint_add_payload(key: &str) -> Value {
+    serde_json::json!({ "issues": [key] })
+}
+
+/// Add an issue to a sprint via the Agile API. This is the reliable way to set a
+/// sprint (no per-instance customfield id, and it avoids the "Number value expected"
+/// quirk of writing the sprint field directly).
+async fn add_to_sprint(ctx: &JiraContext<'_>, key: &str, sprint_id: &str) -> Result<()> {
+    let id: u64 = sprint_id.parse().map_err(|_| {
+        anyhow!("Invalid --sprint '{sprint_id}': expected a numeric sprint id (e.g. 25446)")
+    })?;
+    let payload = build_sprint_add_payload(key);
+    let _: Value = ctx
+        .client
+        .post(&format!("/rest/agile/1.0/sprint/{id}/issue"), &payload)
+        .await
+        .with_context(|| format!("Failed to add {key} to sprint {id}"))?;
+    Ok(())
+}
+
+/// Summarize an issue's Jira sprint field (customfield_10020) for display, e.g.
+/// "Sprint 12 (active)". Prefers an active sprint, else the most recent entry.
+fn extract_active_sprint(value: &Value) -> Option<String> {
+    let arr = value.as_array()?;
+    let pick = arr
+        .iter()
+        .find(|s| s.get("state").and_then(Value::as_str) == Some("active"))
+        .or_else(|| arr.last())?;
+    let name = pick.get("name").and_then(Value::as_str).unwrap_or("");
+    if name.is_empty() {
+        return None;
+    }
+    match pick.get("state").and_then(Value::as_str) {
+        Some(state) if !state.is_empty() => Some(format!("{name} ({state})")),
+        _ => Some(name.to_string()),
+    }
+}
+
 pub async fn update_issue(
     ctx: &JiraContext<'_>,
     key: &str,
@@ -425,14 +480,30 @@ pub async fn update_issue(
     description: Option<&str>,
     priority: Option<&str>,
     custom_fields: &HashMap<String, Value>,
+    sprint: Option<&str>,
 ) -> Result<()> {
-    let payload = build_update_payload(summary, description, priority, custom_fields)?;
+    let has_fields = summary.is_some()
+        || description.is_some()
+        || priority.is_some()
+        || !custom_fields.is_empty();
+    if !has_fields && sprint.is_none() {
+        bail!(
+            "Nothing to update for {key}: provide --summary, --description, --priority, --field, or --sprint"
+        );
+    }
 
-    let _: Value = ctx
-        .client
-        .put(&format!("/rest/api/3/issue/{key}"), &payload)
-        .await
-        .with_context(|| format!("Failed to update issue {key}"))?;
+    if has_fields {
+        let payload = build_update_payload(summary, description, priority, custom_fields)?;
+        let _: Value = ctx
+            .client
+            .put(&format!("/rest/api/3/issue/{key}"), &payload)
+            .await
+            .with_context(|| format!("Failed to update issue {key}"))?;
+    }
+
+    if let Some(sprint_id) = sprint {
+        add_to_sprint(ctx, key, sprint_id).await?;
+    }
 
     tracing::info!(%key, "Issue updated successfully");
     render_success(
@@ -822,6 +893,10 @@ struct IssueFields {
     issuetype: Option<IssueTypeField>,
     #[serde(default)]
     attachment: Vec<AttachmentField>,
+    // customfield_10020 is the standard Jira Cloud "Sprint" field (an array of
+    // sprint objects). Optional so instances that omit/remap it never break the parse.
+    #[serde(rename = "customfield_10020", default)]
+    sprint: Option<Value>,
 }
 
 /// Jira returns attachment `id` as a number in some responses and a string in
@@ -1421,6 +1496,54 @@ mod tests {
     fn test_issue_fields_no_attachment_field() {
         let fields: IssueFields = serde_json::from_str(r#"{"summary": "x"}"#).unwrap();
         assert!(fields.attachment.is_empty());
+    }
+
+    #[test]
+    fn test_build_sprint_add_payload() {
+        let p = build_sprint_add_payload("DEV-1");
+        assert_eq!(p, serde_json::json!({ "issues": ["DEV-1"] }));
+    }
+
+    #[test]
+    fn test_extract_active_sprint_prefers_active() {
+        // Issue is in a closed and an active sprint; show the active one.
+        let v = serde_json::json!([
+            {"id": 1, "name": "Sprint 11", "state": "closed"},
+            {"id": 2, "name": "Sprint 12", "state": "active"}
+        ]);
+        assert_eq!(
+            extract_active_sprint(&v).as_deref(),
+            Some("Sprint 12 (active)")
+        );
+    }
+
+    #[test]
+    fn test_extract_active_sprint_falls_back_to_last() {
+        let v = serde_json::json!([{"id": 1, "name": "Sprint 9", "state": "closed"}]);
+        assert_eq!(
+            extract_active_sprint(&v).as_deref(),
+            Some("Sprint 9 (closed)")
+        );
+        // empty / non-array -> None
+        assert_eq!(extract_active_sprint(&serde_json::json!([])), None);
+        assert_eq!(extract_active_sprint(&serde_json::json!("x")), None);
+    }
+
+    #[test]
+    fn test_issue_fields_deserialize_sprint() {
+        let json = r#"{
+            "summary": "S",
+            "customfield_10020": [{"id": 25446, "name": "Sprint 12", "state": "active"}]
+        }"#;
+        let fields: IssueFields = serde_json::from_str(json).unwrap();
+        let sprint = fields.sprint.as_ref().and_then(extract_active_sprint);
+        assert_eq!(sprint.as_deref(), Some("Sprint 12 (active)"));
+    }
+
+    #[test]
+    fn test_issue_fields_sprint_absent_is_none() {
+        let fields: IssueFields = serde_json::from_str(r#"{"summary": "x"}"#).unwrap();
+        assert!(fields.sprint.is_none());
     }
 
     #[test]

--- a/crates/cli/src/commands/jira/mod.rs
+++ b/crates/cli/src/commands/jira/mod.rs
@@ -156,6 +156,9 @@ enum IssueCommands {
         /// Jira custom field (repeatable). Discover IDs via `jira fields list`.
         #[arg(long = "field", value_name = "KEY=JSON_VALUE")]
         fields: Vec<String>,
+        /// Add the new issue to a sprint by numeric sprint id (Agile API).
+        #[arg(long)]
+        sprint: Option<String>,
     },
 
     /// Update an existing issue
@@ -179,6 +182,10 @@ enum IssueCommands {
         /// Jira custom field (repeatable). Discover IDs via `jira fields list`.
         #[arg(long = "field", value_name = "KEY=JSON_VALUE")]
         fields: Vec<String>,
+        /// Assign the issue to a sprint by numeric sprint id (Agile API). Prefer
+        /// this over --field customfield_10020 for sprints.
+        #[arg(long)]
+        sprint: Option<String>,
     },
 
     /// Delete an issue
@@ -839,6 +846,7 @@ pub async fn execute(args: JiraArgs, client: ApiClient, renderer: &OutputRendere
                 assignee,
                 priority,
                 fields,
+                sprint,
             } => {
                 let custom_fields = issues::parse_custom_fields(&fields)?;
                 issues::create_issue(
@@ -850,6 +858,7 @@ pub async fn execute(args: JiraArgs, client: ApiClient, renderer: &OutputRendere
                     assignee.as_deref(),
                     priority.as_deref(),
                     &custom_fields,
+                    sprint.as_deref(),
                 )
                 .await
             }
@@ -859,6 +868,7 @@ pub async fn execute(args: JiraArgs, client: ApiClient, renderer: &OutputRendere
                 description,
                 priority,
                 fields,
+                sprint,
             } => {
                 let custom_fields = issues::parse_custom_fields(&fields)?;
                 issues::update_issue(
@@ -868,6 +878,7 @@ pub async fn execute(args: JiraArgs, client: ApiClient, renderer: &OutputRendere
                     description.as_deref(),
                     priority.as_deref(),
                     &custom_fields,
+                    sprint.as_deref(),
                 )
                 .await
             }

--- a/docs/docs/commands.html
+++ b/docs/docs/commands.html
@@ -197,7 +197,11 @@ atlassian-cli jira issue create --project DEV --issue-type Task --summary <span 
 atlassian-cli jira issue update DEV-123 --summary <span class="string">"Updated summary"</span>
 atlassian-cli jira issue transition DEV-123 --transition <span class="string">"In Progress"</span>
 atlassian-cli jira issue assign DEV-123 --assignee user@example.com
-atlassian-cli jira issue delete DEV-123</code></pre>
+atlassian-cli jira issue delete DEV-123
+
+<span class="comment"># Assign to a sprint by numeric sprint id (Agile API; no customfield id needed)</span>
+atlassian-cli jira issue update DEV-123 --sprint 25446
+atlassian-cli jira issue create --project DEV --issue-type Task --summary <span class="string">"In sprint"</span> --sprint 25446</code></pre>
 
             <h2 id="jira-projects">Jira — Projects</h2>
             <pre class="code-block"><code>atlassian-cli jira project list

--- a/todo.md
+++ b/todo.md
@@ -1,5 +1,25 @@
 # Changes Made
 
+## 2026-06-18 — Jira sprint UX: --sprint flag + sprint in issue get (#72)
+
+### Context
+Issue #72 reported `--field customfield_10020=<id>` failing to set a sprint. Not a
+current bug: on 0.4.1 it already sends the working payload, the "204 error" was the
+pre-0.4.0 false alarm, and `issue get` didn't show the sprint (so "None" was a
+verification artifact). Added ergonomic sprint support.
+
+### Change (crates/cli/src/commands/jira/{issues.rs,mod.rs})
+- `--sprint <id>` flag on `jira issue create` and `update`, implemented via the Agile
+  API `POST /rest/agile/1.0/sprint/{id}/issue` `{"issues":[KEY]}` (no customfield id,
+  avoids the "Number value expected" quirk). New `add_to_sprint` + pure
+  `build_sprint_add_payload`; numeric-id validation.
+- `update` now PUTs only when there are field changes, so a `--sprint`-only update
+  doesn't send an empty `{"fields":{}}`; bails if nothing to update.
+- `issue get` now displays the sprint: `IssueFields` reads `customfield_10020`
+  (optional/default), `extract_active_sprint` summarizes it ("Sprint 12 (active)"),
+  shown in markdown + JSON/table output.
+- 5 unit tests; commands.html updated. Also merged dependabot PR #71 (zeroize 1.9.0).
+
 ## 2026-06-14 — Site-wide CLI command-syntax cleanup (docs accuracy)
 
 ### Context


### PR DESCRIPTION
Addresses #72 (sprint assignment).

## Finding
Not a current bug: on 0.4.1, `--field 'customfield_10020=25446'` already serializes to the exact payload the reporter's working curl sends (`{"fields":{"customfield_10020":25446}}` → `PUT /rest/api/3/issue/{key}`). The "error decoding response body" they saw was the HTTP-204 false alarm fixed in 0.4.0 (outdated build), and `jira issue get` did not display the sprint, so "sprint = None" was a verification artifact. Codex confirmed.

## Changes (ergonomic sprint support)
- **`--sprint <id>`** on `jira issue create` and `update`, via the Agile API `POST /rest/agile/1.0/sprint/{id}/issue` `{"issues":[KEY]}` — no per-instance customfield id, and avoids the "Number value expected" write quirk. Numeric-id validation.
- `update` now PUTs **only** when there are field changes, so a `--sprint`-only update doesn't send an empty `{"fields":{}}`; bails if nothing to update.
- **`jira issue get` now shows the sprint** — reads the standard `customfield_10020` (optional + serde default, so it never breaks parsing), summarized as e.g. `Sprint 12 (active)` in markdown and JSON/table output.
- Documented `--sprint` in the command reference.

## Tests
5 new unit tests (sprint payload, active-sprint extraction incl. fallback/empty, sprint-field deserialization present/absent). Full `cargo test` (222 bin tests) + `cargo clippy --all-targets` green.

Will reply to #72 and close it on merge. (Dependabot PR #71 zeroize bump already merged.)