### PR TITLE
docs(site): version sweep to 0.4.2 + changelog entry

### DIFF
--- a/docs/about/index.html
+++ b/docs/about/index.html
@@ -117,7 +117,7 @@
             <div class="footer-content">
                 <div class="footer-left">
                     <span class="footer-logo">atlassian-cli</span>
-                    <span class="footer-version">v0.4.1</span>
+                    <span class="footer-version">v0.4.2</span>
                 </div>
                 <div class="footer-links">
                     <a href="/jira/">Jira CLI</a>

--- a/docs/bitbucket/index.html
+++ b/docs/bitbucket/index.html
@@ -52,7 +52,7 @@
       "operatingSystem": "macOS, Linux, Windows",
       "url": "https://atlassiancli.com/bitbucket/",
       "downloadUrl": "https://github.com/omar16100/atlassian-cli/releases",
-      "softwareVersion": "0.4.1",
+      "softwareVersion": "0.4.2",
       "license": "https://opensource.org/licenses/MIT",
       "offers": {
         "@type": "Offer",
@@ -590,7 +590,7 @@ atlassian-cli bitbucket --workspace myteam \
             <div class="footer-content">
                 <div class="footer-left">
                     <span class="footer-logo">atlassian-cli</span>
-                    <span class="footer-version">v0.4.1</span>
+                    <span class="footer-version">v0.4.2</span>
                 </div>
                 <div class="footer-links">
                     <a href="https://github.com/omar16100/atlassian-cli" target="_blank" rel="noopener">GitHub</a>

--- a/docs/blog/atlassian-cli-0-4-release.html
+++ b/docs/blog/atlassian-cli-0-4-release.html
@@ -430,7 +430,7 @@ atlassian-cli jira issue comments list <span class="string">DEV-428</span> --ful
             <div class="footer-content">
                 <div class="footer-left">
                     <span class="footer-logo">atlassian-cli</span>
-                    <span class="footer-version">v0.4.1</span>
+                    <span class="footer-version">v0.4.2</span>
                 </div>
                 <div class="footer-links">
                     <a href="https://github.com/omar16100/atlassian-cli" target="_blank" rel="noopener">GitHub</a>

--- a/docs/blog/atlassian-cli-guide.html
+++ b/docs/blog/atlassian-cli-guide.html
@@ -572,7 +572,7 @@ atlassian-cli jira bulk transition \
             <div class="footer-content">
                 <div class="footer-left">
                     <span class="footer-logo">atlassian-cli</span>
-                    <span class="footer-version">v0.4.1</span>
+                    <span class="footer-version">v0.4.2</span>
                 </div>
                 <div class="footer-links">
                     <a href="https://github.com/omar16100/atlassian-cli" target="_blank" rel="noopener">GitHub</a>

--- a/docs/blog/bitbucket-cli-guide.html
+++ b/docs/blog/bitbucket-cli-guide.html
@@ -851,7 +851,7 @@ atlassian-cli bitbucket --workspace myteam commit browse <span class="string">ap
             <div class="footer-content">
                 <div class="footer-left">
                     <span class="footer-logo">atlassian-cli</span>
-                    <span class="footer-version">v0.4.1</span>
+                    <span class="footer-version">v0.4.2</span>
                 </div>
                 <div class="footer-links">
                     <a href="https://github.com/omar16100/atlassian-cli" target="_blank" rel="noopener">GitHub</a>

--- a/docs/blog/confluence-cli-guide.html
+++ b/docs/blog/confluence-cli-guide.html
@@ -785,7 +785,7 @@ atlassian-cli confluence space create \
             <div class="footer-content">
                 <div class="footer-left">
                     <span class="footer-logo">atlassian-cli</span>
-                    <span class="footer-version">v0.4.1</span>
+                    <span class="footer-version">v0.4.2</span>
                 </div>
                 <div class="footer-links">
                     <a href="https://github.com/omar16100/atlassian-cli" target="_blank" rel="noopener">GitHub</a>

--- a/docs/blog/index.html
+++ b/docs/blog/index.html
@@ -367,7 +367,7 @@
             <div class="footer-content">
                 <div class="footer-left">
                     <span class="footer-logo">atlassian-cli</span>
-                    <span class="footer-version">v0.4.1</span>
+                    <span class="footer-version">v0.4.2</span>
                 </div>
                 <div class="footer-links">
                     <a href="https://github.com/omar16100/atlassian-cli" target="_blank" rel="noopener">GitHub</a>

--- a/docs/blog/jira-bulk-operations.html
+++ b/docs/blog/jira-bulk-operations.html
@@ -663,7 +663,7 @@ echo <span class="string">"Sprint cleanup complete."</span></code></pre>
             <div class="footer-content">
                 <div class="footer-left">
                     <span class="footer-logo">atlassian-cli</span>
-                    <span class="footer-version">v0.4.1</span>
+                    <span class="footer-version">v0.4.2</span>
                 </div>
                 <div class="footer-links">
                     <a href="https://github.com/omar16100/atlassian-cli" target="_blank" rel="noopener">GitHub</a>

--- a/docs/blog/jira-cli-commands-cheat-sheet.html
+++ b/docs/blog/jira-cli-commands-cheat-sheet.html
@@ -875,7 +875,7 @@ atlassian-cli jira bulk export \
             <div class="footer-content">
                 <div class="footer-left">
                     <span class="footer-logo">atlassian-cli</span>
-                    <span class="footer-version">v0.4.1</span>
+                    <span class="footer-version">v0.4.2</span>
                 </div>
                 <div class="footer-links">
                     <a href="https://github.com/omar16100/atlassian-cli" target="_blank" rel="noopener">GitHub</a>

--- a/docs/blog/jira-cli-complete-guide.html
+++ b/docs/blog/jira-cli-complete-guide.html
@@ -830,7 +830,7 @@ jobs:
             <div class="footer-content">
                 <div class="footer-left">
                     <span class="footer-logo">atlassian-cli</span>
-                    <span class="footer-version">v0.4.1</span>
+                    <span class="footer-version">v0.4.2</span>
                 </div>
                 <div class="footer-links">
                     <a href="https://github.com/omar16100/atlassian-cli" target="_blank" rel="noopener">GitHub</a>

--- a/docs/blog/jira-cli-tools-compared.html
+++ b/docs/blog/jira-cli-tools-compared.html
@@ -730,7 +730,7 @@ jira issue create --project DEV --issuetype Task -s <span class="string">"Summar
             <div class="footer-content">
                 <div class="footer-left">
                     <span class="footer-logo">atlassian-cli</span>
-                    <span class="footer-version">v0.4.1</span>
+                    <span class="footer-version">v0.4.2</span>
                 </div>
                 <div class="footer-links">
                     <a href="https://github.com/omar16100/atlassian-cli" target="_blank" rel="noopener">GitHub</a>

--- a/docs/blog/jsm-cli-guide.html
+++ b/docs/blog/jsm-cli-guide.html
@@ -754,7 +754,7 @@ echo <span class="string">"Onboarded: $CUSTOMER_NAME ($CUSTOMER_EMAIL)"</span></
             <div class="footer-content">
                 <div class="footer-left">
                     <span class="footer-logo">atlassian-cli</span>
-                    <span class="footer-version">v0.4.1</span>
+                    <span class="footer-version">v0.4.2</span>
                 </div>
                 <div class="footer-links">
                     <a href="https://github.com/omar16100/atlassian-cli" target="_blank" rel="noopener">GitHub</a>

--- a/docs/changelog/index.html
+++ b/docs/changelog/index.html
@@ -46,9 +46,10 @@
         "@type": "ItemList",
         "itemListOrder": "https://schema.org/ItemListOrderDescending",
         "itemListElement": [
-          {"@type": "ListItem", "position": 1, "name": "v0.4.1", "url": "https://github.com/omar16100/atlassian-cli/releases/tag/v0.4.1"},
-          {"@type": "ListItem", "position": 2, "name": "v0.4.0", "url": "https://github.com/omar16100/atlassian-cli/releases/tag/v0.4.0"},
-          {"@type": "ListItem", "position": 3, "name": "v0.3.3", "url": "https://github.com/omar16100/atlassian-cli/releases/tag/v0.3.3"}
+          {"@type": "ListItem", "position": 1, "name": "v0.4.2", "url": "https://github.com/omar16100/atlassian-cli/releases/tag/v0.4.2"},
+          {"@type": "ListItem", "position": 2, "name": "v0.4.1", "url": "https://github.com/omar16100/atlassian-cli/releases/tag/v0.4.1"},
+          {"@type": "ListItem", "position": 3, "name": "v0.4.0", "url": "https://github.com/omar16100/atlassian-cli/releases/tag/v0.4.0"},
+          {"@type": "ListItem", "position": 4, "name": "v0.3.3", "url": "https://github.com/omar16100/atlassian-cli/releases/tag/v0.3.3"}
         ]
       }
     }
