### PR TITLE
fix(output): serialise the env-var tests in colors.rs

### DIFF
--- a/crates/output/src/colors.rs
+++ b/crates/output/src/colors.rs
@@ -104,6 +104,25 @@ impl Default for StatusFormatter {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::Mutex;
+
+    // Environment variables are process-global, so the tests below cannot run
+    // concurrently: EnvGuard restores state when a test finishes, but it cannot stop a
+    // sibling test from mutating the same variable mid-assertion. Two vectors existed,
+    // both hitting test_clicolor_force_enables_colors, which needs NO_COLOR unset and
+    // TERM not "dumb":
+    //   - test_no_color_env_disables_colors and
+    //     test_no_color_takes_precedence_over_clicolor_force set NO_COLOR=1
+    //   - test_term_dumb_disables_colors sets TERM=dumb, which should_use_colors()
+    //     checks before CLICOLOR_FORCE
+    // Every test that touches the environment must take this lock first.
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    // Poison-tolerant on purpose: if one env test fails while holding the lock, the
+    // other three should still report their own result rather than cascade.
+    fn env_lock() -> std::sync::MutexGuard<'static, ()> {
+        ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner())
+    }
 
     // Helper to save and restore environment variables
     struct EnvGuard {
@@ -141,6 +160,7 @@ mod tests {
 
     #[test]
     fn test_no_color_env_disables_colors() {
+        let _env = env_lock();
         let mut guard = EnvGuard::new();
         guard.set("NO_COLOR", "1");
         assert!(!should_use_colors());
@@ -148,6 +168,7 @@ mod tests {
 
     #[test]
     fn test_term_dumb_disables_colors() {
+        let _env = env_lock();
         let mut guard = EnvGuard::new();
         guard.remove("NO_COLOR");
         guard.remove("CLICOLOR_FORCE");
@@ -157,6 +178,7 @@ mod tests {
 
     #[test]
     fn test_clicolor_force_enables_colors() {
+        let _env = env_lock();
         let mut guard = EnvGuard::new();
         guard.remove("NO_COLOR");
         guard.set("CLICOLOR_FORCE", "1");
@@ -165,6 +187,7 @@ mod tests {
 
     #[test]
     fn test_no_color_takes_precedence_over_clicolor_force() {
+        let _env = env_lock();
         let mut guard = EnvGuard::new();
         guard.set("NO_COLOR", "1");
         guard.set("CLICOLOR_FORCE", "1");

--- a/todo.md
+++ b/todo.md
@@ -15,6 +15,31 @@ not hand-editing: `cargo update -p h2` alone reproduces it, including the `quinn
 resolving to 0.52.0.
 
 `cargo deny check advisories` is clean after the bump.
+## 2026-08-20 - Fix flaky colors env-var race (closes #111)
+
+`crates/output/src/colors.rs`: four tests mutate process-global environment variables, and
+`EnvGuard` restores state per test but cannot stop a sibling thread mutating the same variable
+mid-assertion. Two vectors, both landing on `test_clicolor_force_enables_colors`, which needs
+`NO_COLOR` unset and `TERM` not `dumb`:
+
+- `test_no_color_env_disables_colors` and `test_no_color_takes_precedence_over_clicolor_force`
+  set `NO_COLOR=1`
+- `test_term_dumb_disables_colors` sets `TERM=dumb`, which `should_use_colors()` checks before
+  `CLICOLOR_FORCE`
+
+Serialised the four with a module-level `ENV_LOCK: Mutex<()>` rather than adding a `serial_test`
+dependency. The helper is poison-tolerant (`unwrap_or_else(|e| e.into_inner())`) so one genuine
+failure reports once instead of cascading into three misleading ones.
+
+Reproduced by narrowing the run to just those four, which forces them to run concurrently:
+
+```
+cargo test -p atlassian-cli-output --lib -- --test-threads=4 \
+  test_no_color_env_disables_colors test_term_dumb_disables_colors \
+  test_clicolor_force_enables_colors test_no_color_takes_precedence
+```
+
+**80/100 failures before, 0/100 after.** Full `cargo test --all` green.
 
 
 ## 2026-07-13 — Website separated into private repo; removed from public CLI repo


### PR DESCRIPTION
Closes #111.

## Root cause

Four tests in `crates/output/src/colors.rs` mutate process-global environment variables. `EnvGuard` restores state when a test finishes, but it cannot stop a sibling test on another thread mutating the same variable mid-assertion.

Two vectors, both landing on `test_clicolor_force_enables_colors`, which needs `NO_COLOR` unset and `TERM` not `dumb`:

- `test_no_color_env_disables_colors` and `test_no_color_takes_precedence_over_clicolor_force` set `NO_COLOR=1`
- `test_term_dumb_disables_colors` sets `TERM=dumb`, which `should_use_colors()` checks *before* `CLICOLOR_FORCE`

The issue report only named the `NO_COLOR` vector; the `TERM=dumb` one is the same bug and is fixed by the same change.

## Fix

A module-level `ENV_LOCK: Mutex<()>` taken by all four env-touching tests. No new dependency: `serial_test` would have worked but this is six lines and keeps the dev-dependency set unchanged.

The accessor is deliberately poison-tolerant:

```rust
ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner())
```

Without this, one genuine assertion failure poisons the mutex and the other three tests fail too, turning one real problem into four and hiding which was real.

## Reproduction

The default run did not reproduce for me (0 failures in 60 full-suite runs at `--test-threads` 8 and 16). Narrowing the run to just the four tests forces them to run concurrently and makes it reliable:

```bash
cargo test -p atlassian-cli-output --lib -- --test-threads=4 \
  test_no_color_env_disables_colors test_term_dumb_disables_colors \
  test_clicolor_force_enables_colors test_no_color_takes_precedence
```

**Before: 80/100 runs failed. After: 0/100.**

## Checks

- `cargo fmt --all` clean
- `cargo clippy --all-targets --all-features -- -D warnings` clean
- `cargo test --all` green
- `todo.md` updated