### PR TITLE
chore: bump version to 0.4.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -183,7 +183,7 @@ dependencies = [
 
 [[package]]
 name = "atlassian-cli"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "anyhow",
  "atlassian-cli-api",
@@ -213,7 +213,7 @@ dependencies = [
 
 [[package]]
 name = "atlassian-cli-api"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -235,7 +235,7 @@ dependencies = [
 
 [[package]]
 name = "atlassian-cli-auth"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -257,7 +257,7 @@ dependencies = [
 
 [[package]]
 name = "atlassian-cli-bulk"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "anyhow",
  "criterion",
@@ -270,7 +270,7 @@ dependencies = [
 
 [[package]]
 name = "atlassian-cli-config"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "anyhow",
  "dirs",
@@ -284,7 +284,7 @@ dependencies = [
 
 [[package]]
 name = "atlassian-cli-output"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.4.1"
+version = "0.4.2"
 edition = "2021"
 authors = ["atlassian-cli contributors"]
 license = "MIT"

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -22,11 +22,11 @@ serde.workspace = true
 serde_json.workspace = true
 
 # Internal crates
-atlassian-cli-api = { path = "../api", version = "0.4.1" }
-atlassian-cli-auth = { path = "../auth", version = "0.4.1" }
-atlassian-cli-config = { path = "../config", version = "0.4.1" }
-atlassian-cli-output = { path = "../output", version = "0.4.1" }
-atlassian-cli-bulk = { path = "../bulk", version = "0.4.1" }
+atlassian-cli-api = { path = "../api", version = "0.4.2" }
+atlassian-cli-auth = { path = "../auth", version = "0.4.2" }
+atlassian-cli-config = { path = "../config", version = "0.4.2" }
+atlassian-cli-output = { path = "../output", version = "0.4.2" }
+atlassian-cli-bulk = { path = "../bulk", version = "0.4.2" }
 
 # CLI helpers
 url.workspace = true


### PR DESCRIPTION
Release prep for v0.4.2 (patch).

**Since 0.4.1**
- `jira issue create`/`update` `--sprint <id>` assigns an issue to a sprint via the Agile API, no customfield id needed (#72)
- `jira issue get` now displays the sprint field

Merging this and tagging `v0.4.2` triggers the release (GitHub release, Homebrew, crates.io).