### PR TITLE
fix(deps): bump h2 to 0.4.17 for RUSTSEC-2026-0258

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -106,7 +106,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -117,7 +117,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -842,7 +842,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1104,9 +1104,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.12"
+version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3c0b69cfcb4e1b9f1bf2f53f95f766e4661169728ec61cd3fe5a0166f2d1386"
+checksum = "9f877e75f39e9827ec50a572dd592684ac28c029578726c85f1b2aa6ab807449"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1737,7 +1737,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2165,7 +2165,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2719,7 +2719,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/todo.md
+++ b/todo.md
@@ -1,5 +1,22 @@
 # Changes Made
 
+## 2026-08-20 - Fix RUSTSEC-2026-0258 (h2 unbounded empty DATA frames)
+
+`cargo deny check advisories` started failing on `main` and on every PR opened after the
+advisory was published. h2 was pinned at 0.4.12; the advisory requires >= 0.4.16.
+`cargo update -p h2` moves it to 0.4.17.
+
+This is not caused by any open PR. It surfaced on #109 and #113 only because their Security
+Audit happened to run after publication, while #104, #106 and #112 had run before it. Landing
+this unblocks them and stops contributors being blamed for a repo-wide advisory.
+
+Note the accompanying `windows-sys` movement in the lockfile is cargo's own re-resolution,
+not hand-editing: `cargo update -p h2` alone reproduces it, including the `quinn-udp` edge
+resolving to 0.52.0.
+
+`cargo deny check advisories` is clean after the bump.
+
+
 ## 2026-07-13 — Website separated into private repo; removed from public CLI repo
 
 ### Context


### PR DESCRIPTION
`cargo deny check advisories` is currently failing on `main`.

## What happened

**RUSTSEC-2026-0258 — h2 unbounded empty DATA frames.** Requires `h2 >= 0.4.16`; the lockfile pins 0.4.12. `cargo update -p h2` moves it to 0.4.17.

The advisory was published between 18 and 20 Aug. That timing is why it looks like a PR problem when it isn't:

| PR | Security Audit | When it ran |
|---|---|---|
| #104, #106, #112 | pass | before publication |
| #109, #113 | **fail** | after publication |

Both failing PRs are from a first-time contributor and neither touches dependencies. **This is a repo-wide advisory, not their code.** Landing this unblocks them.

## On the lockfile diff

The `windows-sys` movement alongside the h2 bump is cargo's own re-resolution, not hand-editing: `cargo update -p h2` alone reproduces all of it, including the `quinn-udp` edge resolving to `0.52.0`. Worth recording because the identical movement appears in #112 and should not be held against that PR either.

## Verification

- `cargo deny check advisories` → `advisories ok` (was FAILED)
- `cargo test --all` green, 21 test binaries
- `cargo fmt` / `cargo clippy -D warnings` clean