### PR TITLE
docs(site): 0.4.3 changelog entry and version bump

### DIFF
--- a/docs/404.html
+++ b/docs/404.html
@@ -205,7 +205,7 @@
             <div class="footer-content">
                 <div class="footer-left">
                     <span class="footer-logo">atlassian-cli</span>
-                    <span class="footer-version">v0.4.2</span>
+                    <span class="footer-version">v0.4.3</span>
                 </div>
                 <div class="footer-links">
                     <a href="https://github.com/omar16100/atlassian-cli" target="_blank" rel="noopener">GitHub</a>

--- a/docs/about/index.html
+++ b/docs/about/index.html
@@ -117,7 +117,7 @@
             <div class="footer-content">
                 <div class="footer-left">
                     <span class="footer-logo">atlassian-cli</span>
-                    <span class="footer-version">v0.4.2</span>
+                    <span class="footer-version">v0.4.3</span>
                 </div>
                 <div class="footer-links">
                     <a href="/jira/">Jira CLI</a>

--- a/docs/bitbucket/index.html
+++ b/docs/bitbucket/index.html
@@ -52,7 +52,7 @@
       "operatingSystem": "macOS, Linux, Windows",
       "url": "https://atlassiancli.com/bitbucket/",
       "downloadUrl": "https://github.com/omar16100/atlassian-cli/releases",