@@ -199,6 +200,19 @@
 
                 <div class="release">
                     <div class="release-head">
+                        <span class="release-version">0.4.2</span>
+                        <span class="release-date">June 18, 2026</span>
+                        <a class="release-link" href="https://github.com/omar16100/atlassian-cli/releases/tag/v0.4.2" target="_blank" rel="noopener">GitHub release →</a>
+                    </div>
+                    <ul>
+                        <li><strong>Jira sprints from the CLI</strong> — <code>jira issue create</code> and <code>jira issue update</code> take a <code>--sprint &lt;id&gt;</code> flag that assigns the issue to a sprint via the Agile API, so you no longer need to look up the board's <code>customfield_10020</code> id by hand.</li>
+                        <li><strong>Sprint in <code>issue get</code></strong> — <code>jira issue get</code> now displays the issue's sprint, so you can verify sprint assignment without a raw REST call.</li>
+                        <li><strong>Maintenance:</strong> bumped <code>zeroize</code> to 1.9.0.</li>
+                    </ul>
+                </div>
+
+                <div class="release">
+                    <div class="release-head">
                         <span class="release-version">0.4.1</span>
                         <span class="release-date">June 14, 2026</span>
                         <a class="release-link" href="https://github.com/omar16100/atlassian-cli/releases/tag/v0.4.1" target="_blank" rel="noopener">GitHub release →</a>
