### PR TITLE
feat(bitbucket): show reviewer approval status in pr reviewers

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,6 +247,8 @@ crates/
    atlassian-cli bitbucket --workspace myteam pr merge api-service 123 --strategy merge_commit
    atlassian-cli bitbucket --workspace myteam pr comments api-service 123
    atlassian-cli bitbucket --workspace myteam pr comment api-service 123 --text "Looks good!"
+   atlassian-cli bitbucket --workspace myteam pr reviewers api-service 123
+   atlassian-cli bitbucket --workspace myteam pr reviewers api-service 123 --all
 
    # Bitbucket - Workspaces & Projects
    atlassian-cli bitbucket workspace list --limit 10

--- a/crates/cli/src/commands/bitbucket/mod.rs
+++ b/crates/cli/src/commands/bitbucket/mod.rs
@@ -363,15 +363,21 @@ enum PrCommands {
         #[arg(long)]
         text: String,
     },
-    /// Add reviewers to pull request.
+    /// List pull request reviewers with review status, or add new reviewers.
+    #[command(
+        long_about = "List pull request reviewers with review status, or add new reviewers.\n\nWith no flags, lists current reviewers (role=REVIEWER) and whether each has approved, requested changes, or not responded.\n\nExamples:\n  bb pr reviewers my-repo 123\n  bb pr reviewers my-repo 123 --all\n  bb pr reviewers my-repo 123 --add {uuid}"
+    )]
     Reviewers {
         /// Repository slug.
         repo: String,
         /// Pull request ID.
         pr_id: i64,
-        /// Reviewer UUIDs (comma-separated).
+        /// Reviewer UUIDs to add (comma-separated). If omitted, lists current reviewers instead.
         #[arg(long, value_delimiter = ',')]
         add: Vec<String>,
+        /// When listing, also include non-reviewer participants (commenters).
+        #[arg(long)]
+        all: bool,
     },
 }
 
