### PR TITLE
fix(confluence): repair page comments and attachment downloads (supersedes #79)

### DIFF
--- a/crates/cli/src/commands/confluence/attachments.rs
+++ b/crates/cli/src/commands/confluence/attachments.rs
@@ -133,29 +133,25 @@ pub async fn upload_attachment(
     )
 }
 
-/// Build the absolute URL to fetch an attachment's bytes from its `downloadLink`.
+/// Resolve an attachment's `downloadLink` into a path `ApiClient` can fetch.
 ///
-/// The Confluence Cloud v2 API returns `downloadLink` as a path relative to the
-/// `/wiki` context (e.g. `/rest/api/content/{id}/child/attachment/{att}/download`),
-/// but `ApiClient::base_url()` is the bare site origin (no `/wiki`) — the command
-/// paths add `/wiki` themselves. Naively concatenating base_url + downloadLink
-/// therefore dropped the `/wiki` segment and every download failed. This joins
-/// them correctly and is idempotent: already-absolute links and links that
-/// already include the `/wiki` prefix are left untouched.
-fn build_attachment_download_url(base_url: &str, download_link: &str) -> String {
-    let base = base_url.trim_end_matches('/');
-    if download_link.starts_with("http://") || download_link.starts_with("https://") {
-        download_link.to_string()
-    } else if download_link.starts_with("/wiki/") || download_link == "/wiki" {
-        format!("{base}{download_link}")
-    } else {
-        let sep = if download_link.starts_with('/') {
-            ""
-        } else {
-            "/"
-        };
-        format!("{base}/wiki{sep}{download_link}")
+/// The Confluence Cloud v2 API returns `downloadLink` relative to the `/wiki`
+/// context path (e.g. `/download/attachments/{id}/{file}?version=1&api=v2`),
+/// while `ApiClient` is rooted at the bare site origin and every Confluence
+/// command spells `/wiki` itself. Concatenating base_url + downloadLink
+/// therefore dropped the `/wiki` segment and every download 404'd.
+///
+/// Idempotent: a link that already carries `/wiki`, or an absolute URL, is
+/// returned unchanged.
+fn attachment_download_path(download_link: &str) -> String {
+    if download_link.starts_with("http://")
+        || download_link.starts_with("https://")
+        || download_link == "/wiki"
+        || download_link.starts_with("/wiki/")
+    {
+        return download_link.to_string();
     }
+    format!("/wiki/{}", download_link.trim_start_matches('/'))
 }
 
 // Download attachment
@@ -178,28 +174,14 @@ pub async fn download_attachment(
         .await
         .with_context(|| format!("Failed to get attachment {}", attachment_id))?;
 
-    // Download the file
-    let base_url = ctx.client.base_url();
-    let download_url = build_attachment_download_url(base_url, &attachment.download_link);
-
-    let mut request = ctx.client.http_client().get(download_url);
-
-    // Apply authentication
-    request = ctx.client.apply_auth(request);
-
-    let response = request
-        .send()
+    // Fetch through ApiClient rather than a raw request: it applies auth, retries,
+    // rate limiting and the same-origin (SSRF) check, matching bamboo's
+    // download_artifact. The query string on downloadLink is preserved.
+    let content = ctx
+        .client
+        .get_bytes(&attachment_download_path(&attachment.download_link))
         .await
-        .context("Failed to download attachment")?;
-
-    if !response.status().is_success() {
-        return Err(anyhow::anyhow!("Failed to download attachment"));
-    }
-
-    let content = response
-        .bytes()
-        .await
-        .context("Failed to read attachment content")?;
+        .with_context(|| format!("Failed to download attachment {}", attachment_id))?;
 
     fs::write(output, content)
         .with_context(|| format!("Failed to write file: {}", output.display()))?;
@@ -248,51 +230,55 @@ pub async fn delete_attachment(
 mod tests {
     use super::*;
 
-    const BASE: &str = "https://example.atlassian.net";
-
     // Regression: the v2 API returns downloadLink relative to the /wiki context
-    // (no /wiki prefix). base_url is the bare origin, so we must insert /wiki.
+    // (no /wiki prefix). ApiClient is rooted at the bare origin, so we insert /wiki.
     #[test]
     fn bare_relative_link_gets_wiki_prefix() {
-        let link = "/rest/api/content/100/child/attachment/att1/download";
         assert_eq!(
-            build_attachment_download_url(BASE, link),
-            "https://example.atlassian.net/wiki/rest/api/content/100/child/attachment/att1/download"
+            attachment_download_path("/download/attachments/100/diagram.png"),
+            "/wiki/download/attachments/100/diagram.png"
         );
     }
 
-    // Idempotent: a link that already includes /wiki is left untouched (this is
-    // what the existing get_attachment test fixture returns).
+    // The real v2 downloadLink carries a query string; it must survive intact.
+    #[test]
+    fn query_string_is_preserved() {
+        assert_eq!(
+            attachment_download_path("/download/attachments/1/f.png?version=1&api=v2"),
+            "/wiki/download/attachments/1/f.png?version=1&api=v2"
+        );
+    }
+
+    // Idempotent: a link that already includes /wiki is left untouched.
     #[test]
     fn already_wiki_prefixed_link_is_unchanged() {
         let link = "/wiki/download/attachments/100/diagram.png";
-        assert_eq!(
-            build_attachment_download_url(BASE, link),
-            "https://example.atlassian.net/wiki/download/attachments/100/diagram.png"
-        );
+        assert_eq!(attachment_download_path(link), link);
     }
 
+    // Absolute links pass through. ApiClient::get_bytes then applies its
+    // same-origin check, so a cross-host link is rejected rather than fetched.
     #[test]
     fn absolute_link_is_used_as_is() {
-        let link = "https://media.atlassian.com/file/abc/binary?token=xyz";
-        assert_eq!(build_attachment_download_url(BASE, link), link);
+        let link = "https://example.atlassian.net/wiki/download/attachments/1/a.png";
+        assert_eq!(attachment_download_path(link), link);
     }
 
-    #[test]
-    fn trailing_slash_on_base_url_does_not_double_up() {
-        let link = "/rest/api/content/1/child/attachment/a/download";
-        assert_eq!(
-            build_attachment_download_url("https://example.atlassian.net/", link),
-            "https://example.atlassian.net/wiki/rest/api/content/1/child/attachment/a/download"
-        );
-    }
-
-    // Defensive: a link with no leading slash still produces a well-formed URL.
+    // Defensive: a link with no leading slash still produces a well-formed path.
     #[test]
     fn relative_link_without_leading_slash_is_handled() {
         assert_eq!(
-            build_attachment_download_url(BASE, "download/attachments/1/f.png"),
-            "https://example.atlassian.net/wiki/download/attachments/1/f.png"
+            attachment_download_path("download/attachments/1/f.png"),
+            "/wiki/download/attachments/1/f.png"
+        );
+    }
+
+    // No double slash even if the API ever returned one.
+    #[test]
+    fn double_leading_slash_is_normalised() {
+        assert_eq!(
+            attachment_download_path("//download/attachments/1/f.png"),
+            "/wiki/download/attachments/1/f.png"
         );
     }
 }

--- a/crates/cli/src/commands/confluence/attachments.rs
+++ b/crates/cli/src/commands/confluence/attachments.rs
@@ -133,6 +133,31 @@ pub async fn upload_attachment(
     )
 }
 
+/// Build the absolute URL to fetch an attachment's bytes from its `downloadLink`.
+///
+/// The Confluence Cloud v2 API returns `downloadLink` as a path relative to the
+/// `/wiki` context (e.g. `/rest/api/content/{id}/child/attachment/{att}/download`),
+/// but `ApiClient::base_url()` is the bare site origin (no `/wiki`) — the command
+/// paths add `/wiki` themselves. Naively concatenating base_url + downloadLink
+/// therefore dropped the `/wiki` segment and every download failed. This joins
+/// them correctly and is idempotent: already-absolute links and links that
+/// already include the `/wiki` prefix are left untouched.
+fn build_attachment_download_url(base_url: &str, download_link: &str) -> String {
+    let base = base_url.trim_end_matches('/');
+    if download_link.starts_with("http://") || download_link.starts_with("https://") {
+        download_link.to_string()
+    } else if download_link.starts_with("/wiki/") || download_link == "/wiki" {
+        format!("{base}{download_link}")
+    } else {
+        let sep = if download_link.starts_with('/') {
+            ""
+        } else {
+            "/"
+        };
+        format!("{base}/wiki{sep}{download_link}")
+    }
+}
+
 // Download attachment
 pub async fn download_attachment(
     ctx: &ConfluenceContext<'_>,
@@ -155,11 +180,9 @@ pub async fn download_attachment(
 
     // Download the file
     let base_url = ctx.client.base_url();
+    let download_url = build_attachment_download_url(base_url, &attachment.download_link);
 
-    let mut request = ctx
-        .client
-        .http_client()
-        .get(format!("{}{}", base_url, attachment.download_link));
+    let mut request = ctx.client.http_client().get(download_url);
 
     // Apply authentication
     request = ctx.client.apply_auth(request);
@@ -219,4 +242,57 @@ pub async fn delete_attachment(
             attachment_id,
         ),
     )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const BASE: &str = "https://example.atlassian.net";
+
+    // Regression: the v2 API returns downloadLink relative to the /wiki context
+    // (no /wiki prefix). base_url is the bare origin, so we must insert /wiki.
+    #[test]
+    fn bare_relative_link_gets_wiki_prefix() {
+        let link = "/rest/api/content/100/child/attachment/att1/download";
+        assert_eq!(
+            build_attachment_download_url(BASE, link),
+            "https://example.atlassian.net/wiki/rest/api/content/100/child/attachment/att1/download"
+        );
+    }
+
+    // Idempotent: a link that already includes /wiki is left untouched (this is
+    // what the existing get_attachment test fixture returns).
+    #[test]
+    fn already_wiki_prefixed_link_is_unchanged() {
+        let link = "/wiki/download/attachments/100/diagram.png";
+        assert_eq!(
+            build_attachment_download_url(BASE, link),
+            "https://example.atlassian.net/wiki/download/attachments/100/diagram.png"
+        );
+    }
+
+    #[test]
+    fn absolute_link_is_used_as_is() {
+        let link = "https://media.atlassian.com/file/abc/binary?token=xyz";
+        assert_eq!(build_attachment_download_url(BASE, link), link);
+    }
+
+    #[test]
+    fn trailing_slash_on_base_url_does_not_double_up() {
+        let link = "/rest/api/content/1/child/attachment/a/download";
+        assert_eq!(
+            build_attachment_download_url("https://example.atlassian.net/", link),
+            "https://example.atlassian.net/wiki/rest/api/content/1/child/attachment/a/download"
+        );
+    }
+
+    // Defensive: a link with no leading slash still produces a well-formed URL.
+    #[test]
+    fn relative_link_without_leading_slash_is_handled() {
+        assert_eq!(
+            build_attachment_download_url(BASE, "download/attachments/1/f.png"),
+            "https://example.atlassian.net/wiki/download/attachments/1/f.png"
+        );
+    }
 }

--- a/crates/cli/src/commands/confluence/mod.rs
+++ b/crates/cli/src/commands/confluence/mod.rs
@@ -262,6 +262,9 @@ enum PageCommands {
     Comments {
         /// Page ID
         page_id: String,
+        /// Show full comment body instead of truncated preview
+        #[arg(long)]
+        full: bool,
     },
     /// Add comment to page
     AddComment {
@@ -642,7 +645,9 @@ pub async fn execute(
             PageCommands::RemoveLabel { page_id, label } => {
                 pages::remove_page_label(&ctx, &page_id, &label).await
             }
-            PageCommands::Comments { page_id } => pages::list_page_comments(&ctx, &page_id).await,
+            PageCommands::Comments { page_id, full } => {
+                pages::list_page_comments(&ctx, &page_id, full).await
+            }
             PageCommands::AddComment { page_id, comment } => {
                 pages::add_page_comment(&ctx, &page_id, &comment).await
             }

--- a/crates/cli/src/commands/confluence/pages.rs
+++ b/crates/cli/src/commands/confluence/pages.rs
@@ -472,24 +472,71 @@ pub async fn remove_page_label(
     )
 }
 
+/// A footer comment as returned by `GET /wiki/api/v2/pages/{id}/footer-comments`.
+///
+/// Every field beyond `id` is treated as optional. The Confluence Cloud API
+/// omits `createdAt` for some comments (older/system-generated ones), and only
+/// returns `body` when `body-format` is requested. Deserialising these as
+/// required fields previously caused the whole command to fail with
+/// "missing field `createdAt`" on otherwise healthy pages.
+#[derive(Deserialize)]
+struct Comment {
+    id: String,
+    #[serde(default)]
+    title: String,
+    #[serde(rename = "createdAt", default)]
+    created_at: Option<String>,
+    #[serde(default)]
+    body: Option<CommentBody>,
+}
+
+#[derive(Deserialize)]
+struct CommentBody {
+    #[serde(default)]
+    storage: Option<CommentBodyValue>,
+}
+
+#[derive(Deserialize)]
+struct CommentBodyValue {
+    #[serde(default)]
+    value: String,
+}
+
+#[derive(Deserialize)]
+struct CommentsResponse {
+    #[serde(default)]
+    results: Vec<Comment>,
+}
+
+/// Return the raw storage-format (HTML) body of a comment, if one was returned.
+fn comment_storage_html(comment: &Comment) -> Option<&str> {
+    comment
+        .body
+        .as_ref()
+        .and_then(|b| b.storage.as_ref())
+        .map(|s| s.value.as_str())
+        .filter(|v| !v.is_empty())
+}
+
+/// Convert a comment's storage-format body to markdown for display. Falls back
+/// to an empty string when no body was returned or conversion fails.
+fn comment_body_markdown(comment: &Comment) -> String {
+    match comment_storage_html(comment) {
+        Some(html) => htmd::convert(html).unwrap_or_default().trim().to_string(),
+        None => String::new(),
+    }
+}
+
 // List page comments
 pub async fn list_page_comments(ctx: &ConfluenceContext<'_>, page_id: &str) -> Result<()> {
-    #[derive(Deserialize)]
-    struct CommentsResponse {
-        results: Vec<Comment>,
-    }
-
-    #[derive(Deserialize)]
-    struct Comment {
-        id: String,
-        title: String,
-        #[serde(rename = "createdAt")]
-        created_at: String,
-    }
-
+    // Request the storage-format body so callers actually get the comment text
+    // (the old confluence-cli captured this); previously only metadata was returned.
     let response: CommentsResponse = ctx
         .client
-        .get(&format!("/wiki/api/v2/pages/{}/footer-comments", page_id))
+        .get(&format!(
+            "/wiki/api/v2/pages/{}/footer-comments?body-format=storage",
+            page_id
+        ))
         .await
         .with_context(|| format!("Failed to list comments for page {}", page_id))?;
 
@@ -498,6 +545,7 @@ pub async fn list_page_comments(ctx: &ConfluenceContext<'_>, page_id: &str) -> R
         id: &'a str,
         title: &'a str,
         created_at: &'a str,
+        body: String,
     }
 
     let rows: Vec<Row<'_>> = response
@@ -506,7 +554,8 @@ pub async fn list_page_comments(ctx: &ConfluenceContext<'_>, page_id: &str) -> R
         .map(|c| Row {
             id: c.id.as_str(),
             title: c.title.as_str(),
-            created_at: c.created_at.as_str(),
+            created_at: c.created_at.as_deref().unwrap_or(""),
+            body: comment_body_markdown(c),
         })
         .collect();
 
@@ -996,4 +1045,84 @@ pub async fn delete_blogpost(
         &format!("✅ Deleted blog post: {blogpost_id}"),
         &MutationResult::with_id(format!("Deleted blog post: {blogpost_id}"), blogpost_id),
     )
+}
+
+#[cfg(test)]
+mod comment_tests {
+    use super::*;
+
+    // Regression: the API omits `createdAt` for some footer-comments, which used
+    // to fail deserialisation with "missing field `createdAt`" and abort the
+    // whole `page comments` command. It must now parse into `None`.
+    #[test]
+    fn comment_tolerates_missing_created_at() {
+        let c: Comment = serde_json::from_str(r#"{"id":"42","title":"Re: X"}"#).unwrap();
+        assert_eq!(c.id, "42");
+        assert_eq!(c.title, "Re: X");
+        assert!(c.created_at.is_none());
+    }
+
+    #[test]
+    fn comment_tolerates_missing_title_and_body() {
+        let c: Comment = serde_json::from_str(r#"{"id":"1"}"#).unwrap();
+        assert_eq!(c.id, "1");
+        assert_eq!(c.title, "");
+        assert!(comment_storage_html(&c).is_none());
+        assert_eq!(comment_body_markdown(&c), "");
+    }
+
+    #[test]
+    fn comment_parses_created_at_when_present() {
+        let c: Comment =
+            serde_json::from_str(r#"{"id":"7","createdAt":"2026-01-02T03:04:05Z"}"#).unwrap();
+        assert_eq!(c.created_at.as_deref(), Some("2026-01-02T03:04:05Z"));
+    }
+
+    // The body is only present when `body-format` is requested; when present we
+    // extract the storage HTML and convert it to markdown for display.
+    #[test]
+    fn comment_body_converts_storage_html_to_markdown() {
+        let json = r#"{
+            "id": "9",
+            "createdAt": "2026-01-01T00:00:00Z",
+            "body": { "storage": { "value": "<p>Hello <strong>world</strong></p>", "representation": "storage" } }
+        }"#;
+        let c: Comment = serde_json::from_str(json).unwrap();
+        assert_eq!(
+            comment_storage_html(&c),
+            Some("<p>Hello <strong>world</strong></p>")
+        );
+        let md = comment_body_markdown(&c);
+        assert!(md.contains("Hello"));
+        assert!(md.contains("world"));
+    }
+
+    #[test]
+    fn comment_empty_body_value_is_treated_as_absent() {
+        let json = r#"{"id":"3","body":{"storage":{"value":""}}}"#;
+        let c: Comment = serde_json::from_str(json).unwrap();
+        assert!(comment_storage_html(&c).is_none());
+    }
+
+    // A whole response mixing comments with and without createdAt must fully parse
+    // (previously a single bad comment failed the entire list).
+    #[test]
+    fn comments_response_with_mixed_fields_fully_parses() {
+        let json = r#"{
+            "results": [
+                {"id":"1","title":"a","createdAt":"2026-01-01T00:00:00Z"},
+                {"id":"2","title":"b"},
+                {"id":"3"}
+            ]
+        }"#;
+        let resp: CommentsResponse = serde_json::from_str(json).unwrap();
+        assert_eq!(resp.results.len(), 3);
+        assert!(resp.results[1].created_at.is_none());
+    }
+
+    #[test]
+    fn comments_response_empty_results_parses() {
+        let resp: CommentsResponse = serde_json::from_str(r#"{"results":[]}"#).unwrap();
+        assert!(resp.results.is_empty());
+    }
 }

--- a/crates/cli/src/commands/confluence/pages.rs
+++ b/crates/cli/src/commands/confluence/pages.rs
@@ -474,20 +474,27 @@ pub async fn remove_page_label(
 
 /// A footer comment as returned by `GET /wiki/api/v2/pages/{id}/footer-comments`.
 ///
-/// Every field beyond `id` is treated as optional. The Confluence Cloud API
-/// omits `createdAt` for some comments (older/system-generated ones), and only
-/// returns `body` when `body-format` is requested. Deserialising these as
-/// required fields previously caused the whole command to fail with
-/// "missing field `createdAt`" on otherwise healthy pages.
+/// Everything beyond `id` is optional. Per the Confluence Cloud v2 schema
+/// (`FooterCommentModel`) a comment has **no top-level `createdAt`** — the
+/// timestamp lives at `version.createdAt`. Deserialising `createdAt` as a
+/// required top-level field made this command fail with
+/// "missing field `createdAt`" on any page that had at least one comment.
+/// `body` is only returned when `body-format` is requested.
 #[derive(Deserialize)]
 struct Comment {
     id: String,
     #[serde(default)]
     title: String,
-    #[serde(rename = "createdAt", default)]
-    created_at: Option<String>,
+    #[serde(default)]
+    version: Option<CommentVersion>,
     #[serde(default)]
     body: Option<CommentBody>,
+}
+
+#[derive(Deserialize)]
+struct CommentVersion {
+    #[serde(rename = "createdAt", default)]
+    created_at: Option<String>,
 }
 
 #[derive(Deserialize)]
@@ -506,6 +513,15 @@ struct CommentBodyValue {
 struct CommentsResponse {
     #[serde(default)]
     results: Vec<Comment>,
+}
+
+/// The comment's creation timestamp, which the v2 API nests under `version`.
+fn comment_created_at(comment: &Comment) -> &str {
+    comment
+        .version
+        .as_ref()
+        .and_then(|v| v.created_at.as_deref())
+        .unwrap_or("")
 }
 
 /// Return the raw storage-format (HTML) body of a comment, if one was returned.
@@ -527,10 +543,28 @@ fn comment_body_markdown(comment: &Comment) -> String {
     }
 }
 
+/// Collapse a body to a single-line preview.
+///
+/// The table renderer does not wrap, `render_csv` does not quote or escape, and
+/// `render_markdown_table` does not escape newlines, so an unbounded multi-line
+/// body would corrupt those outputs. Mirrors `jira issue comments`, which shows
+/// a short preview by default and the full body behind `--full`.
+fn comment_body_preview(body: &str) -> String {
+    let flattened = body.split_whitespace().collect::<Vec<_>>().join(" ");
+    flattened.chars().take(COMMENT_PREVIEW_CHARS).collect()
+}
+
+/// Preview length, matching `jira issue comments`.
+const COMMENT_PREVIEW_CHARS: usize = 50;
+
 // List page comments
-pub async fn list_page_comments(ctx: &ConfluenceContext<'_>, page_id: &str) -> Result<()> {
-    // Request the storage-format body so callers actually get the comment text
-    // (the old confluence-cli captured this); previously only metadata was returned.
+pub async fn list_page_comments(
+    ctx: &ConfluenceContext<'_>,
+    page_id: &str,
+    full: bool,
+) -> Result<()> {
+    // Request the storage-format body so callers actually get the comment text;
+    // previously only metadata was returned.
     let response: CommentsResponse = ctx
         .client
         .get(&format!(
@@ -545,17 +579,29 @@ pub async fn list_page_comments(ctx: &ConfluenceContext<'_>, page_id: &str) -> R
         id: &'a str,
         title: &'a str,
         created_at: &'a str,
-        body: String,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        body_preview: Option<String>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        body: Option<String>,
     }
 
     let rows: Vec<Row<'_>> = response
         .results
         .iter()
-        .map(|c| Row {
-            id: c.id.as_str(),
-            title: c.title.as_str(),
-            created_at: c.created_at.as_deref().unwrap_or(""),
-            body: comment_body_markdown(c),
+        .map(|c| {
+            let text = comment_body_markdown(c);
+            let (body_preview, body) = if full {
+                (None, Some(text))
+            } else {
+                (Some(comment_body_preview(&text)), None)
+            };
+            Row {
+                id: c.id.as_str(),
+                title: c.title.as_str(),
+                created_at: comment_created_at(c),
+                body_preview,
+                body,
+            }
         })
         .collect();
 
@@ -1051,78 +1097,95 @@ pub async fn delete_blogpost(
 mod comment_tests {
     use super::*;
 
-    // Regression: the API omits `createdAt` for some footer-comments, which used
-    // to fail deserialisation with "missing field `createdAt`" and abort the
-    // whole `page comments` command. It must now parse into `None`.
+    // Regression: per the v2 schema (FooterCommentModel) a comment has NO
+    // top-level `createdAt` -- the timestamp is at `version.createdAt`. The old
+    // code required a top-level `createdAt: String`, so `page comments` failed
+    // with "missing field `createdAt`" on ANY page that had a comment.
     #[test]
-    fn comment_tolerates_missing_created_at() {
+    fn comment_reads_created_at_from_version() {
+        let json = r#"{
+            "id": "42",
+            "title": "Re: X",
+            "version": { "number": 1, "createdAt": "2026-01-02T03:04:05Z" }
+        }"#;
+        let c: Comment = serde_json::from_str(json).unwrap();
+        assert_eq!(c.id, "42");
+        assert_eq!(comment_created_at(&c), "2026-01-02T03:04:05Z");
+    }
+
+    // The real-world payload that used to abort the whole command.
+    #[test]
+    fn comment_without_top_level_created_at_still_parses() {
         let c: Comment = serde_json::from_str(r#"{"id":"42","title":"Re: X"}"#).unwrap();
         assert_eq!(c.id, "42");
-        assert_eq!(c.title, "Re: X");
-        assert!(c.created_at.is_none());
+        assert_eq!(comment_created_at(&c), "");
     }
 
     #[test]
     fn comment_tolerates_missing_title_and_body() {
         let c: Comment = serde_json::from_str(r#"{"id":"1"}"#).unwrap();
-        assert_eq!(c.id, "1");
         assert_eq!(c.title, "");
         assert!(comment_storage_html(&c).is_none());
         assert_eq!(comment_body_markdown(&c), "");
     }
 
-    #[test]
-    fn comment_parses_created_at_when_present() {
-        let c: Comment =
-            serde_json::from_str(r#"{"id":"7","createdAt":"2026-01-02T03:04:05Z"}"#).unwrap();
-        assert_eq!(c.created_at.as_deref(), Some("2026-01-02T03:04:05Z"));
-    }
-
-    // The body is only present when `body-format` is requested; when present we
-    // extract the storage HTML and convert it to markdown for display.
+    // Body is only present when body-format is requested; when present we take the
+    // storage HTML and convert it to markdown.
     #[test]
     fn comment_body_converts_storage_html_to_markdown() {
         let json = r#"{
             "id": "9",
-            "createdAt": "2026-01-01T00:00:00Z",
             "body": { "storage": { "value": "<p>Hello <strong>world</strong></p>", "representation": "storage" } }
         }"#;
         let c: Comment = serde_json::from_str(json).unwrap();
-        assert_eq!(
-            comment_storage_html(&c),
-            Some("<p>Hello <strong>world</strong></p>")
-        );
         let md = comment_body_markdown(&c);
-        assert!(md.contains("Hello"));
-        assert!(md.contains("world"));
+        assert!(md.contains("Hello"), "got {md:?}");
+        assert!(md.contains("world"), "got {md:?}");
     }
 
     #[test]
     fn comment_empty_body_value_is_treated_as_absent() {
-        let json = r#"{"id":"3","body":{"storage":{"value":""}}}"#;
-        let c: Comment = serde_json::from_str(json).unwrap();
+        let c: Comment =
+            serde_json::from_str(r#"{"id":"3","body":{"storage":{"value":""}}}"#).unwrap();
         assert!(comment_storage_html(&c).is_none());
     }
 
-    // A whole response mixing comments with and without createdAt must fully parse
-    // (previously a single bad comment failed the entire list).
+    // A response mixing comments with and without version must fully parse
+    // (previously a single comment failed the entire list).
     #[test]
     fn comments_response_with_mixed_fields_fully_parses() {
         let json = r#"{
             "results": [
-                {"id":"1","title":"a","createdAt":"2026-01-01T00:00:00Z"},
+                {"id":"1","title":"a","version":{"createdAt":"2026-01-01T00:00:00Z"}},
                 {"id":"2","title":"b"},
                 {"id":"3"}
             ]
         }"#;
         let resp: CommentsResponse = serde_json::from_str(json).unwrap();
         assert_eq!(resp.results.len(), 3);
-        assert!(resp.results[1].created_at.is_none());
+        assert_eq!(comment_created_at(&resp.results[0]), "2026-01-01T00:00:00Z");
+        assert_eq!(comment_created_at(&resp.results[1]), "");
     }
 
     #[test]
     fn comments_response_empty_results_parses() {
         let resp: CommentsResponse = serde_json::from_str(r#"{"results":[]}"#).unwrap();
         assert!(resp.results.is_empty());
+    }
+
+    // The table/CSV/markdown renderers do not wrap, quote or escape newlines, so
+    // the default preview must be a single line and bounded.
+    #[test]
+    fn body_preview_is_single_line_and_bounded() {
+        let body = "line one\nline two\n\nline three";
+        let preview = comment_body_preview(body);
+        assert!(!preview.contains('\n'), "preview must not contain newlines");
+        assert_eq!(preview, "line one line two line three");
+
+        let long = "x".repeat(200);
+        assert_eq!(
+            comment_body_preview(&long).chars().count(),
+            COMMENT_PREVIEW_CHARS
+        );
     }
 }

--- a/crates/cli/tests/confluence_integration.rs
+++ b/crates/cli/tests/confluence_integration.rs
@@ -395,7 +395,10 @@ async fn test_get_attachment() {
             "title": "diagram.png",
             "fileSize": 102400,
             "mediaType": "image/png",
-            "downloadLink": "/wiki/download/attachments/100001/diagram.png"
+            // The real v2 API returns downloadLink relative to the /wiki context,
+            // i.e. WITHOUT a /wiki prefix. The old fixture invented one, which is
+            // why no test caught the dropped-/wiki download bug.
+            "downloadLink": "/download/attachments/100001/diagram.png?version=1&api=v2"
         })))
         .mount(&mock_server)
         .await;
@@ -756,4 +759,77 @@ async fn test_publish_draft_blogpost() {
     let result = put_response.unwrap();
     assert_eq!(result["status"], "current");
     assert_eq!(result["version"]["number"], 1);
+}
+
+// ============================================================================
+// Comments
+// ============================================================================
+
+// Regression: the v2 footer-comment object has no top-level `createdAt` (it lives
+// at `version.createdAt`) and only returns `body` when body-format is requested.
+// The old model required a top-level `createdAt: String`, so this payload aborted
+// the whole `page comments` command with "missing field `createdAt`".
+#[tokio::test]
+async fn test_list_page_comments_real_shape() {
+    let mock_server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/wiki/api/v2/pages/100001/footer-comments"))
+        .and(query_param("body-format", "storage"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "results": [
+                {
+                    "id": "c-1",
+                    "title": "Re: Design",
+                    "version": { "number": 1, "createdAt": "2026-01-02T03:04:05Z" },
+                    "body": { "storage": { "value": "<p>Looks good</p>", "representation": "storage" } }
+                },
+                { "id": "c-2" }
+            ]
+        })))
+        .mount(&mock_server)
+        .await;
+
+    let client = ApiClient::new(mock_server.uri())
+        .unwrap()
+        .with_basic_auth("test@example.com", "fake-token");
+
+    let response: Result<serde_json::Value, _> = client
+        .get("/wiki/api/v2/pages/100001/footer-comments?body-format=storage")
+        .await;
+
+    assert!(response.is_ok(), "comments request failed: {response:?}");
+    let data = response.unwrap();
+    let results = data["results"].as_array().unwrap();
+    assert_eq!(results.len(), 2);
+    assert_eq!(results[0]["version"]["createdAt"], "2026-01-02T03:04:05Z");
+    assert!(results[0].get("createdAt").is_none());
+}
+
+// Regression: downloadLink is relative to the /wiki context, so the bytes must be
+// fetched from /wiki + downloadLink. Fetching base_url + downloadLink dropped the
+// /wiki segment and every download 404'd. Query string must survive too.
+#[tokio::test]
+async fn test_download_attachment_bytes_uses_wiki_prefix() {
+    let mock_server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/wiki/download/attachments/100001/diagram.png"))
+        .and(query_param("version", "1"))
+        .respond_with(ResponseTemplate::new(200).set_body_bytes(b"PNGDATA".to_vec()))
+        .mount(&mock_server)
+        .await;
+
+    let client = ApiClient::new(mock_server.uri())
+        .unwrap()
+        .with_basic_auth("test@example.com", "fake-token");
+
+    // This is exactly the path download_attachment builds from the v2 downloadLink
+    // "/download/attachments/100001/diagram.png?version=1&api=v2".
+    let bytes = client
+        .get_bytes("/wiki/download/attachments/100001/diagram.png?version=1&api=v2")
+        .await;
+
+    assert!(bytes.is_ok(), "download failed: {bytes:?}");
+    assert_eq!(bytes.unwrap(), b"PNGDATA".to_vec());
 }

--- a/crates/output/src/lib.rs
+++ b/crates/output/src/lib.rs
@@ -136,12 +136,34 @@ impl OutputRenderer {
             None => return Ok(false),
         };
 
-        println!("{}", headers.join(","));
+        println!("{}", Self::csv_record(&headers));
         for row in rows {
-            println!("{}", row.join(","));
+            println!("{}", Self::csv_record(&row));
         }
 
         Ok(true)
+    }
+
+    /// Join one CSV record, quoting per RFC 4180.
+    ///
+    /// Fields routinely contain commas (issue summaries, comment bodies) and can
+    /// contain newlines. Joining them raw shifted columns and broke rows, so any
+    /// field containing a comma, double quote, CR or LF is wrapped in double
+    /// quotes with internal quotes doubled.
+    fn csv_record(fields: &[String]) -> String {
+        fields
+            .iter()
+            .map(|f| Self::csv_field(f))
+            .collect::<Vec<_>>()
+            .join(",")
+    }
+
+    fn csv_field(field: &str) -> String {
+        if field.contains([',', '"', '\n', '\r']) {
+            format!("\"{}\"", field.replace('"', "\"\""))
+        } else {
+            field.to_string()
+        }
     }
 
     fn render_quiet(&self, value: &Value) -> bool {
@@ -197,7 +219,7 @@ impl OutputRenderer {
         // Header row
         let header_line: String = headers
             .iter()
-            .map(|h| h.replace('|', "\\|"))
+            .map(|h| Self::markdown_cell(h))
             .collect::<Vec<_>>()
             .join(" | ");
         println!("| {} |", header_line);
@@ -214,13 +236,24 @@ impl OutputRenderer {
         for row in rows {
             let cells: String = row
                 .iter()
-                .map(|c| c.replace('|', "\\|"))
+                .map(|c| Self::markdown_cell(c))
                 .collect::<Vec<_>>()
                 .join(" | ");
             println!("| {} |", cells);
         }
 
         Ok(true)
+    }
+
+    /// Escape one markdown table cell.
+    ///
+    /// A newline terminates the row in markdown, so a multi-line value (a comment
+    /// body, a page description) silently broke the table. Newlines become `<br>`,
+    /// and `|` is escaped so it does not open a new column.
+    fn markdown_cell(cell: &str) -> String {
+        cell.replace('|', "\\|")
+            .replace("\r\n", "<br>")
+            .replace(['\n', '\r'], "<br>")
     }
 
     fn render_markdown_single(&self, value: &Value) -> Result<bool> {
@@ -539,6 +572,49 @@ mod tests {
         let renderer = OutputRenderer::new(OutputFormat::Markdown);
         let result = renderer.render(&test_data);
         assert!(result.is_ok());
+    }
+
+    // Regression: render_csv used to `row.join(",")` with no quoting, so any field
+    // containing a comma (issue summaries, comment bodies) shifted every later
+    // column, and a newline destroyed the row outright.
+    #[test]
+    fn test_csv_field_quotes_per_rfc4180() {
+        assert_eq!(OutputRenderer::csv_field("plain"), "plain");
+        assert_eq!(OutputRenderer::csv_field("a,b"), "\"a,b\"");
+        assert_eq!(
+            OutputRenderer::csv_field("say \"hi\""),
+            "\"say \"\"hi\"\"\""
+        );
+        assert_eq!(
+            OutputRenderer::csv_field("line1\nline2"),
+            "\"line1\nline2\""
+        );
+        assert_eq!(OutputRenderer::csv_field("cr\r"), "\"cr\r\"");
+        // Quoting only when required, so unaffected output is byte-identical.
+        assert_eq!(OutputRenderer::csv_field("no-specials"), "no-specials");
+    }
+
+    #[test]
+    fn test_csv_record_keeps_columns_aligned() {
+        let fields = vec![
+            "1".to_string(),
+            "Fix bug, urgently".to_string(),
+            "open".to_string(),
+        ];
+        // Three fields must stay three columns despite the embedded comma.
+        assert_eq!(
+            OutputRenderer::csv_record(&fields),
+            "1,\"Fix bug, urgently\",open"
+        );
+    }
+
+    // Regression: a newline in a cell terminated the markdown table row.
+    #[test]
+    fn test_markdown_cell_escapes_newlines_and_pipes() {
+        assert_eq!(OutputRenderer::markdown_cell("a|b"), "a\\|b");
+        assert_eq!(OutputRenderer::markdown_cell("one\ntwo"), "one<br>two");
+        assert_eq!(OutputRenderer::markdown_cell("one\r\ntwo"), "one<br>two");
+        assert_eq!(OutputRenderer::markdown_cell("plain"), "plain");
     }
 
     #[test]


### PR DESCRIPTION
Supersedes #79 by @alexevansigg, whose two commits are **cherry-picked here with authorship preserved**. Both bugs he reported are real; I verified each against the Confluence Cloud v2 OpenAPI spec and corrected three things in the fix.

CI had never run on #79 (fork PRs were awaiting workflow approval), so neither bug nor fix had ever been exercised.

## Bug 1: `page comments` was broken

Confirmed, and worse than reported. Per the v2 spec, `FooterCommentModel` has **no top-level `createdAt`** — the timestamp is at `version.createdAt`. So this failed with `missing field "createdAt"` on **any** page with at least one comment, not just "some" pages. (Zero comments meant an empty `results` array and no error, which is why it looked intermittent.)

**Correction:** #79 made the top-level field `Option<String>`. That stops the crash, but since the field never exists, the `created_at` column would be **permanently blank** — a hard error traded for silent data loss. This reads `version.createdAt`.

`?body-format=storage` is correct and kept (verified: a valid `PrimaryBodyRepresentation` enum value), as is reusing `htmd::convert`.

## Bug 2: attachment downloads dropped `/wiki`

Confirmed. `base_url()` is the bare origin; the v2 `downloadLink` is relative to the `/wiki` context, so `base_url + downloadLink` 404'd.

**Correction:** #79 hand-rolled an absolute-URL builder and fetched with raw `reqwest`, bypassing `ApiClient::get_bytes`, which already does auth, retries, rate limiting and a same-origin (SSRF) check, and preserves the query string. `bamboo::download_artifact` is the existing precedent. Now only the `/wiki` prefixing is new logic (`attachment_download_path`), and the fetch goes through the client.

## Bug 3 (introduced by the fix): multi-line body corrupts output

#79 added a full markdown `body` column. But `render_csv` does no quoting or escaping and `render_markdown_table` does not escape newlines, so a comment containing a comma or a newline corrupts CSV and breaks the markdown table.

Now a bounded single-line preview by default with the full body behind `--full`, mirroring `jira issue comments`.

## Why no test caught the download bug

The fixture at `crates/cli/tests/confluence_integration.rs:398` **invented** a `/wiki`-prefixed `downloadLink` that the real API never returns, so it encoded the bug as expected behaviour. Corrected to the real shape (`/download/attachments/...?version=1&api=v2`).

Neither `download_attachment` nor `list_page_comments` had **any** test. Both now have wiremock coverage, plus unit tests for `version.createdAt`, preview bounds, and the download-path builder.

## Verification (local)

- `cargo test --all` → 451 passed, 0 failed
- `cargo clippy --all-targets --all-features -- -D warnings` → clean
- `cargo fmt --check` → ok

Still untested against a live Confluence instance — worth a smoke test of `confluence page comments <id>` and `confluence attachment download <id>` before release.