@@ -256,7 +270,7 @@
             <div class="footer-content">
                 <div class="footer-left">
                     <span class="footer-logo">atlassian-cli</span>
-                    <span class="footer-version">v0.4.1</span>
+                    <span class="footer-version">v0.4.2</span>
                 </div>
                 <div class="footer-links">
                     <a href="/jira/">Jira CLI</a>

--- a/docs/confluence/index.html
+++ b/docs/confluence/index.html
@@ -43,7 +43,7 @@
       "operatingSystem": "macOS, Linux, Windows",
       "url": "https://atlassiancli.com/confluence/",
       "downloadUrl": "https://github.com/omar16100/atlassian-cli/releases",
-      "softwareVersion": "0.4.1",
+      "softwareVersion": "0.4.2",
       "license": "https://opensource.org/licenses/MIT",
       "offers": { "@type": "Offer", "price": "0", "priceCurrency": "USD" },
       "author": { "@type": "Person", "name": "Omar Shabab", "url": "https://omarshabab.com" }
@@ -461,7 +461,7 @@ atlassian-cli confluence search cql \
             <div class="footer-content">
                 <div class="footer-left">
                     <span class="footer-logo">atlassian-cli</span>
-                    <span class="footer-version">v0.4.1</span>
+                    <span class="footer-version">v0.4.2</span>
                 </div>
                 <div class="footer-links">
                     <a href="https://github.com/omar16100/atlassian-cli" target="_blank" rel="noopener">GitHub</a>

--- a/docs/docs/auth.html
+++ b/docs/docs/auth.html
@@ -248,7 +248,7 @@ atlassian-cli auth logout --profile work --bitbucket             <span class="co
             <div class="footer-content">
                 <div class="footer-left">
                     <span class="footer-logo">atlassian-cli</span>
