### PR TITLE
fix(security): clear cargo-deny advisories (quinn-proto, crossbeam-epoch, anyhow)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -122,9 +122,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "argon2"
@@ -696,9 +696,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -1033,11 +1033,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
- "js-sys",
  "libc",
  "r-efi 5.3.0",
  "wasip2",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -1047,11 +1045,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 6.0.0",
  "rand_core 0.10.0",
  "wasip2",
  "wasip3",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -2093,15 +2093,16 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.13"
+version = "0.11.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1906b49b0c3bc04b5fe5d86a77925ae6524a19b816ae38ce1e426255f1d8a31"
+checksum = "2f4bfc015262b9df63c8845072ce59068853ff5872180c2ce2f13038b970e560"
 dependencies = [
  "aws-lc-rs",
  "bytes",
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "lru-slab",
- "rand 0.9.4",
+ "rand 0.10.1",
+ "rand_pcg",
  "ring",
  "rustc-hash",
  "rustls",
@@ -2223,6 +2224,15 @@ name = "rand_core"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c8d0fd677905edcbeedbf2edb6494d676f0e98d54d5cf9bda0b061cb8fb8aba"
+
+[[package]]
+name = "rand_pcg"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
+dependencies = [
+ "rand_core 0.10.0",
+]
 
 [[package]]
 name = "rand_xorshift"


### PR DESCRIPTION
`main` has been red on the Security job since at least 2026-07-10. `cargo deny check advisories` fails; `cargo audit` is `|| echo`-guarded so it never fails the job, which is why this went unnoticed.

Lockfile-only bumps, all semver-compatible (no manifest changes):

| Crate | Bump | Advisory | Reached via |
|---|---|---|---|
| quinn-proto | 0.11.13 → 0.11.16 | RUSTSEC-2026-0037 (DoS), RUSTSEC-2026-0185 (remote memory exhaustion) | reqwest |
| crossbeam-epoch | 0.9.18 → 0.9.20 | RUSTSEC-2026-0204 (invalid pointer deref) | criterion → rayon (dev-only) |
| anyhow | 1.0.102 → 1.0.103 | RUSTSEC-2026-0190 (unsoundness in `Error::downcast_mut`) | direct workspace dep |

The anyhow bump is also part of dependabot's #80 group; it is required here because `deny check advisories` still failed on it after the other two.

## Verification (local)

- `cargo deny check advisories` → **ok** (was FAILED)
- `cargo deny check licenses bans sources` → ok
- `cargo fmt --check` → ok
- `cargo clippy --all-targets --all-features -- -D warnings` → clean
- `cargo test --all` → 435 passed, 0 failed