-      "softwareVersion": "0.4.2",
+      "softwareVersion": "0.4.3",
       "license": "https://opensource.org/licenses/MIT",
       "offers": {
         "@type": "Offer",
@@ -667,7 +667,7 @@ atlassian-cli bitbucket --workspace myteam \
             <div class="footer-content">
                 <div class="footer-left">
                     <span class="footer-logo">atlassian-cli</span>
-                    <span class="footer-version">v0.4.2</span>
+                    <span class="footer-version">v0.4.3</span>
                 </div>
                 <div class="footer-links">
                     <a href="https://github.com/omar16100/atlassian-cli" target="_blank" rel="noopener">GitHub</a>

--- a/docs/blog/acli-jira-commands.html
+++ b/docs/blog/acli-jira-commands.html
@@ -768,7 +768,7 @@ atlassian-cli jira issue search \
             <div class="footer-content">
                 <div class="footer-left">
                     <span class="footer-logo">atlassian-cli</span>
-                    <span class="footer-version">v0.4.2</span>
+                    <span class="footer-version">v0.4.3</span>
                 </div>
                 <div class="footer-links">
                     <a href="https://github.com/omar16100/atlassian-cli" target="_blank" rel="noopener">GitHub</a>

--- a/docs/blog/acli-vs-atlassian-cli.html
+++ b/docs/blog/acli-vs-atlassian-cli.html
@@ -857,7 +857,7 @@ atlassian-cli jsm request list --servicedesk-id 10 --limit 25</code></pre>
             <div class="footer-content">
                 <div class="footer-left">
                     <span class="footer-logo">atlassian-cli</span>
-                    <span class="footer-version">v0.4.2</span>
+                    <span class="footer-version">v0.4.3</span>
                 </div>
                 <div class="footer-links">
                     <a href="https://github.com/omar16100/atlassian-cli" target="_blank" rel="noopener">GitHub</a>

--- a/docs/blog/atlassian-api-token-vs-pat.html
+++ b/docs/blog/atlassian-api-token-vs-pat.html
@@ -774,7 +774,7 @@ atlassian-cli jira issue search --jql <span class="string">"project = DEV"</span
             <div class="footer-content">
                 <div class="footer-left">
                     <span class="footer-logo">atlassian-cli</span>
-                    <span class="footer-version">v0.4.2</span>
+                    <span class="footer-version">v0.4.3</span>
                 </div>
                 <div class="footer-links">
                     <a href="https://github.com/omar16100/atlassian-cli" target="_blank" rel="noopener">GitHub</a>

--- a/docs/blog/atlassian-cli-0-4-release.html
+++ b/docs/blog/atlassian-cli-0-4-release.html
@@ -432,7 +432,7 @@ atlassian-cli jira issue comments list <span class="string">DEV-428</span> --ful
             <div class="footer-content">
                 <div class="footer-left">
                     <span class="footer-logo">atlassian-cli</span>
-                    <span class="footer-version">v0.4.2</span>
+                    <span class="footer-version">v0.4.3</span>
                 </div>
                 <div class="footer-links">
                     <a href="https://github.com/omar16100/atlassian-cli" target="_blank" rel="noopener">GitHub</a>

--- a/docs/blog/atlassian-cli-cheat-sheet.html
+++ b/docs/blog/atlassian-cli-cheat-sheet.html
@@ -773,7 +773,7 @@ atlassian-cli bitbucket --workspace myteam bulk archive-repos --days 180 --dry-r
             <div class="footer-content">
                 <div class="footer-left">
                     <span class="footer-logo">atlassian-cli</span>
-                    <span class="footer-version">v0.4.2</span>
+                    <span class="footer-version">v0.4.3</span>
                 </div>
                 <div class="footer-links">
                     <a href="https://github.com/omar16100/atlassian-cli" target="_blank" rel="noopener">GitHub</a>

--- a/docs/blog/atlassian-cli-guide.html
+++ b/docs/blog/atlassian-cli-guide.html
@@ -574,7 +574,7 @@ atlassian-cli jira bulk transition \
             <div class="footer-content">
                 <div class="footer-left">
                     <span class="footer-logo">atlassian-cli</span>
-                    <span class="footer-version">v0.4.2</span>
+                    <span class="footer-version">v0.4.3</span>
                 </div>
                 <div class="footer-links">
                     <a href="https://github.com/omar16100/atlassian-cli" target="_blank" rel="noopener">GitHub</a>

--- a/docs/blog/atlassian-rest-api-guide.html
+++ b/docs/blog/atlassian-rest-api-guide.html
@@ -821,7 +821,7 @@ echo <span class="string">"Release snapshot complete."</span></code></pre>
             <div class="footer-content">
                 <div class="footer-left">
                     <span class="footer-logo">atlassian-cli</span>
-                    <span class="footer-version">v0.4.2</span>
+                    <span class="footer-version">v0.4.3</span>
                 </div>
                 <div class="footer-links">
                     <a href="https://github.com/omar16100/atlassian-cli" target="_blank" rel="noopener">GitHub</a>

--- a/docs/blog/automate-atlassian-with-scripts.html
+++ b/docs/blog/automate-atlassian-with-scripts.html
@@ -788,7 +788,7 @@ atlassian-cli auth test --profile prod --format quiet \
             <div class="footer-content">
                 <div class="footer-left">
                     <span class="footer-logo">atlassian-cli</span>
-                    <span class="footer-version">v0.4.2</span>
+                    <span class="footer-version">v0.4.3</span>
                 </div>
                 <div class="footer-links">
                     <a href="https://github.com/omar16100/atlassian-cli" target="_blank" rel="noopener">GitHub</a>

--- a/docs/blog/best-atlassian-cli-tools-2026.html
+++ b/docs/blog/best-atlassian-cli-tools-2026.html
@@ -746,7 +746,7 @@ atlassian-cli jira issue search \
             <div class="footer-content">
                 <div class="footer-left">
                     <span class="footer-logo">atlassian-cli</span>
-                    <span class="footer-version">v0.4.2</span>
+                    <span class="footer-version">v0.4.3</span>
                 </div>
                 <div class="footer-links">
                     <a href="https://github.com/omar16100/atlassian-cli" target="_blank" rel="noopener">GitHub</a>

--- a/docs/blog/bitbucket-api-from-cli.html
+++ b/docs/blog/bitbucket-api-from-cli.html
@@ -846,7 +846,7 @@ atlassian-cli bitbucket --workspace myteam bulk delete-branches api-service \
             <div class="footer-content">
                 <div class="footer-left">
                     <span class="footer-logo">atlassian-cli</span>
-                    <span class="footer-version">v0.4.2</span>
+                    <span class="footer-version">v0.4.3</span>
                 </div>
                 <div class="footer-links">
                     <a href="https://github.com/omar16100/atlassian-cli" target="_blank" rel="noopener">GitHub</a>

--- a/docs/blog/bitbucket-cli-commands.html
+++ b/docs/blog/bitbucket-cli-commands.html
@@ -828,7 +828,7 @@ atlassian-cli bitbucket --workspace myteam repo list --format csv</code></pre>
             <div class="footer-content">
                 <div class="footer-left">
                     <span class="footer-logo">atlassian-cli</span>
-                    <span class="footer-version">v0.4.2</span>
+                    <span class="footer-version">v0.4.3</span>
                 </div>
                 <div class="footer-links">
                     <a href="https://github.com/omar16100/atlassian-cli" target="_blank" rel="noopener">GitHub</a>

--- a/docs/blog/bitbucket-cli-guide.html
+++ b/docs/blog/bitbucket-cli-guide.html
@@ -853,7 +853,7 @@ atlassian-cli bitbucket --workspace myteam commit browse <span class="string">ap
             <div class="footer-content">
                 <div class="footer-left">
                     <span class="footer-logo">atlassian-cli</span>
-                    <span class="footer-version">v0.4.2</span>
+                    <span class="footer-version">v0.4.3</span>
                 </div>
                 <div class="footer-links">
                     <a href="https://github.com/omar16100/atlassian-cli" target="_blank" rel="noopener">GitHub</a>

--- a/docs/blog/bitbucket-cli-like-gh.html
+++ b/docs/blog/bitbucket-cli-like-gh.html
@@ -809,7 +809,7 @@ atlassian-cli bb --workspace myteam pipeline trigger api-service --ref-name main
             <div class="footer-content">
                 <div class="footer-left">
                     <span class="footer-logo">atlassian-cli</span>
-                    <span class="footer-version">v0.4.2</span>
+                    <span class="footer-version">v0.4.3</span>
                 </div>
                 <div class="footer-links">
                     <a href="https://github.com/omar16100/atlassian-cli" target="_blank" rel="noopener">GitHub</a>

--- a/docs/blog/bitbucket-pipelines-to-github-actions.html
+++ b/docs/blog/bitbucket-pipelines-to-github-actions.html
@@ -966,7 +966,7 @@ atlassian-cli bitbucket --workspace myteam pipeline list api-service</code></pre
             <div class="footer-content">
                 <div class="footer-left">
                     <span class="footer-logo">atlassian-cli</span>
-                    <span class="footer-version">v0.4.2</span>
+                    <span class="footer-version">v0.4.3</span>
                 </div>
                 <div class="footer-links">
                     <a href="https://github.com/omar16100/atlassian-cli" target="_blank" rel="noopener">GitHub</a>

--- a/docs/blog/bitbucket-pipelines-trigger-cli.html
+++ b/docs/blog/bitbucket-pipelines-trigger-cli.html
@@ -888,7 +888,7 @@ atlassian-cli bb --workspace myteam --repo api-service \
             <div class="footer-content">
                 <div class="footer-left">
                     <span class="footer-logo">atlassian-cli</span>
-                    <span class="footer-version">v0.4.2</span>
+                    <span class="footer-version">v0.4.3</span>
                 </div>
                 <div class="footer-links">
                     <a href="https://github.com/omar16100/atlassian-cli" target="_blank" rel="noopener">GitHub</a>

--- a/docs/blog/bitbucket-pr-review-automation.html
+++ b/docs/blog/bitbucket-pr-review-automation.html
@@ -835,7 +835,7 @@ echo <span class="string">"Merged PR $PR after $APPROVALS approvals"</span></cod
             <div class="footer-content">
                 <div class="footer-left">
                     <span class="footer-logo">atlassian-cli</span>
-                    <span class="footer-version">v0.4.2</span>
+                    <span class="footer-version">v0.4.3</span>
                 </div>
                 <div class="footer-links">
                     <a href="https://github.com/omar16100/atlassian-cli" target="_blank" rel="noopener">GitHub</a>

--- a/docs/blog/bitbucket-rest-api-guide.html
+++ b/docs/blog/bitbucket-rest-api-guide.html
@@ -875,7 +875,7 @@ atlassian-cli bitbucket --workspace myteam pipeline trigger api-service \
             <div class="footer-content">
                 <div class="footer-left">
                     <span class="footer-logo">atlassian-cli</span>
-                    <span class="footer-version">v0.4.2</span>
+                    <span class="footer-version">v0.4.3</span>
                 </div>
                 <div class="footer-links">
                     <a href="https://github.com/omar16100/atlassian-cli" target="_blank" rel="noopener">GitHub</a>

--- a/docs/blog/confluence-api-from-cli.html
+++ b/docs/blog/confluence-api-from-cli.html
@@ -787,7 +787,7 @@ atlassian-cli confluence bulk export \
             <div class="footer-content">
                 <div class="footer-left">
                     <span class="footer-logo">atlassian-cli</span>
-                    <span class="footer-version">v0.4.2</span>
+                    <span class="footer-version">v0.4.3</span>
                 </div>
                 <div class="footer-links">
                     <a href="https://github.com/omar16100/atlassian-cli" target="_blank" rel="noopener">GitHub</a>

--- a/docs/blog/confluence-automation-guide.html
+++ b/docs/blog/confluence-automation-guide.html
@@ -797,7 +797,7 @@ echo <span class="string">"Nightly Confluence run complete."</span></code></pre>
             <div class="footer-content">
                 <div class="footer-left">
                     <span class="footer-logo">atlassian-cli</span>
-                    <span class="footer-version">v0.4.2</span>
+                    <span class="footer-version">v0.4.3</span>
                 </div>
                 <div class="footer-links">
                     <a href="https://github.com/omar16100/atlassian-cli" target="_blank" rel="noopener">GitHub</a>

--- a/docs/blog/confluence-cli-guide.html
+++ b/docs/blog/confluence-cli-guide.html
@@ -787,7 +787,7 @@ atlassian-cli confluence space create \
             <div class="footer-content">
                 <div class="footer-left">
                     <span class="footer-logo">atlassian-cli</span>
-                    <span class="footer-version">v0.4.2</span>
+                    <span class="footer-version">v0.4.3</span>
                 </div>
                 <div class="footer-links">
                     <a href="https://github.com/omar16100/atlassian-cli" target="_blank" rel="noopener">GitHub</a>

--- a/docs/blog/confluence-cql-search-cli.html
+++ b/docs/blog/confluence-cql-search-cli.html
@@ -774,7 +774,7 @@ atlassian-cli confluence bulk delete --cql <span class="string">"space = OLD"</s
             <div class="footer-content">
                 <div class="footer-left">
                     <span class="footer-logo">atlassian-cli</span>
-                    <span class="footer-version">v0.4.2</span>
+                    <span class="footer-version">v0.4.3</span>
                 </div>
                 <div class="footer-links">
                     <a href="https://github.com/omar16100/atlassian-cli" target="_blank" rel="noopener">GitHub</a>

--- a/docs/blog/confluence-rest-api-guide.html
+++ b/docs/blog/confluence-rest-api-guide.html
@@ -855,7 +855,7 @@ atlassian-cli confluence page list --space DEV \
             <div class="footer-content">
                 <div class="footer-left">
                     <span class="footer-logo">atlassian-cli</span>
-                    <span class="footer-version">v0.4.2</span>
+                    <span class="footer-version">v0.4.3</span>
                 </div>
                 <div class="footer-links">
                     <a href="https://github.com/omar16100/atlassian-cli" target="_blank" rel="noopener">GitHub</a>

--- a/docs/blog/confluence-space-export-backup.html
+++ b/docs/blog/confluence-space-export-backup.html
@@ -874,7 +874,7 @@ atlassian-cli confluence page create \
             <div class="footer-content">
                 <div class="footer-left">
                     <span class="footer-logo">atlassian-cli</span>
-                    <span class="footer-version">v0.4.2</span>
+                    <span class="footer-version">v0.4.3</span>
                 </div>
                 <div class="footer-links">
                     <a href="https://github.com/omar16100/atlassian-cli" target="_blank" rel="noopener">GitHub</a>

--- a/docs/blog/create-bitbucket-pr-command-line.html
+++ b/docs/blog/create-bitbucket-pr-command-line.html
@@ -815,7 +815,7 @@ echo <span class="string">"Merged PR #$PR_ID"</span></code></pre>
             <div class="footer-content">
                 <div class="footer-left">
                     <span class="footer-logo">atlassian-cli</span>
-                    <span class="footer-version">v0.4.2</span>
+                    <span class="footer-version">v0.4.3</span>
                 </div>
                 <div class="footer-links">
                     <a href="https://github.com/omar16100/atlassian-cli" target="_blank" rel="noopener">GitHub</a>

--- a/docs/blog/create-jira-issues-from-csv.html
+++ b/docs/blog/create-jira-issues-from-csv.html
@@ -829,7 +829,7 @@ done &lt; created-keys.txt</code></pre>
             <div class="footer-content">
                 <div class="footer-left">
                     <span class="footer-logo">atlassian-cli</span>
-                    <span class="footer-version">v0.4.2</span>
+                    <span class="footer-version">v0.4.3</span>
                 </div>
                 <div class="footer-links">
                     <a href="https://github.com/omar16100/atlassian-cli" target="_blank" rel="noopener">GitHub</a>

--- a/docs/blog/docs-as-code-confluence.html
+++ b/docs/blog/docs-as-code-confluence.html
@@ -751,7 +751,7 @@ atlassian-cli confluence bulk export \
             <div class="footer-content">
                 <div class="footer-left">
                     <span class="footer-logo">atlassian-cli</span>
-                    <span class="footer-version">v0.4.2</span>
+                    <span class="footer-version">v0.4.3</span>
                 </div>
                 <div class="footer-links">
                     <a href="https://github.com/omar16100/atlassian-cli" target="_blank" rel="noopener">GitHub</a>

--- a/docs/blog/export-confluence-to-markdown.html
+++ b/docs/blog/export-confluence-to-markdown.html
@@ -758,7 +758,7 @@ atlassian-cli confluence bulk export --cql <span class="string">"space = DEV"</s
             <div class="footer-content">
                 <div class="footer-left">
                     <span class="footer-logo">atlassian-cli</span>
-                    <span class="footer-version">v0.4.2</span>
+                    <span class="footer-version">v0.4.3</span>
                 </div>
                 <div class="footer-links">
                     <a href="https://github.com/omar16100/atlassian-cli" target="_blank" rel="noopener">GitHub</a>

--- a/docs/blog/index.html
+++ b/docs/blog/index.html
@@ -867,7 +867,7 @@
             <div class="footer-content">
                 <div class="footer-left">
                     <span class="footer-logo">atlassian-cli</span>
-                    <span class="footer-version">v0.4.2</span>
+                    <span class="footer-version">v0.4.3</span>
                 </div>
                 <div class="footer-links">
                     <a href="https://github.com/omar16100/atlassian-cli" target="_blank" rel="noopener">GitHub</a>

--- a/docs/blog/jira-api-from-command-line.html
+++ b/docs/blog/jira-api-from-command-line.html
@@ -803,7 +803,7 @@ atlassian-cli jira bulk assign \
             <div class="footer-content">
                 <div class="footer-left">
                     <span class="footer-logo">atlassian-cli</span>
-                    <span class="footer-version">v0.4.2</span>
+                    <span class="footer-version">v0.4.3</span>
                 </div>
                 <div class="footer-links">
                     <a href="https://github.com/omar16100/atlassian-cli" target="_blank" rel="noopener">GitHub</a>

--- a/docs/blog/jira-automation-examples.html
+++ b/docs/blog/jira-automation-examples.html
@@ -846,7 +846,7 @@ done</code></pre>
             <div class="footer-content">
                 <div class="footer-left">
                     <span class="footer-logo">atlassian-cli</span>
-                    <span class="footer-version">v0.4.2</span>
+                    <span class="footer-version">v0.4.3</span>
                 </div>
                 <div class="footer-links">
                     <a href="https://github.com/omar16100/atlassian-cli" target="_blank" rel="noopener">GitHub</a>

--- a/docs/blog/jira-automation-guide.html
+++ b/docs/blog/jira-automation-guide.html
@@ -805,7 +805,7 @@ atlassian-cli jira audit list --from 2026-01-01 --limit 200 \
             <div class="footer-content">
                 <div class="footer-left">
                     <span class="footer-logo">atlassian-cli</span>
-                    <span class="footer-version">v0.4.2</span>
+                    <span class="footer-version">v0.4.3</span>
                 </div>
                 <div class="footer-links">
                     <a href="https://github.com/omar16100/atlassian-cli" target="_blank" rel="noopener">GitHub</a>

--- a/docs/blog/jira-automation-rules-examples.html
+++ b/docs/blog/jira-automation-rules-examples.html
@@ -776,7 +776,7 @@ atlassian-cli jira automation list --format json > automation-snapshot.json</cod
             <div class="footer-content">
                 <div class="footer-left">
                     <span class="footer-logo">atlassian-cli</span>
-                    <span class="footer-version">v0.4.2</span>
+                    <span class="footer-version">v0.4.3</span>
                 </div>
                 <div class="footer-links">
                     <a href="https://github.com/omar16100/atlassian-cli" target="_blank" rel="noopener">GitHub</a>

--- a/docs/blog/jira-branch-names-from-issue-keys.html
+++ b/docs/blog/jira-branch-names-from-issue-keys.html
@@ -802,7 +802,7 @@ exit 0</code></pre>
             <div class="footer-content">
                 <div class="footer-left">
                     <span class="footer-logo">atlassian-cli</span>
-                    <span class="footer-version">v0.4.2</span>
+                    <span class="footer-version">v0.4.3</span>
                 </div>
                 <div class="footer-links">
                     <a href="https://github.com/omar16100/atlassian-cli" target="_blank" rel="noopener">GitHub</a>

--- a/docs/blog/jira-bulk-operations.html
+++ b/docs/blog/jira-bulk-operations.html
@@ -665,7 +665,7 @@ echo <span class="string">"Sprint cleanup complete."</span></code></pre>
             <div class="footer-content">
                 <div class="footer-left">
                     <span class="footer-logo">atlassian-cli</span>
-                    <span class="footer-version">v0.4.2</span>
+                    <span class="footer-version">v0.4.3</span>
                 </div>
                 <div class="footer-links">
                     <a href="https://github.com/omar16100/atlassian-cli" target="_blank" rel="noopener">GitHub</a>

--- a/docs/blog/jira-cli-commands-cheat-sheet.html
+++ b/docs/blog/jira-cli-commands-cheat-sheet.html
@@ -877,7 +877,7 @@ atlassian-cli jira bulk export \
             <div class="footer-content">
                 <div class="footer-left">
                     <span class="footer-logo">atlassian-cli</span>
-                    <span class="footer-version">v0.4.2</span>
+                    <span class="footer-version">v0.4.3</span>
                 </div>
                 <div class="footer-links">
                     <a href="https://github.com/omar16100/atlassian-cli" target="_blank" rel="noopener">GitHub</a>

--- a/docs/blog/jira-cli-complete-guide.html
+++ b/docs/blog/jira-cli-complete-guide.html
@@ -834,7 +834,7 @@ jobs:
             <div class="footer-content">
                 <div class="footer-left">
                     <span class="footer-logo">atlassian-cli</span>
-                    <span class="footer-version">v0.4.2</span>
+                    <span class="footer-version">v0.4.3</span>
                 </div>
                 <div class="footer-links">
                     <a href="https://github.com/omar16100/atlassian-cli" target="_blank" rel="noopener">GitHub</a>

--- a/docs/blog/jira-cli-in-github-actions.html
+++ b/docs/blog/jira-cli-in-github-actions.html
@@ -827,7 +827,7 @@ deploy:
             <div class="footer-content">
                 <div class="footer-left">
                     <span class="footer-logo">atlassian-cli</span>
-                    <span class="footer-version">v0.4.2</span>
+                    <span class="footer-version">v0.4.3</span>
                 </div>
                 <div class="footer-links">
                     <a href="https://github.com/omar16100/atlassian-cli" target="_blank" rel="noopener">GitHub</a>

--- a/docs/blog/jira-cli-tools-compared.html
+++ b/docs/blog/jira-cli-tools-compared.html
@@ -732,7 +732,7 @@ jira issue create --project DEV --issuetype Task -s <span class="string">"Summar
             <div class="footer-content">
                 <div class="footer-left">
                     <span class="footer-logo">atlassian-cli</span>
-                    <span class="footer-version">v0.4.2</span>
+                    <span class="footer-version">v0.4.3</span>
                 </div>
                 <div class="footer-links">
                     <a href="https://github.com/omar16100/atlassian-cli" target="_blank" rel="noopener">GitHub</a>

--- a/docs/blog/jira-command-line-getting-started.html
+++ b/docs/blog/jira-command-line-getting-started.html
@@ -808,7 +808,7 @@ atlassian-cli jira issue search --profile work --jql <span class="string">"proje
             <div class="footer-content">
                 <div class="footer-left">
                     <span class="footer-logo">atlassian-cli</span>
-                    <span class="footer-version">v0.4.2</span>
+                    <span class="footer-version">v0.4.3</span>
                 </div>
                 <div class="footer-links">
                     <a href="https://github.com/omar16100/atlassian-cli" target="_blank" rel="noopener">GitHub</a>

--- a/docs/blog/jira-issue-hierarchy-epics.html
+++ b/docs/blog/jira-issue-hierarchy-epics.html
@@ -753,7 +753,7 @@ atlassian-cli jira issue create \
             <div class="footer-content">
                 <div class="footer-left">
                     <span class="footer-logo">atlassian-cli</span>
-                    <span class="footer-version">v0.4.2</span>
+                    <span class="footer-version">v0.4.3</span>
                 </div>
                 <div class="footer-links">
                     <a href="https://github.com/omar16100/atlassian-cli" target="_blank" rel="noopener">GitHub</a>

--- a/docs/blog/jira-jql-command-line.html
+++ b/docs/blog/jira-jql-command-line.html
@@ -783,7 +783,7 @@ echo <span class="string">"Wrote triage-$(date +%F).csv"</span></code></pre>
             <div class="footer-content">
                 <div class="footer-left">
                     <span class="footer-logo">atlassian-cli</span>
-                    <span class="footer-version">v0.4.2</span>
+                    <span class="footer-version">v0.4.3</span>
                 </div>
                 <div class="footer-links">
                     <a href="https://github.com/omar16100/atlassian-cli" target="_blank" rel="noopener">GitHub</a>

--- a/docs/blog/jira-markdown-formatting.html
+++ b/docs/blog/jira-markdown-formatting.html
@@ -789,7 +789,7 @@ atlassian-cli jira issue get DEV-123 --format markdown &gt; ticket.md</code></pr
             <div class="footer-content">
                 <div class="footer-left">
                     <span class="footer-logo">atlassian-cli</span>
-                    <span class="footer-version">v0.4.2</span>
+                    <span class="footer-version">v0.4.3</span>
                 </div>
                 <div class="footer-links">
                     <a href="https://github.com/omar16100/atlassian-cli" target="_blank" rel="noopener">GitHub</a>

--- a/docs/blog/jira-rest-api-guide.html
+++ b/docs/blog/jira-rest-api-guide.html
@@ -904,7 +904,7 @@ atlassian-cli jira issue transition DEV-123 --transition <span class="string">"D
             <div class="footer-content">
                 <div class="footer-left">
                     <span class="footer-logo">atlassian-cli</span>
-                    <span class="footer-version">v0.4.2</span>
+                    <span class="footer-version">v0.4.3</span>
                 </div>
                 <div class="footer-links">
                     <a href="https://github.com/omar16100/atlassian-cli" target="_blank" rel="noopener">GitHub</a>

--- a/docs/blog/jira-service-management-api.html
+++ b/docs/blog/jira-service-management-api.html
@@ -819,7 +819,7 @@ echo <span class="string">"Triage snapshot complete for $KEY."</span></code></pr
             <div class="footer-content">
                 <div class="footer-left">
                     <span class="footer-logo">atlassian-cli</span>
-                    <span class="footer-version">v0.4.2</span>
+                    <span class="footer-version">v0.4.3</span>
                 </div>
                 <div class="footer-links">
                     <a href="https://github.com/omar16100/atlassian-cli" target="_blank" rel="noopener">GitHub</a>

--- a/docs/blog/jira-task-management-cli.html
+++ b/docs/blog/jira-task-management-cli.html
@@ -843,7 +843,7 @@ atlassian-cli jira issue search \
             <div class="footer-content">
                 <div class="footer-left">
                     <span class="footer-logo">atlassian-cli</span>
-                    <span class="footer-version">v0.4.2</span>
+                    <span class="footer-version">v0.4.3</span>
                 </div>
                 <div class="footer-links">
                     <a href="https://github.com/omar16100/atlassian-cli" target="_blank" rel="noopener">GitHub</a>

--- a/docs/blog/jira-webhooks-automation.html
+++ b/docs/blog/jira-webhooks-automation.html
@@ -797,7 +797,7 @@ def handle_event(payload):
             <div class="footer-content">
                 <div class="footer-left">
                     <span class="footer-logo">atlassian-cli</span>
-                    <span class="footer-version">v0.4.2</span>
+                    <span class="footer-version">v0.4.3</span>
                 </div>
                 <div class="footer-links">
                     <a href="https://github.com/omar16100/atlassian-cli" target="_blank" rel="noopener">GitHub</a>

--- a/docs/blog/jira-worklog-time-tracking-cli.html
+++ b/docs/blog/jira-worklog-time-tracking-cli.html
@@ -825,7 +825,7 @@ echo <span class="string">"Weekly summary complete."</span></code></pre>
             <div class="footer-content">
                 <div class="footer-left">
                     <span class="footer-logo">atlassian-cli</span>
-                    <span class="footer-version">v0.4.2</span>
+                    <span class="footer-version">v0.4.3</span>
                 </div>
                 <div class="footer-links">
                     <a href="https://github.com/omar16100/atlassian-cli" target="_blank" rel="noopener">GitHub</a>

--- a/docs/blog/jql-query-cheat-sheet.html
+++ b/docs/blog/jql-query-cheat-sheet.html
@@ -828,7 +828,7 @@ atlassian-cli jira bulk transition \
             <div class="footer-content">
                 <div class="footer-left">
                     <span class="footer-logo">atlassian-cli</span>
-                    <span class="footer-version">v0.4.2</span>
+                    <span class="footer-version">v0.4.3</span>
                 </div>
                 <div class="footer-links">
                     <a href="https://github.com/omar16100/atlassian-cli" target="_blank" rel="noopener">GitHub</a>

--- a/docs/blog/jsm-cli-guide.html
+++ b/docs/blog/jsm-cli-guide.html
@@ -756,7 +756,7 @@ echo <span class="string">"Onboarded: $CUSTOMER_NAME ($CUSTOMER_EMAIL)"</span></
             <div class="footer-content">
                 <div class="footer-left">
                     <span class="footer-logo">atlassian-cli</span>
-                    <span class="footer-version">v0.4.2</span>
+                    <span class="footer-version">v0.4.3</span>
                 </div>
                 <div class="footer-links">
                     <a href="https://github.com/omar16100/atlassian-cli" target="_blank" rel="noopener">GitHub</a>

--- a/docs/blog/jsm-customer-service-cli.html
+++ b/docs/blog/jsm-customer-service-cli.html
@@ -847,7 +847,7 @@ echo <span class="string">"Logged and acknowledged $KEY"</span></code></pre>
             <div class="footer-content">
                 <div class="footer-left">
                     <span class="footer-logo">atlassian-cli</span>
-                    <span class="footer-version">v0.4.2</span>
+                    <span class="footer-version">v0.4.3</span>
                 </div>
                 <div class="footer-links">
                     <a href="https://github.com/omar16100/atlassian-cli" target="_blank" rel="noopener">GitHub</a>

--- a/docs/blog/jsm-integrations-cli.html
+++ b/docs/blog/jsm-integrations-cli.html
@@ -818,7 +818,7 @@ atlassian-cli jsm request list --servicedesk-id 10 --limit 25 --profile prod</co
             <div class="footer-content">
                 <div class="footer-left">
                     <span class="footer-logo">atlassian-cli</span>
-                    <span class="footer-version">v0.4.2</span>
+                    <span class="footer-version">v0.4.3</span>
                 </div>
                 <div class="footer-links">
                     <a href="https://github.com/omar16100/atlassian-cli" target="_blank" rel="noopener">GitHub</a>

--- a/docs/blog/jsm-knowledge-base-cli.html
+++ b/docs/blog/jsm-knowledge-base-cli.html
@@ -776,7 +776,7 @@ echo <span class="string">"KB health check complete: kb-$DATE.json"</span></code
             <div class="footer-content">
                 <div class="footer-left">
                     <span class="footer-logo">atlassian-cli</span>
-                    <span class="footer-version">v0.4.2</span>
+                    <span class="footer-version">v0.4.3</span>
                 </div>
                 <div class="footer-links">
                     <a href="https://github.com/omar16100/atlassian-cli" target="_blank" rel="noopener">GitHub</a>

--- a/docs/blog/jsm-queue-sla-reporting.html
+++ b/docs/blog/jsm-queue-sla-reporting.html
@@ -774,7 +774,7 @@ fi</code></pre>
             <div class="footer-content">
                 <div class="footer-left">
                     <span class="footer-logo">atlassian-cli</span>
-                    <span class="footer-version">v0.4.2</span>
+                    <span class="footer-version">v0.4.3</span>
                 </div>
                 <div class="footer-links">
                     <a href="https://github.com/omar16100/atlassian-cli" target="_blank" rel="noopener">GitHub</a>

--- a/docs/blog/jsm-request-management-cli.html
+++ b/docs/blog/jsm-request-management-cli.html
@@ -794,7 +794,7 @@ echo <span class="string">"Intake complete for $KEY"</span></code></pre>
             <div class="footer-content">
                 <div class="footer-left">
                     <span class="footer-logo">atlassian-cli</span>
-                    <span class="footer-version">v0.4.2</span>
+                    <span class="footer-version">v0.4.3</span>
                 </div>
                 <div class="footer-links">
                     <a href="https://github.com/omar16100/atlassian-cli" target="_blank" rel="noopener">GitHub</a>

--- a/docs/blog/jsm-service-desk-automation-cli.html
+++ b/docs/blog/jsm-service-desk-automation-cli.html
@@ -816,7 +816,7 @@ echo <span class="string">"Done."</span></code></pre>
             <div class="footer-content">
                 <div class="footer-left">
                     <span class="footer-logo">atlassian-cli</span>
-                    <span class="footer-version">v0.4.2</span>
+                    <span class="footer-version">v0.4.3</span>
                 </div>
                 <div class="footer-links">
                     <a href="https://github.com/omar16100/atlassian-cli" target="_blank" rel="noopener">GitHub</a>

--- a/docs/blog/markdown-to-confluence.html
+++ b/docs/blog/markdown-to-confluence.html
@@ -728,7 +728,7 @@ atlassian-cli confluence page get 12345 --format markdown &gt; release-notes.md<
             <div class="footer-content">
                 <div class="footer-left">
                     <span class="footer-logo">atlassian-cli</span>
-                    <span class="footer-version">v0.4.2</span>
+                    <span class="footer-version">v0.4.3</span>
                 </div>
                 <div class="footer-links">
                     <a href="https://github.com/omar16100/atlassian-cli" target="_blank" rel="noopener">GitHub</a>

--- a/docs/blog/migrate-bitbucket-to-github.html
+++ b/docs/blog/migrate-bitbucket-to-github.html
@@ -812,7 +812,7 @@ echo <span class="string">"Migration pass complete."</span></code></pre>
             <div class="footer-content">
                 <div class="footer-left">
                     <span class="footer-logo">atlassian-cli</span>
-                    <span class="footer-version">v0.4.2</span>
+                    <span class="footer-version">v0.4.3</span>
                 </div>
                 <div class="footer-links">
                     <a href="https://github.com/omar16100/atlassian-cli" target="_blank" rel="noopener">GitHub</a>

--- a/docs/blog/one-cli-jira-confluence-bitbucket.html
+++ b/docs/blog/one-cli-jira-confluence-bitbucket.html
@@ -795,7 +795,7 @@ atlassian-cli jira issue transition <span class="string">"$ISSUE"</span> --trans
             <div class="footer-content">
                 <div class="footer-left">
                     <span class="footer-logo">atlassian-cli</span>
-                    <span class="footer-version">v0.4.2</span>
+                    <span class="footer-version">v0.4.3</span>
                 </div>
                 <div class="footer-links">
                     <a href="https://github.com/omar16100/atlassian-cli" target="_blank" rel="noopener">GitHub</a>

--- a/docs/blog/rovo-dev-cli-explained.html
+++ b/docs/blog/rovo-dev-cli-explained.html
@@ -809,7 +809,7 @@ atlassian-cli bitbucket --workspace myteam pr list api-service \
             <div class="footer-content">
                 <div class="footer-left">
                     <span class="footer-logo">atlassian-cli</span>
-                    <span class="footer-version">v0.4.2</span>
+                    <span class="footer-version">v0.4.3</span>
                 </div>
                 <div class="footer-links">
                     <a href="https://github.com/omar16100/atlassian-cli" target="_blank" rel="noopener">GitHub</a>

--- a/docs/blog/sync-jira-to-confluence.html
+++ b/docs/blog/sync-jira-to-confluence.html
@@ -750,7 +750,7 @@ echo <span class="string">"Synced $(jq 'length' issues.json) issues to page $PAG
             <div class="footer-content">
                 <div class="footer-left">
                     <span class="footer-logo">atlassian-cli</span>
-                    <span class="footer-version">v0.4.2</span>
+                    <span class="footer-version">v0.4.3</span>
                 </div>
                 <div class="footer-links">
                     <a href="https://github.com/omar16100/atlassian-cli" target="_blank" rel="noopener">GitHub</a>

--- a/docs/changelog/index.html
+++ b/docs/changelog/index.html
@@ -46,10 +46,11 @@
         "@type": "ItemList",
         "itemListOrder": "https://schema.org/ItemListOrderDescending",
         "itemListElement": [
-          {"@type": "ListItem", "position": 1, "name": "v0.4.2", "url": "https://github.com/omar16100/atlassian-cli/releases/tag/v0.4.2"},
-          {"@type": "ListItem", "position": 2, "name": "v0.4.1", "url": "https://github.com/omar16100/atlassian-cli/releases/tag/v0.4.1"},
-          {"@type": "ListItem", "position": 3, "name": "v0.4.0", "url": "https://github.com/omar16100/atlassian-cli/releases/tag/v0.4.0"},
-          {"@type": "ListItem", "position": 4, "name": "v0.3.3", "url": "https://github.com/omar16100/atlassian-cli/releases/tag/v0.3.3"}
+          {"@type": "ListItem", "position": 1, "name": "v0.4.3", "url": "https://github.com/omar16100/atlassian-cli/releases/tag/v0.4.3"},
+          {"@type": "ListItem", "position": 2, "name": "v0.4.2", "url": "https://github.com/omar16100/atlassian-cli/releases/tag/v0.4.2"},
+          {"@type": "ListItem", "position": 3, "name": "v0.4.1", "url": "https://github.com/omar16100/atlassian-cli/releases/tag/v0.4.1"},
+          {"@type": "ListItem", "position": 4, "name": "v0.4.0", "url": "https://github.com/omar16100/atlassian-cli/releases/tag/v0.4.0"},
+          {"@type": "ListItem", "position": 5, "name": "v0.3.3", "url": "https://github.com/omar16100/atlassian-cli/releases/tag/v0.3.3"}
         ]
       }
     }
