### PR TITLE
chore: release 0.5.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -183,7 +183,7 @@ dependencies = [
 
 [[package]]
 name = "atlassian-cli"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "anyhow",
  "atlassian-cli-api",
@@ -214,7 +214,7 @@ dependencies = [
 
 [[package]]
 name = "atlassian-cli-api"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -236,7 +236,7 @@ dependencies = [
 
 [[package]]
 name = "atlassian-cli-auth"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -256,7 +256,7 @@ dependencies = [
 
 [[package]]
 name = "atlassian-cli-bulk"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "anyhow",
  "criterion",
@@ -269,7 +269,7 @@ dependencies = [
 
 [[package]]
 name = "atlassian-cli-config"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "anyhow",
  "dirs",
@@ -283,7 +283,7 @@ dependencies = [
 
 [[package]]
 name = "atlassian-cli-output"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.5.0"
+version = "0.5.1"
 edition = "2021"
 authors = ["atlassian-cli contributors"]
 license = "MIT"

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -23,11 +23,11 @@ serde_json.workspace = true
 serde_yaml.workspace = true
 
 # Internal crates
-atlassian-cli-api = { path = "../api", version = "0.5.0" }
-atlassian-cli-auth = { path = "../auth", version = "0.5.0" }
-atlassian-cli-config = { path = "../config", version = "0.5.0" }
-atlassian-cli-output = { path = "../output", version = "0.5.0" }
-atlassian-cli-bulk = { path = "../bulk", version = "0.5.0" }
+atlassian-cli-api = { path = "../api", version = "0.5.1" }
+atlassian-cli-auth = { path = "../auth", version = "0.5.1" }
+atlassian-cli-config = { path = "../config", version = "0.5.1" }
+atlassian-cli-output = { path = "../output", version = "0.5.1" }
+atlassian-cli-bulk = { path = "../bulk", version = "0.5.1" }
 
 # CLI helpers
 url.workspace = true

--- a/todo.md
+++ b/todo.md
@@ -1422,3 +1422,11 @@ Audit after the 0.5.0 release, prompted by "is everything documented?".
 - Extended the audit to the README after finding the example-script rot: **45 of its 128 command examples did not parse**. Causes: Jira issue commands never updated after the `issue` group was introduced (`jira get` -> `jira issue get`), `--id`/`--project`/`--space`/`--cql`/`--query` for arguments that are positional, `confluence bulk` documented as space-driven when it is CQL-driven, `space add-permission`/`page add-restriction` documented with flags that do not exist, pipelines taking `--repo` rather than a positional, and `jsm servicedesk` vs `jsm service-desk`. All fixed and verified.
 - Found and fixed a defect in the just-released 0.5.0: `jira api -X PUT` was rejected, because `ValueEnum` derives lowercase variant names and only `-X put` parsed. The README and the command's own help both showed uppercase. Now `ignore_case`.
 - New `crates/cli/tests/docs_examples.rs` parses every README command against the built binary (unroutable host, so nothing leaves the process; clap exit code 2 means malformed). Spawned concurrently: 7s instead of 100s. Verified it fails when a command line is broken.
+
+## 2026-08-10 — Release 0.5.1
+
+Patch for a defect shipped in 0.5.0 plus the documentation repair.
+
+- `jira api -X PUT` was rejected; only lowercase `-X put` parsed, while the README and the command's own help showed uppercase.
+- `docs/index.md` added; 0.5.0 docs un-staled; `docs/status.md` refreshed.
+- 19 broken `--output json` invocations across all 9 example scripts and 45 broken README command examples fixed, with `tests/docs_examples.rs` added so they cannot rot silently again.


### PR DESCRIPTION
Patch release for a defect shipped in 0.5.0, plus the documentation repair from #98.

- **`jira api -X PUT` was rejected.** `ValueEnum` derives lowercase variant names, so only `-X put` parsed, while the README and the command's own help both showed the conventional uppercase spelling. A brand-new command failing on the spelling it documents is worth a patch rather than waiting.
- `docs/index.md` added (it never existed), 0.5.0 documents un-staled, `docs/status.md` refreshed.
- 19 broken example-script invocations and 45 broken README command examples repaired, with `tests/docs_examples.rs` added so documented command lines are parsed against the built binary in CI.

No behaviour change beyond accepting the uppercase method spelling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)