@@ -1114,8 +1120,17 @@ pub async fn execute(
             PrCommands::Comment { repo, pr_id, text } => {
                 pullrequests::add_pr_comment(&ctx, &workspace, &repo, pr_id, &text).await
             }
-            PrCommands::Reviewers { repo, pr_id, add } => {
-                pullrequests::add_pr_reviewers(&ctx, &workspace, &repo, pr_id, add).await
+            PrCommands::Reviewers {
+                repo,
+                pr_id,
+                add,
+                all,
+            } => {
+                if add.is_empty() {
+                    pullrequests::list_pr_reviewers(&ctx, &workspace, &repo, pr_id, all).await
+                } else {
+                    pullrequests::add_pr_reviewers(&ctx, &workspace, &repo, pr_id, add).await
+                }
             }
         },
         BitbucketCommands::Workspace(cmd) => match cmd {

--- a/crates/cli/src/commands/bitbucket/pullrequests.rs
+++ b/crates/cli/src/commands/bitbucket/pullrequests.rs
@@ -79,13 +79,24 @@ struct RepositoryWorkspace {
 
 #[derive(Deserialize)]
 struct Participant {
-    #[allow(dead_code)]
     #[serde(default)]
     approved: bool,
-    #[allow(dead_code)]
     user: User,
-    #[allow(dead_code)]
     role: String,
+    #[serde(default)]
+    state: Option<String>,
+    #[serde(default)]
+    participated_on: Option<String>,
+}
+
+/// Derive a human-friendly review status label from a participant's `approved`/`state` fields.
+fn participant_status(approved: bool, state: Option<&str>) -> &'static str {
+    match state {
+        Some("approved") => "Approved",
+        Some("changes_requested") => "Changes Requested",
+        _ if approved => "Approved",
+        _ => "No Response",
+    }
 }
 
 #[derive(Deserialize)]
@@ -572,6 +583,48 @@ pub async fn add_pr_reviewers(
     )
 }
 
+/// List reviewers (or all participants) on a pull request along with their review status.
+pub async fn list_pr_reviewers(
+    ctx: &BitbucketContext<'_>,
+    workspace: &str,
+    repo_slug: &str,
+    pr_id: i64,
+    show_all: bool,
+) -> Result<()> {
+    let path = format!("/2.0/repositories/{workspace}/{repo_slug}/pullrequests/{pr_id}");
+    let pr: PullRequest = ctx.client.get(&path).await.with_context(|| {
+        format!("Failed to fetch pull request {pr_id} from {workspace}/{repo_slug}")
+    })?;
+
+    #[derive(Serialize)]
+    struct Row<'a> {
+        name: &'a str,
+        role: &'a str,
+        status: &'a str,
+        participated_on: &'a str,
+    }
+
+    let participants = pr.participants.unwrap_or_default();
+    let rows: Vec<Row<'_>> = participants
+        .iter()
+        .filter(|p| show_all || p.role == "REVIEWER")
+        .map(|p| Row {
+            name: p.user.display_name.as_str(),
+            role: p.role.as_str(),
+            status: participant_status(p.approved, p.state.as_deref()),
+            participated_on: p.participated_on.as_deref().unwrap_or(""),
+        })
+        .collect();
+
+    if rows.is_empty() {
+        tracing::info!(pr_id, workspace, repo_slug, show_all, "No reviewers found");
+        println!("No reviewers found");
+        return Ok(());
+    }
+
+    ctx.renderer.render(&rows)
+}
+
 pub async fn get_pr_diff(
     _ctx: &BitbucketContext<'_>,
     workspace: &str,
@@ -634,4 +687,33 @@ pub async fn get_pr_info(
 /// Check if a PR is from a fork
 pub fn is_from_fork(pr_info: &PullRequestInfo, target_workspace: &str, target_repo: &str) -> bool {
     pr_info.source_workspace != target_workspace || pr_info.source_repo != target_repo
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_participant_status_approved_state() {
+        assert_eq!(participant_status(true, Some("approved")), "Approved");
+    }
+
+    #[test]
+    fn test_participant_status_changes_requested() {
+        assert_eq!(
+            participant_status(false, Some("changes_requested")),
+            "Changes Requested"
+        );
+    }
+
+    #[test]
+    fn test_participant_status_no_state_but_approved_fallback() {
+        // Older API responses may omit `state` but still set `approved`.
+        assert_eq!(participant_status(true, None), "Approved");
+    }
+
+    #[test]
+    fn test_participant_status_no_response() {
+        assert_eq!(participant_status(false, None), "No Response");
+    }
 }

--- a/crates/cli/tests/bitbucket_integration.rs
+++ b/crates/cli/tests/bitbucket_integration.rs
@@ -437,6 +437,73 @@ async fn test_bitbucket_approve_pull_request() {
 }
 
 #[tokio::test]
+async fn test_bitbucket_get_pull_request_with_reviewer_participants() {
+    let mock_server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/2.0/repositories/myworkspace/myrepo/pullrequests/1"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "id": 1,
+            "title": "Add new feature",
+            "state": "OPEN",
+            "author": {"display_name": "John Doe"},
+            "source": {
+                "branch": {"name": "feature/new-feature"}
+            },
+            "destination": {
+                "branch": {"name": "main"}
+            },
+            "participants": [
+                {
+                    "user": {"display_name": "Jane Doe"},
+                    "role": "REVIEWER",
+                    "approved": true,
+                    "state": "approved",
+                    "participated_on": "2026-08-10T12:00:00Z"
+                },
+                {
+                    "user": {"display_name": "John Smith"},
+                    "role": "REVIEWER",
+                    "approved": false,
+                    "state": "changes_requested",
+                    "participated_on": "2026-08-11T09:30:00Z"
+                },
+                {
+                    "user": {"display_name": "Alex Lee"},
+                    "role": "PARTICIPANT",
+                    "approved": false,
+                    "state": null,
+                    "participated_on": null
+                }
+            ]
+        })))
+        .mount(&mock_server)
+        .await;
+
+    let client = ApiClient::new(mock_server.uri())
+        .unwrap()
+        .with_basic_auth("test@example.com", "fake-token");
+
+    let response: Result<serde_json::Value, _> = client
+        .get("/2.0/repositories/myworkspace/myrepo/pullrequests/1")
+        .await;
+
+    assert!(response.is_ok());
+    let pr = response.unwrap();
+    let participants = pr["participants"].as_array().unwrap();
+    assert_eq!(participants.len(), 3);
+
+    assert_eq!(participants[0]["role"], "REVIEWER");
+    assert_eq!(participants[0]["state"], "approved");
+
+    assert_eq!(participants[1]["state"], "changes_requested");
+    assert_eq!(participants[1]["approved"], false);
+
+    assert_eq!(participants[2]["role"], "PARTICIPANT");
+    assert!(participants[2]["state"].is_null());
+}
+
+#[tokio::test]
 async fn test_bitbucket_branch_protection() {
     let mock_server = MockServer::start().await;
 

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -1,5 +1,10 @@
 # atlassian-cli TODO
 
+## Bitbucket PR Reviewer Status (2026-08-15)
+- [x] `bb pr reviewers <repo> <pr_id>` now lists current reviewers with approval status (Approved/Changes Requested/No Response) when `--add` is omitted
+- [x] Add `--all` flag to also include non-reviewer participants (commenters)
+- [x] Fixed latent bug where omitting `--add` silently no-op'd and printed a false "Reviewers added" success message
+
 ## Product Landing Pages — Jira & Confluence (2026-03-14)
 - [x] Create /docs/jira/index.html — Jira CLI product page (315 lines)
 - [x] Create /docs/confluence/index.html — Confluence CLI product page (326 lines)


### PR DESCRIPTION
## Description
`bb pr reviewers <repo> <pr_id>` previously only supported adding reviewers via `--add`. Omitting `--add` silently looped zero times and printed a misleading "Reviewers added to pull request" success message (a latent no-op bug). This PR repurposes that no-`--add` invocation to list current reviewers and their review status instead:

- Default: lists `role == REVIEWER` participants with a derived `status` column (`Approved` / `Changes Requested` / `No Response`), based on the Bitbucket API's `participant.state`/`approved` fields.
- New `--all` flag: also include `role == PARTICIPANT` people (commenters/other interactors).
- `--add <uuid1,uuid2>` keeps working exactly as before (unchanged).

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring

## Related Issues
Closes #102

## Testing
- [x] Added/updated unit tests
- [x] Added/updated integration tests
- [x] Tested manually (describe below)

### Manual Testing
```bash
$ atlassian-cli bitbucket pr reviewers --help
List pull request reviewers with review status, or add new reviewers.

With no flags, lists current reviewers (role=REVIEWER) and whether each has approved, requested
changes, or not responded.

Examples:
  bb pr reviewers my-repo 123
  bb pr reviewers my-repo 123 --all
  bb pr reviewers my-repo 123 --add {uuid}
```
Added 4 unit tests for `participant_status()` (approved/changes_requested/fallback/no-response) and a new wiremock integration test (`test_bitbucket_get_pull_request_with_reviewer_participants`) covering a mixed REVIEWER/PARTICIPANT participants payload.

## Checklist
- [x] Code follows project style (ran `cargo fmt`)
- [x] All clippy warnings addressed (ran `cargo clippy`)
- [x] All tests pass (ran `cargo test`)
- [x] Updated `todo.md` with changes
- [x] Updated documentation if needed
- [x] No security vulnerabilities introduced

## Additional Notes
Implementation notes:
- Extended the existing (previously unused) `Participant` struct in `crates/cli/src/commands/bitbucket/pullrequests.rs` with `state`/`participated_on` fields returned by the Bitbucket Cloud API.
- New `list_pr_reviewers()` reuses the existing PR GET endpoint (participants are embedded in the PR resource — no extra API call needed).

Made with [Cursor](https://cursor.com)