-                    <span class="footer-version">v0.4.1</span>
+                    <span class="footer-version">v0.4.2</span>
                 </div>
                 <div class="footer-links">
                     <a href="/install/">Install</a>

--- a/docs/docs/commands.html
+++ b/docs/docs/commands.html
@@ -438,7 +438,7 @@ atlassian-cli jsm feedback delete SD-123</code></pre>
             <div class="footer-content">
                 <div class="footer-left">
                     <span class="footer-logo">atlassian-cli</span>
-                    <span class="footer-version">v0.4.1</span>
+                    <span class="footer-version">v0.4.2</span>
                 </div>
                 <div class="footer-links">
                     <a href="/install/">Install</a>

--- a/docs/docs/index.html
+++ b/docs/docs/index.html
@@ -141,7 +141,7 @@
             <div class="footer-content">
                 <div class="footer-left">
                     <span class="footer-logo">atlassian-cli</span>
-                    <span class="footer-version">v0.4.1</span>
+                    <span class="footer-version">v0.4.2</span>
                 </div>
                 <div class="footer-links">
                     <a href="/install/">Install</a>

--- a/docs/index.html
+++ b/docs/index.html
@@ -54,7 +54,7 @@
       "operatingSystem": "macOS, Linux, Windows",
       "url": "https://atlassiancli.com/",
       "downloadUrl": "https://github.com/omar16100/atlassian-cli/releases",
