### PR TITLE
fix(bitbucket): repair `pr reviewers --add` and cover reviewer listing

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,6 +249,7 @@ crates/
    atlassian-cli bitbucket --workspace myteam pr comment api-service 123 --text "Looks good!"
    atlassian-cli bitbucket --workspace myteam pr reviewers api-service 123
    atlassian-cli bitbucket --workspace myteam pr reviewers api-service 123 --all
+   atlassian-cli bitbucket --workspace myteam pr reviewers api-service 123 --add '{557058:1a2b3c}'
 
    # Bitbucket - Workspaces & Projects
    atlassian-cli bitbucket workspace list --limit 10

--- a/crates/cli/src/commands/bitbucket/mod.rs
+++ b/crates/cli/src/commands/bitbucket/mod.rs
@@ -376,7 +376,7 @@ enum PrCommands {
         #[arg(long, value_delimiter = ',')]
         add: Vec<String>,
         /// When listing, also include non-reviewer participants (commenters).
-        #[arg(long)]
+        #[arg(long, conflicts_with = "add")]
         all: bool,
     },
 }

--- a/crates/cli/src/commands/bitbucket/pullrequests.rs
+++ b/crates/cli/src/commands/bitbucket/pullrequests.rs
@@ -39,12 +39,13 @@ struct PullRequest {
     task_count: Option<i32>,
     #[serde(default)]
     participants: Option<Vec<Participant>>,
+    #[serde(default)]
+    reviewers: Option<Vec<User>>,
 }
 
 #[derive(Deserialize)]
 struct User {
     display_name: String,
-    #[allow(dead_code)]
     #[serde(default)]
     uuid: Option<String>,
 }
@@ -97,6 +98,29 @@ fn participant_status(approved: bool, state: Option<&str>) -> &'static str {
         _ if approved => "Approved",
         _ => "No Response",
     }
+}
+
+#[derive(Serialize)]
+struct ReviewerRow<'a> {
+    name: &'a str,
+    role: &'a str,
+    status: &'a str,
+    participated_on: &'a str,
+}
+
+/// Build the reviewer table rows. Only `role == REVIEWER` participants are kept unless
+/// `show_all` is set, in which case commenters and other participants are included too.
+fn reviewer_rows(participants: &[Participant], show_all: bool) -> Vec<ReviewerRow<'_>> {
+    participants
+        .iter()
+        .filter(|p| show_all || p.role == "REVIEWER")
+        .map(|p| ReviewerRow {
+            name: p.user.display_name.as_str(),
+            role: p.role.as_str(),
+            status: participant_status(p.approved, p.state.as_deref()),
+            participated_on: p.participated_on.as_deref().unwrap_or(""),
+        })
+        .collect()
 }
 
 #[derive(Deserialize)]
@@ -246,9 +270,9 @@ pub async fn create_pull_request(
     }
 
     if !reviewers.is_empty() {
-        let reviewer_objs: Vec<_> = reviewers
+        let reviewer_objs: Vec<_> = merge_reviewer_uuids(&[], &reviewers)
             .iter()
-            .map(|uuid| serde_json::json!({"uuid": uuid}))
+            .map(|uuid| serde_json::json!({ "uuid": uuid }))
             .collect();
         payload["reviewers"] = serde_json::json!(reviewer_objs);
     }
@@ -553,6 +577,36 @@ pub async fn add_pr_comment(
     )
 }
 
