### PR TITLE
fix(confluence): repair page comments and attachment downloads

### DIFF
--- a/crates/cli/src/commands/confluence/attachments.rs
+++ b/crates/cli/src/commands/confluence/attachments.rs
@@ -133,6 +133,31 @@ pub async fn upload_attachment(
     )
 }
 
+/// Build the absolute URL to fetch an attachment's bytes from its `downloadLink`.
+///
+/// The Confluence Cloud v2 API returns `downloadLink` as a path relative to the
+/// `/wiki` context (e.g. `/rest/api/content/{id}/child/attachment/{att}/download`),
+/// but `ApiClient::base_url()` is the bare site origin (no `/wiki`) — the command
+/// paths add `/wiki` themselves. Naively concatenating base_url + downloadLink
+/// therefore dropped the `/wiki` segment and every download failed. This joins
+/// them correctly and is idempotent: already-absolute links and links that
+/// already include the `/wiki` prefix are left untouched.
+fn build_attachment_download_url(base_url: &str, download_link: &str) -> String {
+    let base = base_url.trim_end_matches('/');
+    if download_link.starts_with("http://") || download_link.starts_with("https://") {
+        download_link.to_string()
+    } else if download_link.starts_with("/wiki/") || download_link == "/wiki" {
+        format!("{base}{download_link}")
+    } else {
+        let sep = if download_link.starts_with('/') {
+            ""
+        } else {
+            "/"
+        };
+        format!("{base}/wiki{sep}{download_link}")
+    }
+}
+
 // Download attachment
 pub async fn download_attachment(
     ctx: &ConfluenceContext<'_>,
@@ -155,11 +180,9 @@ pub async fn download_attachment(
 
     // Download the file
     let base_url = ctx.client.base_url();
+    let download_url = build_attachment_download_url(base_url, &attachment.download_link);
 
-    let mut request = ctx
-        .client
-        .http_client()
-        .get(format!("{}{}", base_url, attachment.download_link));
+    let mut request = ctx.client.http_client().get(download_url);
 
     // Apply authentication
     request = ctx.client.apply_auth(request);
@@ -219,4 +242,57 @@ pub async fn delete_attachment(
             attachment_id,
         ),
     )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const BASE: &str = "https://example.atlassian.net";
+
+    // Regression: the v2 API returns downloadLink relative to the /wiki context
+    // (no /wiki prefix). base_url is the bare origin, so we must insert /wiki.
+    #[test]
+    fn bare_relative_link_gets_wiki_prefix() {
+        let link = "/rest/api/content/100/child/attachment/att1/download";
+        assert_eq!(
+            build_attachment_download_url(BASE, link),
+            "https://example.atlassian.net/wiki/rest/api/content/100/child/attachment/att1/download"
+        );
+    }
+
+    // Idempotent: a link that already includes /wiki is left untouched (this is
+    // what the existing get_attachment test fixture returns).
+    #[test]
+    fn already_wiki_prefixed_link_is_unchanged() {
+        let link = "/wiki/download/attachments/100/diagram.png";
+        assert_eq!(
+            build_attachment_download_url(BASE, link),
+            "https://example.atlassian.net/wiki/download/attachments/100/diagram.png"
+        );
+    }
+
+    #[test]
+    fn absolute_link_is_used_as_is() {
+        let link = "https://media.atlassian.com/file/abc/binary?token=xyz";
+        assert_eq!(build_attachment_download_url(BASE, link), link);
+    }
+
+    #[test]
+    fn trailing_slash_on_base_url_does_not_double_up() {
+        let link = "/rest/api/content/1/child/attachment/a/download";
+        assert_eq!(
+            build_attachment_download_url("https://example.atlassian.net/", link),
+            "https://example.atlassian.net/wiki/rest/api/content/1/child/attachment/a/download"
+        );
+    }
+
+    // Defensive: a link with no leading slash still produces a well-formed URL.
+    #[test]
+    fn relative_link_without_leading_slash_is_handled() {
+        assert_eq!(
+            build_attachment_download_url(BASE, "download/attachments/1/f.png"),
+            "https://example.atlassian.net/wiki/download/attachments/1/f.png"
+        );
+    }
 }