-      "softwareVersion": "0.4.1",
+      "softwareVersion": "0.4.2",
       "license": "https://opensource.org/licenses/MIT",
       "isAccessibleForFree": true,
       "offers": {
@@ -549,7 +549,7 @@ atlassian-cli auth test --bitbucket --profile <span class="string">bb-ci</span><
             <div class="footer-content">
                 <div class="footer-left">
                     <span class="footer-logo">atlassian-cli</span>
-                    <span class="footer-version">v0.4.1</span>
+                    <span class="footer-version">v0.4.2</span>
                 </div>
                 <div class="footer-links">
                     <a href="/install/">Install</a>

--- a/docs/install/index.html
+++ b/docs/install/index.html
@@ -138,7 +138,7 @@
             <h2 class="section-title" id="verify" style="margin-top: 3rem;">Verify the install</h2>
             <pre class="code-block"><code>atlassian-cli --version
 atlassian-cli --help</code></pre>
-            <p>You should see the version number (currently <strong>0.4.1</strong>) and the top-level help text.</p>
+            <p>You should see the version number (currently <strong>0.4.2</strong>) and the top-level help text.</p>
 
             <h2 class="section-title" id="first-run" style="margin-top: 3rem;">First-time setup</h2>
             <p class="section-subtitle">Configure a profile once, reuse it everywhere.</p>
@@ -200,7 +200,7 @@ atlassian-cli auth test --profile <span class="string">work</span></code></pre>
             <div class="footer-content">
                 <div class="footer-left">
                     <span class="footer-logo">atlassian-cli</span>
-                    <span class="footer-version">v0.4.1</span>
+                    <span class="footer-version">v0.4.2</span>
                 </div>
                 <div class="footer-links">
                     <a href="/jira/">Jira CLI</a>

--- a/docs/jira/index.html
+++ b/docs/jira/index.html
@@ -43,7 +43,7 @@
       "operatingSystem": "macOS, Linux, Windows",
       "url": "https://atlassiancli.com/jira/",
       "downloadUrl": "https://github.com/omar16100/atlassian-cli/releases",
-      "softwareVersion": "0.4.1",
+      "softwareVersion": "0.4.2",
       "license": "https://opensource.org/licenses/MIT",
       "offers": { "@type": "Offer", "price": "0", "priceCurrency": "USD" },
       "author": { "@type": "Person", "name": "Omar Shabab", "url": "https://omarshabab.com" }
@@ -449,7 +449,7 @@ atlassian-cli jira issue search \
             <div class="footer-content">
                 <div class="footer-left">
                     <span class="footer-logo">atlassian-cli</span>
-                    <span class="footer-version">v0.4.1</span>
+                    <span class="footer-version">v0.4.2</span>
                 </div>
                 <div class="footer-links">
                     <a href="https://github.com/omar16100/atlassian-cli" target="_blank" rel="noopener">GitHub</a>

--- a/docs/jsm/index.html
+++ b/docs/jsm/index.html
@@ -52,7 +52,7 @@
       "operatingSystem": "macOS, Linux, Windows",
       "url": "https://atlassiancli.com/jsm/",
       "downloadUrl": "https://github.com/omar16100/atlassian-cli/releases",
-      "softwareVersion": "0.4.1",
+      "softwareVersion": "0.4.2",
       "license": "https://opensource.org/licenses/MIT",
       "offers": {
         "@type": "Offer",
@@ -483,7 +483,7 @@ atlassian-cli jsm request list --limit 5</code></pre>
             <div class="footer-content">
                 <div class="footer-left">
                     <span class="footer-logo">atlassian-cli</span>
-                    <span class="footer-version">v0.4.1</span>
+                    <span class="footer-version">v0.4.2</span>
                 </div>
                 <div class="footer-links">
                     <a href="https://github.com/omar16100/atlassian-cli" target="_blank" rel="noopener">GitHub</a>

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -56,7 +56,7 @@ atlassian-cli is an independent open-source project. It is NOT affiliated with, 
 
 ## Version
 
-Current version: 0.4.1
+Current version: 0.4.2
 Recent (0.4): Markdown-to-ADF for Jira descriptions and comments, a Confluence v2 Folder API command group (confluence folder get/create/delete), Bitbucket custom pipeline triggers (pipeline trigger --custom-pipeline), Jira attachments in issue get, comments list --full, and a fix for false errors on HTTP 204 responses.
 License: MIT
 Author: Omar Shabab (https://omarshabab.com)

--- a/docs/runbooks/bitbucket-branch-cleanup.html
+++ b/docs/runbooks/bitbucket-branch-cleanup.html
@@ -578,7 +578,7 @@ main <span class="string">"$@"</span></code></pre>
             <div class="footer-content">
                 <div class="footer-left">
                     <span class="footer-logo">atlassian-cli</span>
-                    <span class="footer-version">v0.4.1</span>
+                    <span class="footer-version">v0.4.2</span>
                 </div>
                 <div class="footer-links">
                     <a href="https://github.com/omar16100/atlassian-cli" target="_blank" rel="noopener">GitHub</a>

--- a/docs/runbooks/bitbucket-pr-automation.html
+++ b/docs/runbooks/bitbucket-pr-automation.html
@@ -644,7 +644,7 @@ main <span class="string">"$@"</span></code></pre>
             <div class="footer-content">
                 <div class="footer-left">
                     <span class="footer-logo">atlassian-cli</span>
-                    <span class="footer-version">v0.4.1</span>
+                    <span class="footer-version">v0.4.2</span>
                 </div>
                 <div class="footer-links">
                     <a href="https://github.com/omar16100/atlassian-cli" target="_blank" rel="noopener">GitHub</a>

--- a/docs/runbooks/bitbucket-repo-audit.html
+++ b/docs/runbooks/bitbucket-repo-audit.html
@@ -522,7 +522,7 @@ main</code></pre>
             <div class="footer-content">
                 <div class="footer-left">
                     <span class="footer-logo">atlassian-cli</span>
-                    <span class="footer-version">v0.4.1</span>
+                    <span class="footer-version">v0.4.2</span>
                 </div>
                 <div class="footer-links">
                     <a href="https://github.com/omar16100/atlassian-cli" target="_blank" rel="noopener">GitHub</a>

--- a/docs/runbooks/confluence-backup.html
+++ b/docs/runbooks/confluence-backup.html
@@ -539,7 +539,7 @@ main</code></pre>
             <div class="footer-content">
                 <div class="footer-left">
                     <span class="footer-logo">atlassian-cli</span>
-                    <span class="footer-version">v0.4.1</span>
+                    <span class="footer-version">v0.4.2</span>
                 </div>
                 <div class="footer-links">
                     <a href="https://github.com/omar16100/atlassian-cli" target="_blank" rel="noopener">GitHub</a>

--- a/docs/runbooks/confluence-bulk-cleanup.html
+++ b/docs/runbooks/confluence-bulk-cleanup.html
@@ -569,7 +569,7 @@ main <span class="string">"$@"</span></code></pre>
             <div class="footer-content">
                 <div class="footer-left">
                     <span class="footer-logo">atlassian-cli</span>
-                    <span class="footer-version">v0.4.1</span>
+                    <span class="footer-version">v0.4.2</span>
                 </div>
                 <div class="footer-links">
                     <a href="https://github.com/omar16100/atlassian-cli" target="_blank" rel="noopener">GitHub</a>

--- a/docs/runbooks/confluence-markdown-sync.html
+++ b/docs/runbooks/confluence-markdown-sync.html
@@ -644,7 +644,7 @@ jobs:
             <div class="footer-content">
                 <div class="footer-left">
                     <span class="footer-logo">atlassian-cli</span>
-                    <span class="footer-version">v0.4.1</span>
+                    <span class="footer-version">v0.4.2</span>
                 </div>
                 <div class="footer-links">
                     <a href="https://github.com/omar16100/atlassian-cli" target="_blank" rel="noopener">GitHub</a>

--- a/docs/runbooks/confluence-space-report.html
+++ b/docs/runbooks/confluence-space-report.html
@@ -559,7 +559,7 @@ main</code></pre>
             <div class="footer-content">
                 <div class="footer-left">
                     <span class="footer-logo">atlassian-cli</span>
-                    <span class="footer-version">v0.4.1</span>
+                    <span class="footer-version">v0.4.2</span>
                 </div>
                 <div class="footer-links">
                     <a href="https://github.com/omar16100/atlassian-cli" target="_blank" rel="noopener">GitHub</a>

--- a/docs/runbooks/jira-bulk-transition.html
+++ b/docs/runbooks/jira-bulk-transition.html
@@ -529,7 +529,7 @@ main <span class="string">"$@"</span></code></pre>
             <div class="footer-content">
                 <div class="footer-left">
                     <span class="footer-logo">atlassian-cli</span>
-                    <span class="footer-version">v0.4.1</span>
+                    <span class="footer-version">v0.4.2</span>
                 </div>
                 <div class="footer-links">
                     <a href="https://github.com/omar16100/atlassian-cli" target="_blank" rel="noopener">GitHub</a>

--- a/docs/runbooks/jira-project-cleanup.html
+++ b/docs/runbooks/jira-project-cleanup.html
@@ -598,7 +598,7 @@ main <span class="string">"$@"</span></code></pre>
             <div class="footer-content">
                 <div class="footer-left">
                     <span class="footer-logo">atlassian-cli</span>
-                    <span class="footer-version">v0.4.1</span>
+                    <span class="footer-version">v0.4.2</span>
                 </div>
                 <div class="footer-links">
                     <a href="https://github.com/omar16100/atlassian-cli" target="_blank" rel="noopener">GitHub</a>

--- a/docs/runbooks/jira-sprint-report.html
+++ b/docs/runbooks/jira-sprint-report.html
@@ -575,7 +575,7 @@ main <span class="string">"$@"</span></code></pre>
             <div class="footer-content">
                 <div class="footer-left">
                     <span class="footer-logo">atlassian-cli</span>
-                    <span class="footer-version">v0.4.1</span>
+                    <span class="footer-version">v0.4.2</span>
                 </div>
                 <div class="footer-links">
                     <a href="https://github.com/omar16100/atlassian-cli" target="_blank" rel="noopener">GitHub</a>


### PR DESCRIPTION
Site catch-up after the v0.4.2 release.

- Footer version badges + `softwareVersion` schema bumped 0.4.1 → 0.4.2 across the site (historical 0.4 release blog prose left untouched)
- Install page + `llms.txt` current-version text
- `/changelog/` gains a 0.4.2 entry (`--sprint` flag, sprint in `issue get`, zeroize 1.9.0) and the schema ItemList updated