@@ -200,6 +201,21 @@
 
                 <div class="release">
                     <div class="release-head">
+                        <span class="release-version">0.4.3</span>
+                        <span class="release-date">July 13, 2026</span>
+                        <a class="release-link" href="https://github.com/omar16100/atlassian-cli/releases/tag/v0.4.3" target="_blank" rel="noopener">GitHub release &rarr;</a>
+                    </div>
+                    <ul>
+                        <li><strong>Markdown tables in Jira</strong>: a GFM table in <code>--description</code> or a comment <code>--body</code> now becomes a real Jira table instead of raw pipe characters. Thanks to <a href="https://github.com/fabianderschatta" target="_blank" rel="noopener">@fabianderschatta</a>.</li>
+                        <li><strong>Confluence page comments work again</strong>: <code>confluence page comments</code> failed on any page that had at least one comment. It now also shows the comment body, with a new <code>--full</code> flag for untruncated text. Thanks to <a href="https://github.com/alexevansigg" target="_blank" rel="noopener">@alexevansigg</a>.</li>
+                        <li><strong>Confluence attachment downloads work again</strong>: <code>confluence attachment download</code> dropped the <code>/wiki</code> path segment and always failed with a 404.</li>
+                        <li><strong>Correct CSV and markdown output</strong>: CSV fields are now quoted per RFC 4180, so a comma inside a value (an issue summary, a comment) no longer shifts every later column. Markdown table cells escape newlines.</li>
+                        <li><strong>Maintenance:</strong> bumped <code>aes-gcm</code> to 0.11 and <code>indicatif</code> to 0.18.6, and updated <code>quinn-proto</code>, <code>crossbeam-epoch</code> and <code>anyhow</code> to clear security advisories.</li>
+                    </ul>
+                </div>
+
+                <div class="release">
+                    <div class="release-head">
                         <span class="release-version">0.4.2</span>
                         <span class="release-date">June 18, 2026</span>
                         <a class="release-link" href="https://github.com/omar16100/atlassian-cli/releases/tag/v0.4.2" target="_blank" rel="noopener">GitHub release →</a>