+/// Normalise a Bitbucket account UUID to the brace form the API expects (`{uuid}`),
+/// so `--add abc-123` and `--add '{abc-123}'` both work.
+fn normalize_uuid(raw: &str) -> String {
+    let trimmed = raw.trim();
+    if trimmed.starts_with('{') && trimmed.ends_with('}') {
+        trimmed.to_string()
+    } else {
+        format!("{{{trimmed}}}")
+    }
+}
+
+/// Merge the PR's existing reviewer UUIDs with the requested ones, preserving order and
+/// dropping duplicates and empties.
+fn merge_reviewer_uuids(existing: &[String], requested: &[String]) -> Vec<String> {
+    let mut merged: Vec<String> = Vec::new();
+    for uuid in existing.iter().chain(requested.iter()) {
+        let normalized = normalize_uuid(uuid);
+        if normalized == "{}" || merged.contains(&normalized) {
+            continue;
+        }
+        merged.push(normalized);
+    }
+    merged
+}
+
+/// Add reviewers to a pull request.
+///
+/// Bitbucket Cloud has no endpoint for adding a single reviewer to an existing PR: the
+/// reviewer list is replaced wholesale by a `PUT` on the pull request itself. So we read the
+/// current reviewers, union the requested UUIDs in, and PUT the result back.
 pub async fn add_pr_reviewers(
     ctx: &BitbucketContext<'_>,
     workspace: &str,
@@ -560,18 +614,47 @@ pub async fn add_pr_reviewers(
     pr_id: i64,
     reviewers: Vec<String>,
 ) -> Result<()> {
-    for uuid in reviewers {
-        let path = format!(
-            "/2.0/repositories/{workspace}/{repo_slug}/pullrequests/{pr_id}/default-reviewers/{uuid}"
-        );
-        let _: serde_json::Value = ctx
-            .client
-            .put(&path, &serde_json::json!({}))
-            .await
-            .with_context(|| format!("Failed to add reviewer {uuid} to pull request {pr_id}"))?;
+    let path = format!("/2.0/repositories/{workspace}/{repo_slug}/pullrequests/{pr_id}");
+    let pr: PullRequest = ctx.client.get(&path).await.with_context(|| {
+        format!("Failed to fetch pull request {pr_id} from {workspace}/{repo_slug}")
+    })?;
 
-        tracing::info!(uuid, pr_id, "Reviewer added successfully");
-    }
+    let existing: Vec<String> = pr
+        .reviewers
+        .as_ref()
+        .map(|list| {
+            list.iter()
+                .filter_map(|user| user.uuid.clone())
+                .collect::<Vec<_>>()
+        })
+        .unwrap_or_default();
+
+    let merged = merge_reviewer_uuids(&existing, &reviewers);
+    tracing::info!(
+        pr_id,
+        workspace,
+        repo_slug,
+        existing = existing.len(),
+        requested = reviewers.len(),
+        total = merged.len(),
+        "Updating pull request reviewers"
+    );
+
+    let payload = serde_json::json!({
+        "title": pr.title,
+        "reviewers": merged
+            .iter()
+            .map(|uuid| serde_json::json!({ "uuid": uuid }))
+            .collect::<Vec<_>>(),
+    });
+
+    let _: serde_json::Value = ctx
+        .client
+        .put(&path, &payload)
+        .await
+        .with_context(|| format!("Failed to add reviewers to pull request {pr_id}"))?;
+
+    tracing::info!(pr_id, count = merged.len(), "Reviewers added successfully");
 
     render_success(
         ctx.renderer,
@@ -596,25 +679,8 @@ pub async fn list_pr_reviewers(
         format!("Failed to fetch pull request {pr_id} from {workspace}/{repo_slug}")
     })?;
 
-    #[derive(Serialize)]
-    struct Row<'a> {
-        name: &'a str,
-        role: &'a str,
-        status: &'a str,
-        participated_on: &'a str,
-    }
-
     let participants = pr.participants.unwrap_or_default();
-    let rows: Vec<Row<'_>> = participants
-        .iter()
-        .filter(|p| show_all || p.role == "REVIEWER")
-        .map(|p| Row {
-            name: p.user.display_name.as_str(),
-            role: p.role.as_str(),
-            status: participant_status(p.approved, p.state.as_deref()),
-            participated_on: p.participated_on.as_deref().unwrap_or(""),
-        })
-        .collect();
+    let rows = reviewer_rows(&participants, show_all);
 
     if rows.is_empty() {
         tracing::info!(pr_id, workspace, repo_slug, show_all, "No reviewers found");
@@ -715,5 +781,130 @@ mod tests {
     #[test]
     fn test_participant_status_no_response() {
         assert_eq!(participant_status(false, None), "No Response");
+    }
+
+    fn participant(
+        name: &str,
+        role: &str,
+        approved: bool,
+        state: Option<&str>,
+        participated_on: Option<&str>,
+    ) -> Participant {
+        Participant {
+            approved,
+            user: User {
+                display_name: name.to_string(),
+                uuid: None,
+            },
+            role: role.to_string(),
+            state: state.map(str::to_string),
+            participated_on: participated_on.map(str::to_string),
+        }
+    }
+
+    fn sample_participants() -> Vec<Participant> {
+        vec![
+            participant(
+                "Jane Doe",
+                "REVIEWER",
+                true,
+                Some("approved"),
+                Some("2026-08-10T12:00:00Z"),
+            ),
+            participant(
+                "John Smith",
+                "REVIEWER",
+                false,
+                Some("changes_requested"),
+                Some("2026-08-11T09:30:00Z"),
+            ),
+            participant("Alex Lee", "REVIEWER", false, None, None),
+            participant(
+                "Sam Chen",
+                "PARTICIPANT",
+                false,
+                None,
+                Some("2026-08-12T08:00:00Z"),
+            ),
+        ]
+    }
+
+    #[test]
+    fn test_reviewer_rows_default_excludes_participants() {
+        let participants = sample_participants();
+        let rows = reviewer_rows(&participants, false);
+
+        assert_eq!(rows.len(), 3);
+        assert!(rows.iter().all(|r| r.role == "REVIEWER"));
+        assert_eq!(rows[0].name, "Jane Doe");
+        assert_eq!(rows[0].status, "Approved");
+        assert_eq!(rows[0].participated_on, "2026-08-10T12:00:00Z");
+        assert_eq!(rows[1].status, "Changes Requested");
+        assert_eq!(rows[2].status, "No Response");
+        // Missing participated_on renders as an empty cell, not "null".
+        assert_eq!(rows[2].participated_on, "");
+    }
+
+    #[test]
+    fn test_reviewer_rows_all_includes_participants() {
+        let participants = sample_participants();
+        let rows = reviewer_rows(&participants, true);
+
+        assert_eq!(rows.len(), 4);
+        assert_eq!(rows[3].name, "Sam Chen");
+        assert_eq!(rows[3].role, "PARTICIPANT");
+        assert_eq!(rows[3].status, "No Response");
+    }
+
+    #[test]
+    fn test_reviewer_rows_empty() {
+        assert!(reviewer_rows(&[], false).is_empty());
+        assert!(reviewer_rows(&[], true).is_empty());
+    }
+
+    #[test]
+    fn test_reviewer_rows_no_reviewers_only_participants() {
+        let participants = vec![participant("Sam Chen", "PARTICIPANT", false, None, None)];
+
+        assert!(reviewer_rows(&participants, false).is_empty());
+        assert_eq!(reviewer_rows(&participants, true).len(), 1);
+    }
+
+    #[test]
+    fn test_normalize_uuid_adds_braces() {
+        assert_eq!(normalize_uuid("abc-123"), "{abc-123}");
+        assert_eq!(normalize_uuid("{abc-123}"), "{abc-123}");
+        assert_eq!(normalize_uuid("  abc-123  "), "{abc-123}");
+    }
+
+    #[test]
+    fn test_merge_reviewer_uuids_unions_and_dedupes() {
+        let existing = vec!["{a}".to_string(), "b".to_string()];
+        let requested = vec!["b".to_string(), "{c}".to_string(), "a".to_string()];
+
+        assert_eq!(
+            merge_reviewer_uuids(&existing, &requested),
+            vec!["{a}".to_string(), "{b}".to_string(), "{c}".to_string()]
+        );
+    }
+
+    #[test]
+    fn test_merge_reviewer_uuids_keeps_existing_when_nothing_requested() {
+        let existing = vec!["{a}".to_string()];
+
+        assert_eq!(
+            merge_reviewer_uuids(&existing, &[]),
+            vec!["{a}".to_string()]
+        );
+    }
+
+    #[test]
+    fn test_merge_reviewer_uuids_skips_empty_entries() {
+        let requested = vec!["".to_string(), "  ".to_string(), "a".to_string()];
+
+        assert_eq!(
+            merge_reviewer_uuids(&[], &requested),
+            vec!["{a}".to_string()]
+        );
     }
 }

--- a/crates/cli/tests/bitbucket_integration.rs
+++ b/crates/cli/tests/bitbucket_integration.rs
@@ -1,5 +1,5 @@
 use atlassian_cli_api::ApiClient;
-use wiremock::matchers::{method, path, query_param, query_param_contains};
+use wiremock::matchers::{body_json, method, path, query_param, query_param_contains};
 use wiremock::{Mock, MockServer, ResponseTemplate};
 
 #[tokio::test]
@@ -501,6 +501,65 @@ async fn test_bitbucket_get_pull_request_with_reviewer_participants() {
 
     assert_eq!(participants[2]["role"], "PARTICIPANT");
     assert!(participants[2]["state"].is_null());
+}
+
+/// Pins the request contract `add_pr_reviewers` is written against: reviewers are set by
+/// PUTting the pull request itself with the full reviewer list, since Bitbucket Cloud has no
+/// per-reviewer endpoint on a PR.
+///
+/// Like the rest of this file, this drives `ApiClient` directly rather than the command, so
+/// it documents and exercises the wire format but would not catch the command regressing to
+/// a different URL. The command's own merge and normalisation logic is unit-tested in
+/// `crates/cli/src/commands/bitbucket/pullrequests.rs`.
+#[tokio::test]
+async fn test_bitbucket_add_pull_request_reviewers() {
+    let mock_server = MockServer::start().await;
+
+    Mock::given(method("PUT"))
+        .and(path("/2.0/repositories/myworkspace/myrepo/pullrequests/1"))
+        .and(body_json(serde_json::json!({
+            "title": "Add new feature",
+            "reviewers": [
+                {"uuid": "{existing-uuid}"},
+                {"uuid": "{new-uuid}"}
+            ]
+        })))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "id": 1,
+            "title": "Add new feature",
+            "state": "OPEN",
+            "author": {"display_name": "John Doe"},
+            "source": {"branch": {"name": "feature/new-feature"}},
+            "destination": {"branch": {"name": "main"}},
+            "reviewers": [
+                {"display_name": "Jane Doe", "uuid": "{existing-uuid}"},
+                {"display_name": "John Smith", "uuid": "{new-uuid}"}
+            ]
+        })))
+        .expect(1)
+        .mount(&mock_server)
+        .await;
+
+    let client = ApiClient::new(mock_server.uri())
+        .unwrap()
+        .with_basic_auth("test@example.com", "fake-token");
+
+    let response: Result<serde_json::Value, _> = client
+        .put(
+            "/2.0/repositories/myworkspace/myrepo/pullrequests/1",
+            &serde_json::json!({
+                "title": "Add new feature",
+                "reviewers": [
+                    {"uuid": "{existing-uuid}"},
+                    {"uuid": "{new-uuid}"}
+                ]
+            }),
+        )
+        .await;
+
+    assert!(response.is_ok());
+    let pr = response.unwrap();
+    assert_eq!(pr["reviewers"].as_array().unwrap().len(), 2);
 }
 
 #[tokio::test]

