### PR TITLE
Feat/jira adf table support

### DIFF
--- a/crates/cli/src/commands/jira/adf.rs
+++ b/crates/cli/src/commands/jira/adf.rs
@@ -50,15 +50,17 @@ impl NodeBuilder {
 pub fn markdown_to_adf(text: &str) -> Value {
     let mut options = Options::empty();
     options.insert(Options::ENABLE_STRIKETHROUGH);
+    options.insert(Options::ENABLE_TABLES);
     let parser = Parser::new_ext(text, options);
 
     let mut stack: Vec<NodeBuilder> = vec![NodeBuilder::new("doc")];
     let mut marks: Vec<Value> = Vec::new();
+    let mut in_table_head = false;
 
     for event in parser {
         match event {
-            Event::Start(tag) => handle_start(tag, &mut stack, &mut marks),
-            Event::End(tag) => handle_end(tag, &mut stack, &mut marks),
+            Event::Start(tag) => handle_start(tag, &mut stack, &mut marks, &mut in_table_head),
+            Event::End(tag) => handle_end(tag, &mut stack, &mut marks, &mut in_table_head),
             Event::Text(t) => push_text(&mut stack, &t, &marks),
             Event::Code(t) => {
                 // inline code: a text node carrying a `code` mark. ADF only allows
@@ -99,7 +101,12 @@ pub fn markdown_to_adf(text: &str) -> Value {
 
 /// Block tags push a container node; inline emphasis/link tags push a mark that
 /// applies to subsequent text until the matching end tag.
-fn handle_start(tag: Tag, stack: &mut Vec<NodeBuilder>, marks: &mut Vec<Value>) {
+fn handle_start(
+    tag: Tag,
+    stack: &mut Vec<NodeBuilder>,
+    marks: &mut Vec<Value>,
+    in_table_head: &mut bool,
+) {
     match tag {
         Tag::Paragraph => {
             close_auto_paragraph(stack);
@@ -154,6 +161,28 @@ fn handle_start(tag: Tag, stack: &mut Vec<NodeBuilder>, marks: &mut Vec<Value>) 
             close_auto_paragraph(stack);
             stack.push(NodeBuilder::new("listItem"));
         }
+        Tag::Table(_) => {
+            close_auto_paragraph(stack);
+            stack.push(NodeBuilder::new("table"));
+        }
+        Tag::TableHead => {
+            close_auto_paragraph(stack);
+            *in_table_head = true;
+            stack.push(NodeBuilder::new("tableRow"));
+        }
+        Tag::TableRow => {
+            close_auto_paragraph(stack);
+            stack.push(NodeBuilder::new("tableRow"));
+        }
+        Tag::TableCell => {
+            close_auto_paragraph(stack);
+            let cell_type = if *in_table_head {
+                "tableHeader"
+            } else {
+                "tableCell"
+            };
+            stack.push(NodeBuilder::new(cell_type));
+        }
         Tag::Emphasis => marks.push(json!({ "type": "em" })),
         Tag::Strong => marks.push(json!({ "type": "strong" })),
         Tag::Strikethrough => marks.push(json!({ "type": "strike" })),
@@ -177,7 +206,7 @@ fn handle_start(tag: Tag, stack: &mut Vec<NodeBuilder>, marks: &mut Vec<Value>) 
 fn in_restricted_parent(stack: &[NodeBuilder]) -> bool {
     matches!(
         stack.last().map(|n| n.node_type),
-        Some("listItem") | Some("blockquote")
+        Some("listItem") | Some("blockquote") | Some("tableCell") | Some("tableHeader")
     )
 }
 
@@ -192,18 +221,28 @@ fn heading_level(level: HeadingLevel) -> u8 {
     }
 }
 
-fn handle_end(tag: TagEnd, stack: &mut Vec<NodeBuilder>, marks: &mut Vec<Value>) {
+fn handle_end(
+    tag: TagEnd,
+    stack: &mut Vec<NodeBuilder>,
+    marks: &mut Vec<Value>,
+    in_table_head: &mut bool,
+) {
     match tag {
         TagEnd::Paragraph | TagEnd::Heading(_) | TagEnd::CodeBlock => pop_and_append(stack),
-        TagEnd::Item | TagEnd::BlockQuote(_) => {
+        TagEnd::Item | TagEnd::BlockQuote(_) | TagEnd::TableCell => {
             close_auto_paragraph(stack);
-            // listItem / blockquote require non-empty content.
+            // listItem / blockquote / tableCell require non-empty content.
             ensure_nonempty_block_container(stack);
             pop_and_append(stack);
         }
-        TagEnd::List(_) => {
+        TagEnd::List(_) | TagEnd::TableRow | TagEnd::Table => {
             close_auto_paragraph(stack);
             pop_and_append(stack);
+        }
+        TagEnd::TableHead => {
+            close_auto_paragraph(stack);
+            pop_and_append(stack);
+            *in_table_head = false;
         }
         TagEnd::Emphasis | TagEnd::Strong | TagEnd::Strikethrough | TagEnd::Link => {
             marks.pop();
@@ -460,6 +499,24 @@ mod tests {
         let text = &content(&doc)[0]["content"][0];
         assert_eq!(text["text"], "label");
         assert!(text.get("marks").is_none());
+    }
+
+    #[test]
+    fn gfm_table_converts_to_adf_table() {
+        let doc = markdown_to_adf("| A | B |\n|---|---|\n| 1 | 2 |\n| 3 | 4 |");
+        let table = &content(&doc)[0];
+        assert_eq!(table["type"], "table");
+        let rows = table["content"].as_array().unwrap();
+        assert_eq!(rows.len(), 3);
+        assert_eq!(rows[0]["type"], "tableRow");
+        let header_cells = rows[0]["content"].as_array().unwrap();
+        assert_eq!(header_cells[0]["type"], "tableHeader");
+        assert_eq!(header_cells[0]["content"][0]["content"][0]["text"], "A");
+        assert_eq!(rows[1]["type"], "tableRow");
+        let body_cells = rows[1]["content"].as_array().unwrap();
+        assert_eq!(body_cells[0]["type"], "tableCell");
+        assert_eq!(body_cells[0]["content"][0]["content"][0]["text"], "1");
+        assert_eq!(body_cells[1]["content"][0]["content"][0]["text"], "2");
     }
 
     #[test]

--- a/crates/cli/src/commands/jira/adf.rs
+++ b/crates/cli/src/commands/jira/adf.rs
@@ -55,12 +55,12 @@ pub fn markdown_to_adf(text: &str) -> Value {
 
     let mut stack: Vec<NodeBuilder> = vec![NodeBuilder::new("doc")];
     let mut marks: Vec<Value> = Vec::new();
-    let mut in_table_head = false;
+    let mut table = TableState::default();
 
     for event in parser {
         match event {
-            Event::Start(tag) => handle_start(tag, &mut stack, &mut marks, &mut in_table_head),
-            Event::End(tag) => handle_end(tag, &mut stack, &mut marks, &mut in_table_head),
+            Event::Start(tag) => handle_start(tag, &mut stack, &mut marks, &mut table),
+            Event::End(tag) => handle_end(tag, &mut stack, &mut marks, &mut table),
             Event::Text(t) => push_text(&mut stack, &t, &marks),
             Event::Code(t) => {
                 // inline code: a text node carrying a `code` mark. ADF only allows
@@ -99,13 +99,28 @@ pub fn markdown_to_adf(text: &str) -> Value {
     })
 }
 
+/// Table parsing state.
+///
+/// `in_head` distinguishes header cells (`tableHeader`) from body cells
+/// (`tableCell`) — pulldown-cmark emits the same `TableCell` tag for both, and
+/// has no `TableBody` tag, so body rows simply follow the `TableHead` end tag.
+///
+/// `degraded` is set when a table opens inside a listItem/blockquote, where ADF
+/// forbids tables. Markdown allows no nested tables, so a flat pair of flags is
+/// sufficient.
+#[derive(Default)]
+struct TableState {
+    in_head: bool,
+    degraded: bool,
+}
+
 /// Block tags push a container node; inline emphasis/link tags push a mark that
 /// applies to subsequent text until the matching end tag.
 fn handle_start(
     tag: Tag,
     stack: &mut Vec<NodeBuilder>,
     marks: &mut Vec<Value>,
-    in_table_head: &mut bool,
+    table: &mut TableState,
 ) {
     match tag {
         Tag::Paragraph => {
@@ -163,20 +178,38 @@ fn handle_start(
         }
         Tag::Table(_) => {
             close_auto_paragraph(stack);
-            stack.push(NodeBuilder::new("table"));
+            // ADF disallows tables inside list items and blockquotes. Degrade the
+            // whole table to one paragraph per cell so the text survives, rather
+            // than emitting a document the API rejects with a 400.
+            table.degraded = in_restricted_parent(stack);
+            stack.push(NodeBuilder::new(if table.degraded {
+                "__transparent__"
+            } else {
+                "table"
+            }));
         }
         Tag::TableHead => {
             close_auto_paragraph(stack);
-            *in_table_head = true;
-            stack.push(NodeBuilder::new("tableRow"));
+            table.in_head = true;
+            stack.push(NodeBuilder::new(if table.degraded {
+                "__transparent__"
+            } else {
+                "tableRow"
+            }));
         }
         Tag::TableRow => {
             close_auto_paragraph(stack);
-            stack.push(NodeBuilder::new("tableRow"));
+            stack.push(NodeBuilder::new(if table.degraded {
+                "__transparent__"
+            } else {
+                "tableRow"
+            }));
         }
         Tag::TableCell => {
             close_auto_paragraph(stack);
-            let cell_type = if *in_table_head {
+            let cell_type = if table.degraded {
+                "paragraph"
+            } else if table.in_head {
                 "tableHeader"
             } else {
                 "tableCell"
@@ -225,24 +258,38 @@ fn handle_end(
     tag: TagEnd,
     stack: &mut Vec<NodeBuilder>,
     marks: &mut Vec<Value>,
-    in_table_head: &mut bool,
+    table: &mut TableState,
 ) {
     match tag {
         TagEnd::Paragraph | TagEnd::Heading(_) | TagEnd::CodeBlock => pop_and_append(stack),
-        TagEnd::Item | TagEnd::BlockQuote(_) | TagEnd::TableCell => {
+        TagEnd::Item | TagEnd::BlockQuote(_) => {
             close_auto_paragraph(stack);
-            // listItem / blockquote / tableCell require non-empty content.
+            // listItem / blockquote require non-empty content.
             ensure_nonempty_block_container(stack);
             pop_and_append(stack);
         }
-        TagEnd::List(_) | TagEnd::TableRow | TagEnd::Table => {
+        TagEnd::TableCell => {
+            close_auto_paragraph(stack);
+            // A degraded cell is itself a paragraph; backfilling it would nest a
+            // paragraph inside a paragraph. A real tableCell needs >=1 block child.
+            if !table.degraded {
+                ensure_nonempty_block_container(stack);
+            }
+            pop_and_append(stack);
+        }
+        TagEnd::List(_) | TagEnd::TableRow => {
             close_auto_paragraph(stack);
             pop_and_append(stack);
+        }
+        TagEnd::Table => {
+            close_auto_paragraph(stack);
+            pop_and_append(stack);
+            table.degraded = false;
         }
         TagEnd::TableHead => {
             close_auto_paragraph(stack);
             pop_and_append(stack);
-            *in_table_head = false;
+            table.in_head = false;
         }
         TagEnd::Emphasis | TagEnd::Strong | TagEnd::Strikethrough | TagEnd::Link => {
             marks.pop();
@@ -517,6 +564,64 @@ mod tests {
         assert_eq!(body_cells[0]["type"], "tableCell");
         assert_eq!(body_cells[0]["content"][0]["content"][0]["text"], "1");
         assert_eq!(body_cells[1]["content"][0]["content"][0]["text"], "2");
+    }
+
+    #[test]
+    fn empty_table_cell_gets_empty_paragraph() {
+        let doc = markdown_to_adf("| a |  |\n|---|---|\n| 1 | 2 |");
+        let header_cells = content(&doc)[0]["content"][0]["content"]
+            .as_array()
+            .unwrap();
+        // ADF requires >=1 block child in a cell, so an empty cell holds an empty paragraph.
+        assert_eq!(header_cells[1]["type"], "tableHeader");
+        assert_eq!(header_cells[1]["content"][0]["type"], "paragraph");
+        assert!(header_cells[1]["content"][0].get("content").is_none());
+    }
+
+    // ADF disallows `table` inside listItem/blockquote; emitting one there makes
+    // Jira reject the whole document with a 400. Degrade to paragraphs instead.
+    #[test]
+    fn table_in_list_item_degrades_to_paragraphs() {
+        let doc = markdown_to_adf("- item\n\n  | a |\n  |---|\n  | 1 |");
+        let list_item = &content(&doc)[0]["content"][0];
+        assert_eq!(list_item["type"], "listItem");
+        let blocks = list_item["content"].as_array().unwrap();
+        assert!(
+            blocks.iter().all(|b| b["type"] == "paragraph"),
+            "listItem must contain only paragraphs, got {blocks:?}"
+        );
+        let texts: Vec<&str> = blocks
+            .iter()
+            .filter_map(|b| b["content"][0]["text"].as_str())
+            .collect();
+        assert_eq!(texts, vec!["item", "a", "1"]);
+    }
+
+    #[test]
+    fn table_in_blockquote_degrades_to_paragraphs() {
+        let doc = markdown_to_adf("> | a |\n> |---|\n> | 1 |");
+        let quote = &content(&doc)[0];
+        assert_eq!(quote["type"], "blockquote");
+        let blocks = quote["content"].as_array().unwrap();
+        assert!(
+            blocks.iter().all(|b| b["type"] == "paragraph"),
+            "blockquote must contain only paragraphs, got {blocks:?}"
+        );
+        let texts: Vec<&str> = blocks
+            .iter()
+            .filter_map(|b| b["content"][0]["text"].as_str())
+            .collect();
+        assert_eq!(texts, vec!["a", "1"]);
+    }
+
+    #[test]
+    fn table_after_degraded_table_still_renders_as_table() {
+        // `degraded` must reset on TagEnd::Table, or every later table is degraded too.
+        let doc = markdown_to_adf("> | a |\n> |---|\n> | 1 |\n\n| b |\n|---|\n| 2 |");
+        let c = content(&doc);
+        assert_eq!(c[0]["type"], "blockquote");
+        assert_eq!(c[1]["type"], "table");
+        assert_eq!(c[1]["content"][0]["content"][0]["type"], "tableHeader");
     }
 
     #[test]

--- a/todo.md
+++ b/todo.md
@@ -43,6 +43,23 @@ early-2026 baseline of 51 clicks/3mo), avg pos ~8.5, but 0 top-10 rankings and a
 - 50 same-day posts on a ~0-backlink domain carries Google scaled-content risk; mitigated via distinct keywords,
   genuine content, strict QA. Recommend noindex on later waves as an opt-in follow-up.
 
+## 2026-07-13 — Jira markdown-to-ADF: GFM table support
+
+### Context
+`--description`/comment `--body` markdown tables rendered as raw pipe text in
+Jira (`| a | b |` dumped literally) instead of a table. Root cause:
+`markdown_to_adf` never enabled pulldown-cmark's `ENABLE_TABLES` option, so
+table syntax was never parsed as a table.
+
+### Change (crates/cli/src/commands/jira/adf.rs)
+- Enabled `Options::ENABLE_TABLES`.
+- Mapped `Table`/`TableHead`/`TableRow`/`TableCell` events to ADF
+  `table`/`tableRow`/`tableHeader`/`tableCell` nodes; headings inside table
+  cells downgrade to paragraphs (same restriction as list items/blockquotes).
+- New unit test `gfm_table_converts_to_adf_table`; manually verified against a
+  live Jira issue (table renders correctly via both `--description` and
+  comment `--body`).
+
 ## 2026-06-18 — Jira sprint UX: --sprint flag + sprint in issue get (#72)
 
 ### Context


### PR DESCRIPTION
## Description
Enables GFM table parsing in the markdown-to-ADF converter used by `jira issue create/update --description` and `jira issue comments add/update --body`. Previously, pipe tables fell through as literal paragraph text since `pulldown-cmark`'s `ENABLE_TABLES` option was never turned on. Now `Table`/`TableHead`/`TableRow`/`TableCell` events map to the corresponding ADF `table`/`tableRow`/`tableHeader`/`tableCell` nodes, consistent with how headings/lists/blockquotes are already handled.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring

## Related Issues
Closes #(issue number)

## Testing
- [x] Added/updated unit tests
- [ ] Added/updated integration tests
- [x] Tested manually (describe below)

### Manual Testing
```bash
# Wrote a failing test first (RED), confirming the bug:
cargo test -p atlassian-cli gfm_table_converts_to_adf_table
# -> FAILED: assertion `left == right` failed
#    left: "paragraph", right: "table"

# After the fix (GREEN):
cargo test -p atlassian-cli commands::jira::adf
# -> 17 passed; 0 failed

# Full test suite:
cargo test -p atlassian-cli
# -> all tests passed

# Live verification against a real Jira issue:
atlassian-cli jira issue comments add PROJ-123 --body "| Column A | Column B | Column C |
|----------|----------|----------|
| foo | bar | baz |"
# -> confirmed in the Jira UI: rendered as a real table, not raw pipe text

atlassian-cli jira issue update PROJ-123 --description "| Column A | Column B | Column C |
|----------|----------|----------|
| foo | bar | baz |"
# -> confirmed same correct rendering via --description
```

## Checklist
- [x] Code follows project style (ran `cargo fmt`)
- [x] All clippy warnings addressed (ran `cargo clippy`)
- [x] All tests pass (ran `cargo test`)
- [x] Updated `todo.md` with changes
- [ ] Updated documentation if needed
- [x] No security vulnerabilities introduced

## Screenshots (if applicable)
Table rendering verified live in the Jira UI for both `--description` and comment `--body`. No screenshots attached as tests have been made with our own JIRA instance.

## Additional Notes
- Headings inside table cells downgrade to plain paragraphs, same restriction already applied to list items and blockquotes (ADF doesn't allow headings there).