@@ -270,7 +286,7 @@
             <div class="footer-content">
                 <div class="footer-left">
                     <span class="footer-logo">atlassian-cli</span>
-                    <span class="footer-version">v0.4.2</span>
+                    <span class="footer-version">v0.4.3</span>
                 </div>
                 <div class="footer-links">
                     <a href="/jira/">Jira CLI</a>

--- a/docs/confluence/index.html
+++ b/docs/confluence/index.html
@@ -43,7 +43,7 @@
       "operatingSystem": "macOS, Linux, Windows",
       "url": "https://atlassiancli.com/confluence/",
       "downloadUrl": "https://github.com/omar16100/atlassian-cli/releases",
-      "softwareVersion": "0.4.2",
+      "softwareVersion": "0.4.3",
       "license": "https://opensource.org/licenses/MIT",
       "offers": { "@type": "Offer", "price": "0", "priceCurrency": "USD" },
       "author": { "@type": "Person", "name": "Omar Shabab", "url": "https://omarshabab.com" }
@@ -510,7 +510,7 @@ atlassian-cli confluence search cql \
             <div class="footer-content">
                 <div class="footer-left">
                     <span class="footer-logo">atlassian-cli</span>
-                    <span class="footer-version">v0.4.2</span>
+                    <span class="footer-version">v0.4.3</span>
                 </div>
                 <div class="footer-links">
                     <a href="https://github.com/omar16100/atlassian-cli" target="_blank" rel="noopener">GitHub</a>