--- a/crates/cli/src/commands/confluence/pages.rs
+++ b/crates/cli/src/commands/confluence/pages.rs
@@ -472,24 +472,71 @@ pub async fn remove_page_label(
     )
 }
 
+/// A footer comment as returned by `GET /wiki/api/v2/pages/{id}/footer-comments`.
+///
+/// Every field beyond `id` is treated as optional. The Confluence Cloud API
+/// omits `createdAt` for some comments (older/system-generated ones), and only
+/// returns `body` when `body-format` is requested. Deserialising these as
+/// required fields previously caused the whole command to fail with
+/// "missing field `createdAt`" on otherwise healthy pages.
+#[derive(Deserialize)]
+struct Comment {
+    id: String,
+    #[serde(default)]
+    title: String,
+    #[serde(rename = "createdAt", default)]
+    created_at: Option<String>,
+    #[serde(default)]
+    body: Option<CommentBody>,
+}
+
+#[derive(Deserialize)]
+struct CommentBody {
+    #[serde(default)]
+    storage: Option<CommentBodyValue>,
+}
+
+#[derive(Deserialize)]
+struct CommentBodyValue {
+    #[serde(default)]
+    value: String,
+}
+
+#[derive(Deserialize)]
+struct CommentsResponse {
+    #[serde(default)]
+    results: Vec<Comment>,
+}
+
+/// Return the raw storage-format (HTML) body of a comment, if one was returned.
+fn comment_storage_html(comment: &Comment) -> Option<&str> {
+    comment
+        .body
+        .as_ref()
+        .and_then(|b| b.storage.as_ref())
+        .map(|s| s.value.as_str())
+        .filter(|v| !v.is_empty())
+}
+
+/// Convert a comment's storage-format body to markdown for display. Falls back
+/// to an empty string when no body was returned or conversion fails.
+fn comment_body_markdown(comment: &Comment) -> String {
+    match comment_storage_html(comment) {
+        Some(html) => htmd::convert(html).unwrap_or_default().trim().to_string(),
+        None => String::new(),
+    }
+}
+
 // List page comments
 pub async fn list_page_comments(ctx: &ConfluenceContext<'_>, page_id: &str) -> Result<()> {
-    #[derive(Deserialize)]
-    struct CommentsResponse {
-        results: Vec<Comment>,
-    }
-
-    #[derive(Deserialize)]
-    struct Comment {
-        id: String,
-        title: String,
-        #[serde(rename = "createdAt")]
-        created_at: String,
-    }
-
+    // Request the storage-format body so callers actually get the comment text
+    // (the old confluence-cli captured this); previously only metadata was returned.
     let response: CommentsResponse = ctx
         .client
-        .get(&format!("/wiki/api/v2/pages/{}/footer-comments", page_id))
+        .get(&format!(
+            "/wiki/api/v2/pages/{}/footer-comments?body-format=storage",
+            page_id
+        ))
         .await
         .with_context(|| format!("Failed to list comments for page {}", page_id))?;
 
@@ -498,6 +545,7 @@ pub async fn list_page_comments(ctx: &ConfluenceContext<'_>, page_id: &str) -> R
         id: &'a str,
         title: &'a str,
         created_at: &'a str,
+        body: String,
     }
 
     let rows: Vec<Row<'_>> = response
@@ -506,7 +554,8 @@ pub async fn list_page_comments(ctx: &ConfluenceContext<'_>, page_id: &str) -> R
         .map(|c| Row {
             id: c.id.as_str(),
             title: c.title.as_str(),
-            created_at: c.created_at.as_str(),
+            created_at: c.created_at.as_deref().unwrap_or(""),
+            body: comment_body_markdown(c),
         })
         .collect();
 
@@ -996,4 +1045,84 @@ pub async fn delete_blogpost(
         &format!("✅ Deleted blog post: {blogpost_id}"),
         &MutationResult::with_id(format!("Deleted blog post: {blogpost_id}"), blogpost_id),
     )
+}
+
+#[cfg(test)]
+mod comment_tests {
+    use super::*;
+
+    // Regression: the API omits `createdAt` for some footer-comments, which used
+    // to fail deserialisation with "missing field `createdAt`" and abort the
+    // whole `page comments` command. It must now parse into `None`.
+    #[test]
+    fn comment_tolerates_missing_created_at() {
+        let c: Comment = serde_json::from_str(r#"{"id":"42","title":"Re: X"}"#).unwrap();
+        assert_eq!(c.id, "42");
+        assert_eq!(c.title, "Re: X");
+        assert!(c.created_at.is_none());
+    }
+
+    #[test]
+    fn comment_tolerates_missing_title_and_body() {
+        let c: Comment = serde_json::from_str(r#"{"id":"1"}"#).unwrap();
+        assert_eq!(c.id, "1");
+        assert_eq!(c.title, "");
+        assert!(comment_storage_html(&c).is_none());
+        assert_eq!(comment_body_markdown(&c), "");
+    }
+
+    #[test]
+    fn comment_parses_created_at_when_present() {
+        let c: Comment =
+            serde_json::from_str(r#"{"id":"7","createdAt":"2026-01-02T03:04:05Z"}"#).unwrap();
+        assert_eq!(c.created_at.as_deref(), Some("2026-01-02T03:04:05Z"));
+    }
+
+    // The body is only present when `body-format` is requested; when present we
+    // extract the storage HTML and convert it to markdown for display.
+    #[test]
+    fn comment_body_converts_storage_html_to_markdown() {
+        let json = r#"{
+            "id": "9",
+            "createdAt": "2026-01-01T00:00:00Z",
+            "body": { "storage": { "value": "<p>Hello <strong>world</strong></p>", "representation": "storage" } }
+        }"#;
+        let c: Comment = serde_json::from_str(json).unwrap();
+        assert_eq!(
+            comment_storage_html(&c),
+            Some("<p>Hello <strong>world</strong></p>")
+        );
+        let md = comment_body_markdown(&c);
+        assert!(md.contains("Hello"));
+        assert!(md.contains("world"));
+    }
+
+    #[test]
+    fn comment_empty_body_value_is_treated_as_absent() {
+        let json = r#"{"id":"3","body":{"storage":{"value":""}}}"#;
+        let c: Comment = serde_json::from_str(json).unwrap();
+        assert!(comment_storage_html(&c).is_none());
+    }
+
+    // A whole response mixing comments with and without createdAt must fully parse
+    // (previously a single bad comment failed the entire list).
+    #[test]
+    fn comments_response_with_mixed_fields_fully_parses() {
+        let json = r#"{
+            "results": [
+                {"id":"1","title":"a","createdAt":"2026-01-01T00:00:00Z"},
+                {"id":"2","title":"b"},
+                {"id":"3"}
+            ]
+        }"#;
+        let resp: CommentsResponse = serde_json::from_str(json).unwrap();
+        assert_eq!(resp.results.len(), 3);
+        assert!(resp.results[1].created_at.is_none());
+    }
+
+    #[test]
+    fn comments_response_empty_results_parses() {
+        let resp: CommentsResponse = serde_json::from_str(r#"{"results":[]}"#).unwrap();
+        assert!(resp.results.is_empty());
+    }
 }


### PR DESCRIPTION
  ### Description:

  Two Confluence bugs made `page comments` and `attachment download` unusable.
  Verified against real Cloud sites. Both fixes live in `commands/confluence/` and are
  small; most of the diff is tests.

  #### `page comments` crashed on `missing field createdAt`

  The v2 `footer-comments` endpoint omits `createdAt` on some comments, but the
  `Comment` struct required it. so serde failed the whole response and the
  command errored on perfectly healthy pages. Made the field optional.

  While here: the command only ever returned id/title/createdAt, never the
  comment text. It now requests `?body-format=storage` and renders the body as
  markdown (via the same `htmd` converter used for page bodies).

  #### `attachment download` always failed

  The download URL was built as `base_url + downloadLink`, but `base_url` has no
  `/wiki` context path (command paths add it themselves) while `downloadLink` is
  relative to `/wiki`. The missing segment broke every download. Pulled the URL
  logic into a small idempotent helper that adds `/wiki` when needed and leaves
  absolute or already-prefixed links alone.

  ### Testing

  - 12 new unit tests covering the comment parsing edge cases and each download-URL shape.
  - `cargo test --all`, `fmt`, and `clippy -D warnings` all pass.

  ### Known limitation

  Comment bodies look great in `--format json`; in markdown/table a long body
  crammed into one cell is a bit ugly.