--- a/docs/16082026_bb_pr_reviewer_status.md
+++ b/docs/16082026_bb_pr_reviewer_status.md
@@ -1,0 +1,77 @@
+# Bitbucket PR reviewer status and reviewer updates
+
+Status: implemented on branch `fix/bb-pr-reviewers-followup`, on top of PR #103 (merged).
+
+## Problem
+
+`bb pr reviewers <repo> <pr_id>` only ever added reviewers. Two defects followed from that:
+
+1. With no `--add`, the command iterated an empty list and then printed
+   `✅ Reviewers added to pull request #N`. A no-op reporting success. There was no way to
+   see who the reviewers were or whether they had approved, so scripts had to run
+   `pr get --format json | jq '.participants[]'` (issue #102).
+2. With `--add`, the command PUT
+   `/2.0/repositories/{ws}/{repo}/pullrequests/{id}/default-reviewers/{uuid}`. Bitbucket
+   Cloud has no such endpoint: repo-level default reviewers live at
+   `/2.0/repositories/{ws}/{repo}/default-reviewers/{user}`, and a pull request's reviewer
+   list is replaced by a `PUT` on the pull request itself. Every `--add` was a 404. This is
+   the same class of defect as issue #100 (`jira issue comments update`).
+
+## Design notes
+
+**Listing.** The no-`--add` invocation now lists participants
+(`crates/cli/src/commands/bitbucket/pullrequests.rs::list_pr_reviewers`). Participants are
+embedded in the pull request resource, so the existing PR GET is reused and no second call is
+made. Default output is `role == REVIEWER` only; `--all` adds `PARTICIPANT` rows
+(commenters and other interactors).
+
+`status` is derived, not returned by the API:
+
+| Participant fields | Status |
+| --- | --- |
+| `state == "approved"`, or `approved == true` with no `state` | `Approved` |
+| `state == "changes_requested"` | `Changes Requested` |
+| anything else | `No Response` |
+
+The `approved`-with-no-`state` arm exists because older responses set the boolean without the
+string. Filtering and row construction live in a pure `reviewer_rows(&[Participant], bool)`
+so they are unit-testable; `list_pr_reviewers` is left with I/O and rendering, matching
+`list_pull_requests`.
+
+**Adding.** `add_pr_reviewers` now reads the PR, unions the existing reviewer UUIDs with the
+requested ones, and PUTs `{"title": <unchanged>, "reviewers": [{"uuid": …}]}` back. The PR
+PUT takes the pull request to update; `title` is sent unchanged rather than omitted, since it
+is the one field documented as required when creating a PR and echoing it back cannot change
+anything. Reading first is what makes `--add` additive rather than destructive, since the
+submitted `reviewers` array replaces the whole list.
+
+UUIDs are normalised to Bitbucket's brace form by `normalize_uuid`, so `--add abc-123` and
+`--add '{abc-123}'` behave the same. `create_pull_request --reviewers` was passing raw input
+straight through and had the same bare-UUID problem, so it now shares the helper.
+
+`--all` is `conflicts_with = "add"`: it only affects listing, and silently ignoring it on the
+add path was how the original no-op bug read to users.
+
+## Limitations
+
+- Reviewers can only be added, not removed. Removal means sending a shorter list on the same
+  PUT; no flag exposes it yet.
+- The reviewer union is last-write-wins against whatever the PR looked like at GET time. Two
+  concurrent `--add` calls can drop one of the additions.
+- A participant whose `state` is some value Bitbucket adds later renders as `No Response`
+  rather than the raw string.
+- `--add` takes account UUIDs only, not usernames or emails.
+
+## Tests
+
+- 12 unit tests in `crates/cli/src/commands/bitbucket/pullrequests.rs`: status derivation
+  (four arms), REVIEWER-only vs `--all` filtering, empty participants, participants-without-
+  reviewers, empty `participated_on` rendering as a blank cell, UUID normalisation, and
+  union/dedupe including empty entries.
+- `crates/cli/tests/bitbucket_integration.rs`: the participants payload shape, and
+  `test_bitbucket_add_pull_request_reviewers`, which pins the PUT path and body. Like every
+  test in that file it drives `ApiClient` directly rather than the command, so it documents
+  the wire format but would not catch `add_pr_reviewers` calling a different URL.
+- Not covered by tests: the live Bitbucket contract. Nothing here would have caught the
+  original wrong endpoint either, since a mock serves whatever path it is given. The `--add`
+  path needs a run against a real workspace before it is trusted.

--- a/docs/index.md
+++ b/docs/index.md
@@ -45,6 +45,7 @@ changes made, newest last; `docs/todo.md` is the forward-looking roadmap.
 
 | Document | Date | What it covers |
 | --- | --- | --- |
+| [16082026_bb_pr_reviewer_status.md](16082026_bb_pr_reviewer_status.md) | 2026-08-16 | `bb pr reviewers` listing with approval status, `--all`, and the `--add` endpoint fix |
 | [10082026_raw_api_passthrough.md](10082026_raw_api_passthrough.md) | 2026-08-10 | `jira api` raw authenticated REST passthrough, `ApiClient::request_raw`, origin and redirect safety |
 | [10082026_jira_attachments.md](10082026_jira_attachments.md) | 2026-08-10 | `jira attachment` group: list, get, download (single, stdout, bulk), upload, delete |
 | [02042026_jira_search_migration.md](02042026_jira_search_migration.md) | 2026-04-02 | Migration to `/rest/api/3/search/jql` after the old endpoint was removed |

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -1,10 +1,5 @@
 # atlassian-cli TODO
 
-## Bitbucket PR Reviewer Status (2026-08-15)
-- [x] `bb pr reviewers <repo> <pr_id>` now lists current reviewers with approval status (Approved/Changes Requested/No Response) when `--add` is omitted
-- [x] Add `--all` flag to also include non-reviewer participants (commenters)
-- [x] Fixed latent bug where omitting `--add` silently no-op'd and printed a false "Reviewers added" success message
-
 ## Product Landing Pages — Jira & Confluence (2026-03-14)
 - [x] Create /docs/jira/index.html — Jira CLI product page (315 lines)
 - [x] Create /docs/confluence/index.html — Confluence CLI product page (326 lines)

--- a/todo.md
+++ b/todo.md
@@ -1479,3 +1479,12 @@ Validated all 1,924 command examples on the site against the real binary (checke
 
 - `--profile` and `--config` were not global, while `--format` was. So `... issue list --profile prod`, which is what users and most published examples write, was rejected. Both are now `global = true`. This alone accounted for 36 broken site examples plus every shipped example script.
 - `auth login` run bare failed argument parsing, even though the CLI's own errors say "Run `atlassian-cli auth login` first" and the guides repeat it. Missing `--profile`/`--base-url`/`--email` are now prompted for, matching how `--token` already behaved. Without a terminal it stays a hard error rather than hanging on stdin, so CI keeps failing loudly.
+## 2026-08-16 — `bb pr reviewers` lists review status; `--add` endpoint fixed (branch `fix/bb-pr-reviewers-followup`)
+
+Issue #102 and PR #103 from an outside contributor, plus the follow-up this repo owed them.
+
+- PR #103 (merged): `bb pr reviewers <repo> <pr_id>` with no `--add` now lists participants with a derived `status` column (Approved / Changes Requested / No Response) instead of looping zero times and printing "✅ Reviewers added to pull request #N". `--all` includes `role == PARTICIPANT` rows. Participants come from the PR GET, which already embeds them, so there is no extra call.
+- `--all` combined with `--add` was silently ignored; now `conflicts_with = "add"`, so clap rejects it.
+- Fixed `--add`, which had never worked: it PUT `/pullrequests/{id}/default-reviewers/{uuid}`, an endpoint Bitbucket Cloud does not have (repo default reviewers are at `/repositories/{ws}/{repo}/default-reviewers/{user}`, and a PR's reviewer list is replaced by a PUT on the PR). Same class of defect as #100. It now reads the PR's current reviewers, unions the requested UUIDs in, and PUTs `{title, reviewers}` back.
+- UUIDs are normalised to Bitbucket's brace form, so `--add abc-123` and `--add '{abc-123}'` both work. `pr create --reviewers` uses the same normalisation, where a bare UUID had the same problem.
+- Row filtering moved out of `list_pr_reviewers` into a pure `reviewer_rows()`; 12 unit tests now cover status derivation, REVIEWER-vs-`--all` filtering, empty results, UUID normalisation and the union/dedupe. The added wiremock test pins the PUT path and body.


### PR DESCRIPTION
Follow-up to #103 (which added `pr reviewers` listing), covering the review points raised there.

## What this fixes

**`--add` had never worked.** It PUT `/2.0/repositories/{ws}/{repo}/pullrequests/{id}/default-reviewers/{uuid}`, an endpoint Bitbucket Cloud does not have: repo default reviewers are at `/repositories/{ws}/{repo}/default-reviewers/{user}`, and a PR's reviewer list is replaced by a PUT on the PR itself. Every `--add` was a 404. Same class of defect as #100.

`add_pr_reviewers` now reads the PR, unions the requested UUIDs into the existing reviewer list, and PUTs `{title, reviewers}` back. Reading first is what keeps `--add` additive, since the submitted array replaces the whole list.

**Bare UUIDs.** Normalised to Bitbucket's brace form, so `--add abc-123` and `--add '{abc-123}'` behave the same. `pr create --reviewers` passed raw input through and had the same problem, so it shares the helper.

**`--all` alongside `--add`** was silently ignored; now `conflicts_with = "add"`, so clap rejects it rather than repeating the failure mode #102 reported.

**Tests.** Row filtering moved out of `list_pr_reviewers` into a pure `reviewer_rows()`. 12 unit tests now cover status derivation, `REVIEWER` vs `--all` filtering, empty results, UUID normalisation and union/dedupe. The added wiremock test pins the PUT wire format; like the rest of that file it drives `ApiClient` rather than the command, and the test comment says so rather than claiming more.

## Docs

- `docs/16082026_bb_pr_reviewer_status.md` (new) and its row in `docs/index.md`.
- Changelog entry moved to the repo-root `todo.md`; `docs/todo.md` is the forward-looking roadmap.
- README gains the `--add` example.

## Untested

The live Bitbucket contract for the PR PUT. A mock serves whatever path it is given, so nothing here would have caught the original wrong endpoint either. `--add` needs a run against a real workspace before it is trusted.

## Also found, not fixed here

`docs/examples/bitbucket/pr-automation.sh` passes the workspace as a positional to `pr list`/`get`/`approve`/`merge`, which all take `<REPO> <PR_ID>` only, so every invocation in that script exits 2. Its `get_approval_count` also reads `.participants[]` from `pr get --format json`, which does not emit that field. Filing separately rather than widening this PR.