--- a/docs/docs/auth.html
+++ b/docs/docs/auth.html
@@ -248,7 +248,7 @@ atlassian-cli auth logout --profile work --bitbucket             <span class="co
             <div class="footer-content">
                 <div class="footer-left">
                     <span class="footer-logo">atlassian-cli</span>
-                    <span class="footer-version">v0.4.2</span>
+                    <span class="footer-version">v0.4.3</span>
                 </div>
                 <div class="footer-links">
                     <a href="/install/">Install</a>

--- a/docs/docs/commands.html
+++ b/docs/docs/commands.html
@@ -438,7 +438,7 @@ atlassian-cli jsm feedback delete SD-123</code></pre>
             <div class="footer-content">
                 <div class="footer-left">
                     <span class="footer-logo">atlassian-cli</span>
-                    <span class="footer-version">v0.4.2</span>
+                    <span class="footer-version">v0.4.3</span>
                 </div>
                 <div class="footer-links">
                     <a href="/install/">Install</a>

--- a/docs/docs/index.html
+++ b/docs/docs/index.html
@@ -141,7 +141,7 @@
             <div class="footer-content">
                 <div class="footer-left">
                     <span class="footer-logo">atlassian-cli</span>
-                    <span class="footer-version">v0.4.2</span>
+                    <span class="footer-version">v0.4.3</span>
                 </div>
                 <div class="footer-links">
                     <a href="/install/">Install</a>

