### PR TITLE
chore: release 0.5.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -183,7 +183,7 @@ dependencies = [
 
 [[package]]
 name = "atlassian-cli"
-version = "0.4.3"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "atlassian-cli-api",
@@ -214,7 +214,7 @@ dependencies = [
 
 [[package]]
 name = "atlassian-cli-api"
-version = "0.4.3"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -236,7 +236,7 @@ dependencies = [
 
 [[package]]
 name = "atlassian-cli-auth"
-version = "0.4.3"
+version = "0.5.0"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -256,7 +256,7 @@ dependencies = [
 
 [[package]]
 name = "atlassian-cli-bulk"
-version = "0.4.3"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "criterion",
@@ -269,7 +269,7 @@ dependencies = [
 
 [[package]]
 name = "atlassian-cli-config"
-version = "0.4.3"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "dirs",
@@ -283,7 +283,7 @@ dependencies = [
 
 [[package]]
 name = "atlassian-cli-output"
-version = "0.4.3"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.4.3"
+version = "0.5.0"
 edition = "2021"
 authors = ["atlassian-cli contributors"]
 license = "MIT"

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -23,11 +23,11 @@ serde_json.workspace = true
 serde_yaml.workspace = true
 
 # Internal crates
-atlassian-cli-api = { path = "../api", version = "0.4.3" }
-atlassian-cli-auth = { path = "../auth", version = "0.4.3" }
-atlassian-cli-config = { path = "../config", version = "0.4.3" }
-atlassian-cli-output = { path = "../output", version = "0.4.3" }
-atlassian-cli-bulk = { path = "../bulk", version = "0.4.3" }
+atlassian-cli-api = { path = "../api", version = "0.5.0" }
+atlassian-cli-auth = { path = "../auth", version = "0.5.0" }
+atlassian-cli-config = { path = "../config", version = "0.5.0" }
+atlassian-cli-output = { path = "../output", version = "0.5.0" }
+atlassian-cli-bulk = { path = "../bulk", version = "0.5.0" }
 
 # CLI helpers
 url.workspace = true

--- a/todo.md
+++ b/todo.md
@@ -1399,3 +1399,12 @@ Plan: `/Users/macmini/.claude/plans/https-github-com-omar16100-atlassian-cli-bin
 - Codex review of the passthrough found two blockers, both fixed: (1) `safe_join` compared scheme and host but **not port**, so any other port on the same host (e.g. another local service on a localhost profile) received the profile's credentials. This was pre-existing and affected every command; now a shared `same_origin` helper compares scheme + host + `port_or_known_default`. (2) `request_raw` used the default redirect policy, so a same-origin endpoint could bounce a credentialed, body-carrying request anywhere: 307/308 replay the body and custom `-H` headers are not stripped. `request_raw` now uses a separate client whose policy follows same-origin redirects only and returns the 3xx otherwise. The ordinary client still follows cross-host redirects, which attachment downloads depend on (guarded by a test).
 - Also: `--output` refuses to clobber without `--force` and uses `create_new` (no symlink follow); 429 retries respect `Retry-After`; binary detection now rejects control bytes, not just invalid UTF-8, so a response cannot drive the terminal.
 - Consequence: `jira api /rest/api/3/attachment/content/<id>` no longer resolves the media-host hop. Documented, with users pointed at `jira attachment download`.
+
+## 2026-08-10 — Release 0.5.0
+
+Minor bump (not patch): two new command groups plus a new public API on the shared `atlassian-cli-api` crate.
+
+- `jira attachment` group: list/get/download (single, `--output -`, bulk `--issue`/`--dir`)/upload/delete (#93, PR #94).
+- `jira api` raw authenticated passthrough (#93 alternative, PR #96).
+- `ApiClient::request_raw` / `RawRequest` / `RawResponse` / `resolve_url` added.
+- Security fixes shipped along the way, both pre-existing and affecting all commands: `init_tracing` logged to stdout, which could corrupt piped binary output; `safe_join` compared scheme and host but not port, so another port on the same host could receive the profile's credentials.


### PR DESCRIPTION
Version bump for the #93 work. Minor rather than patch: two new command groups and a new public API on the shared `atlassian-cli-api` crate.

## Included

- **`jira attachment`** (#94, closes #93): `list`, `get`, `download` (single, `--output -` for stdout streaming, and bulk via `--issue`/`--dir`), `upload`, `delete`.
- **`jira api`** (#96): raw authenticated REST passthrough, the alternative proposed in #93.
- **`ApiClient::request_raw` / `RawRequest` / `RawResponse` / `resolve_url`** on `atlassian-cli-api`.

## Security fixes worth calling out

Both pre-existing and affecting every command, not just the new ones:

- `init_tracing` had no `.with_writer`, so tracing-subscriber logged to **stdout**. Any rate-limit or retry warning could corrupt piped output.
- The SSRF origin check compared scheme and host but **not port**, so on a profile like `http://127.0.0.1:1234` another local port could be reached and would receive the profile's `Authorization` header.

## Behaviour change

`jira issue get --format json` additively gains `author` and `created` on each attachment. No key removed or renamed.

Suite green at 574 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)