--- a/docs/index.html
+++ b/docs/index.html
@@ -54,7 +54,7 @@
       "operatingSystem": "macOS, Linux, Windows",
       "url": "https://atlassiancli.com/",
       "downloadUrl": "https://github.com/omar16100/atlassian-cli/releases",
-      "softwareVersion": "0.4.2",
+      "softwareVersion": "0.4.3",
       "license": "https://opensource.org/licenses/MIT",
       "isAccessibleForFree": true,
       "offers": {
@@ -549,7 +549,7 @@ atlassian-cli auth test --bitbucket --profile <span class="string">bb-ci</span><
             <div class="footer-content">
                 <div class="footer-left">
                     <span class="footer-logo">atlassian-cli</span>
-                    <span class="footer-version">v0.4.2</span>
+                    <span class="footer-version">v0.4.3</span>
                 </div>
                 <div class="footer-links">
                     <a href="/install/">Install</a>

--- a/docs/install/index.html
+++ b/docs/install/index.html
@@ -138,7 +138,7 @@
             <h2 class="section-title" id="verify" style="margin-top: 3rem;">Verify the install</h2>
             <pre class="code-block"><code>atlassian-cli --version
 atlassian-cli --help</code></pre>
-            <p>You should see the version number (currently <strong>0.4.2</strong>) and the top-level help text.</p>
+            <p>You should see the version number (currently <strong>0.4.3</strong>) and the top-level help text.</p>
 
             <h2 class="section-title" id="first-run" style="margin-top: 3rem;">First-time setup</h2>
             <p class="section-subtitle">Configure a profile once, reuse it everywhere.</p>
@@ -200,7 +200,7 @@ atlassian-cli auth test --profile <span class="string">work</span></code></pre>
             <div class="footer-content">
                 <div class="footer-left">
                     <span class="footer-logo">atlassian-cli</span>
-                    <span class="footer-version">v0.4.2</span>
+                    <span class="footer-version">v0.4.3</span>
                 </div>
                 <div class="footer-links">
                     <a href="/jira/">Jira CLI</a>

--- a/docs/jira/index.html
+++ b/docs/jira/index.html
@@ -43,7 +43,7 @@
       "operatingSystem": "macOS, Linux, Windows",
       "url": "https://atlassiancli.com/jira/",
       "downloadUrl": "https://github.com/omar16100/atlassian-cli/releases",
-      "softwareVersion": "0.4.2",
+      "softwareVersion": "0.4.3",
       "license": "https://opensource.org/licenses/MIT",
       "offers": { "@type": "Offer", "price": "0", "priceCurrency": "USD" },
       "author": { "@type": "Person", "name": "Omar Shabab", "url": "https://omarshabab.com" }
@@ -525,7 +525,7 @@ atlassian-cli jira issue search \
             <div class="footer-content">
                 <div class="footer-left">
                     <span class="footer-logo">atlassian-cli</span>
-                    <span class="footer-version">v0.4.2</span>
+                    <span class="footer-version">v0.4.3</span>
                 </div>
                 <div class="footer-links">
                     <a href="https://github.com/omar16100/atlassian-cli" target="_blank" rel="noopener">GitHub</a>

--- a/docs/jsm/index.html
+++ b/docs/jsm/index.html
@@ -52,7 +52,7 @@
       "operatingSystem": "macOS, Linux, Windows",
       "url": "https://atlassiancli.com/jsm/",
       "downloadUrl": "https://github.com/omar16100/atlassian-cli/releases",
-      "softwareVersion": "0.4.2",
+      "softwareVersion": "0.4.3",
       "license": "https://opensource.org/licenses/MIT",
       "offers": {
         "@type": "Offer",
@@ -607,7 +607,7 @@ atlassian-cli jsm request list --limit 5</code></pre>
             <div class="footer-content">
                 <div class="footer-left">
                     <span class="footer-logo">atlassian-cli</span>
-                    <span class="footer-version">v0.4.2</span>
+                    <span class="footer-version">v0.4.3</span>
                 </div>
                 <div class="footer-links">
                     <a href="https://github.com/omar16100/atlassian-cli" target="_blank" rel="noopener">GitHub</a>

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -56,7 +56,7 @@ atlassian-cli is an independent open-source project. It is NOT affiliated with, 
 
 ## Version
 
-Current version: 0.4.2
+Current version: 0.4.3
 Recent (0.4): Markdown-to-ADF for Jira descriptions and comments, a Confluence v2 Folder API command group (confluence folder get/create/delete), Bitbucket custom pipeline triggers (pipeline trigger --custom-pipeline), Jira attachments in issue get, comments list --full, and a fix for false errors on HTTP 204 responses.
 License: MIT
 Author: Omar Shabab (https://omarshabab.com)

--- a/docs/runbooks/bitbucket-branch-cleanup.html
+++ b/docs/runbooks/bitbucket-branch-cleanup.html
@@ -578,7 +578,7 @@ main <span class="string">"$@"</span></code></pre>
             <div class="footer-content">
                 <div class="footer-left">
                     <span class="footer-logo">atlassian-cli</span>
-                    <span class="footer-version">v0.4.2</span>
+                    <span class="footer-version">v0.4.3</span>
                 </div>
                 <div class="footer-links">
                     <a href="https://github.com/omar16100/atlassian-cli" target="_blank" rel="noopener">GitHub</a>

--- a/docs/runbooks/bitbucket-pr-automation.html
+++ b/docs/runbooks/bitbucket-pr-automation.html
@@ -644,7 +644,7 @@ main <span class="string">"$@"</span></code></pre>
             <div class="footer-content">
                 <div class="footer-left">
                     <span class="footer-logo">atlassian-cli</span>
-                    <span class="footer-version">v0.4.2</span>
+                    <span class="footer-version">v0.4.3</span>
                 </div>
                 <div class="footer-links">
                     <a href="https://github.com/omar16100/atlassian-cli" target="_blank" rel="noopener">GitHub</a>

--- a/docs/runbooks/bitbucket-repo-audit.html
+++ b/docs/runbooks/bitbucket-repo-audit.html
@@ -522,7 +522,7 @@ main</code></pre>
             <div class="footer-content">
                 <div class="footer-left">
                     <span class="footer-logo">atlassian-cli</span>
-                    <span class="footer-version">v0.4.2</span>
+                    <span class="footer-version">v0.4.3</span>
                 </div>
                 <div class="footer-links">
                     <a href="https://github.com/omar16100/atlassian-cli" target="_blank" rel="noopener">GitHub</a>

--- a/docs/runbooks/confluence-backup.html
+++ b/docs/runbooks/confluence-backup.html
@@ -539,7 +539,7 @@ main</code></pre>
             <div class="footer-content">
                 <div class="footer-left">
                     <span class="footer-logo">atlassian-cli</span>
-                    <span class="footer-version">v0.4.2</span>
+                    <span class="footer-version">v0.4.3</span>
                 </div>
                 <div class="footer-links">
                     <a href="https://github.com/omar16100/atlassian-cli" target="_blank" rel="noopener">GitHub</a>

--- a/docs/runbooks/confluence-bulk-cleanup.html
+++ b/docs/runbooks/confluence-bulk-cleanup.html
@@ -569,7 +569,7 @@ main <span class="string">"$@"</span></code></pre>
             <div class="footer-content">
                 <div class="footer-left">
                     <span class="footer-logo">atlassian-cli</span>
-                    <span class="footer-version">v0.4.2</span>
+                    <span class="footer-version">v0.4.3</span>
                 </div>
                 <div class="footer-links">
                     <a href="https://github.com/omar16100/atlassian-cli" target="_blank" rel="noopener">GitHub</a>

--- a/docs/runbooks/confluence-markdown-sync.html
+++ b/docs/runbooks/confluence-markdown-sync.html
@@ -696,7 +696,7 @@ jobs:
             <div class="footer-content">
                 <div class="footer-left">
                     <span class="footer-logo">atlassian-cli</span>
-                    <span class="footer-version">v0.4.2</span>
+                    <span class="footer-version">v0.4.3</span>
                 </div>
                 <div class="footer-links">
                     <a href="https://github.com/omar16100/atlassian-cli" target="_blank" rel="noopener">GitHub</a>

--- a/docs/runbooks/confluence-space-report.html
+++ b/docs/runbooks/confluence-space-report.html
@@ -559,7 +559,7 @@ main</code></pre>
             <div class="footer-content">
                 <div class="footer-left">
                     <span class="footer-logo">atlassian-cli</span>
-                    <span class="footer-version">v0.4.2</span>
+                    <span class="footer-version">v0.4.3</span>
                 </div>
                 <div class="footer-links">
                     <a href="https://github.com/omar16100/atlassian-cli" target="_blank" rel="noopener">GitHub</a>

--- a/docs/runbooks/jira-bulk-transition.html
+++ b/docs/runbooks/jira-bulk-transition.html
@@ -529,7 +529,7 @@ main <span class="string">"$@"</span></code></pre>
             <div class="footer-content">
                 <div class="footer-left">
                     <span class="footer-logo">atlassian-cli</span>
-                    <span class="footer-version">v0.4.2</span>
+                    <span class="footer-version">v0.4.3</span>
                 </div>
                 <div class="footer-links">
                     <a href="https://github.com/omar16100/atlassian-cli" target="_blank" rel="noopener">GitHub</a>

--- a/docs/runbooks/jira-project-cleanup.html
+++ b/docs/runbooks/jira-project-cleanup.html
@@ -598,7 +598,7 @@ main <span class="string">"$@"</span></code></pre>
             <div class="footer-content">
                 <div class="footer-left">
                     <span class="footer-logo">atlassian-cli</span>
-                    <span class="footer-version">v0.4.2</span>
+                    <span class="footer-version">v0.4.3</span>
                 </div>
                 <div class="footer-links">
                     <a href="https://github.com/omar16100/atlassian-cli" target="_blank" rel="noopener">GitHub</a>

--- a/docs/runbooks/jira-sprint-report.html
+++ b/docs/runbooks/jira-sprint-report.html
@@ -575,7 +575,7 @@ main <span class="string">"$@"</span></code></pre>
             <div class="footer-content">
                 <div class="footer-left">
                     <span class="footer-logo">atlassian-cli</span>
-                    <span class="footer-version">v0.4.2</span>
+                    <span class="footer-version">v0.4.3</span>
                 </div>
                 <div class="footer-links">
                     <a href="https://github.com/omar16100/atlassian-cli" target="_blank" rel="noopener">GitHub</a>

--- a/docs/status.md
+++ b/docs/status.md
@@ -1,5 +1,5 @@
 | Phase | Implementation | Tests | Docs / Examples |
 | --- | --- | --- | --- |
 | Phase 2: Jira CLI | ✅ 100% – Issue CRUD, projects, automation, bulk ops complete | ✅ 11 Wiremock integration tests | ⚠️ In progress – add deep-dive guides/workflows |
-| Phase 3: Confluence CLI | ✅ 100% – Search, page/space commands implemented | ❌ Pending Wiremock integration tests for key commands | ❌ Needs cookbook examples (page sync, backups) |
+| Phase 3: Confluence CLI | ✅ 100% – Search, page/space commands implemented | ⚠️ 20 Wiremock integration tests (spaces/pages/blogposts/search/bulk/publish, plus footer-comments and attachment download added in 0.4.3) | ❌ Needs cookbook examples (page sync, backups) |
 | Phase 4: Bitbucket CLI | ✅ 100% – Repos, branches, PRs, pipelines shipped | ✅ 14 Wiremock integration tests (repos/branches/PRs) | ⚠️ Partial – add PR workflow/multi-repo recipe |


### PR DESCRIPTION
Site update for the 0.4.3 release. GitHub Pages serves `main:/docs`, so merging this deploys atlassiancli.com.

- New changelog entry for 0.4.3, crediting @fabianderschatta (#81) and @alexevansigg (#79/#85).
- Renumbered the `CollectionPage` → `ItemList` JSON-LD positions and prepended `v0.4.3`.
- Version strings: footer badge (82 pages), `softwareVersion` JSON-LD (5 pages), install-page prose, `llms.txt`.

Deliberately **not** a blanket find-replace: historical version references (the changelog's older entries, blog posts that are *about* the 0.4 release) are untouched. The only remaining `0.4.2` strings in `docs/` are the changelog's own 0.4.2 history entry.

Verified: all JSON-LD blocks across `docs/` still parse.