### PR TITLE
fix(cli): make --profile global and let auth login prompt

### DIFF
--- a/crates/cli/src/commands/auth.rs
+++ b/crates/cli/src/commands/auth.rs
@@ -1,3 +1,4 @@
+use std::io::{IsTerminal, Write};
 use std::path::Path;
 
 use anyhow::{anyhow, Context, Result};
@@ -139,14 +140,16 @@ pub struct StatusArgs {
     Note: App passwords are deprecated. Use Bitbucket API tokens (Basic auth) or access tokens (Bearer auth).\n  \
     Create API tokens at: https://id.atlassian.com/manage-profile/security/api-tokens -> Select 'Bitbucket'")]
 pub struct LoginArgs {
-    /// Profile name to create or update.
+    /// Profile name to create or update. Prompted for if omitted.
     #[arg(long)]
-    pub profile: String,
-    /// Atlassian site base URL (e.g. https://example.atlassian.net). Not required for --bitbucket.
-    #[arg(long, required_unless_present = "bitbucket")]
+    pub profile: Option<String>,
+    /// Atlassian site base URL (e.g. https://example.atlassian.net). Prompted for
+    /// if omitted. Not required for --bitbucket.
+    #[arg(long)]
     pub base_url: Option<String>,
-    /// Account email associated with the API token. Not required for --bearer.
-    #[arg(long, required_unless_present = "bearer")]
+    /// Account email associated with the API token. Prompted for if omitted.
+    /// Not required for --bearer.
+    #[arg(long)]
     pub email: Option<String>,
     /// API token to store securely (falls back to ATLASSIAN_API_TOKEN env or interactive prompt).
     #[arg(long, env = "ATLASSIAN_API_TOKEN")]
@@ -163,6 +166,13 @@ pub struct LoginArgs {
     /// Bitbucket workspace slug (optional, for --bitbucket mode).
     #[arg(long, requires = "bitbucket")]
     pub workspace: Option<String>,
+}
+
+impl LoginArgs {
+    /// Profile name, resolved by `login` before anything else runs.
+    fn profile_name(&self) -> &str {
+        self.profile.as_deref().unwrap_or_default()
+    }
 }
 
 #[derive(Args, Debug, Clone)]
@@ -194,7 +204,43 @@ pub async fn handle(
     }
 }
 
-fn login(args: LoginArgs, config: &mut Config, config_path: Option<&Path>) -> Result<()> {
+/// Take a value from a flag, or ask for it interactively.
+///
+/// `auth login` used to reject the bare command, even though the CLI's own
+/// errors and the published guides both tell users to run exactly that. Only a
+/// terminal gets a prompt: without one this stays a hard error, so scripts and
+/// CI keep failing loudly rather than hanging on stdin.
+fn resolve_value(existing: Option<String>, label: &str, flag: &str) -> Result<String> {
+    if let Some(value) = existing {
+        if !value.trim().is_empty() {
+            return Ok(value.trim().to_string());
+        }
+    }
+
+    if !std::io::stdin().is_terminal() {
+        return Err(anyhow!(
+            "Missing --{flag}. Pass it on the command line (no terminal available to prompt for {label})."
+        ));
+    }
+
+    // Prompt on stderr so stdout stays clean for redirection.
+    eprint!("{label}: ");
+    std::io::stderr()
+        .flush()
+        .context("Failed to write prompt")?;
+    let mut line = String::new();
+    std::io::stdin()
+        .read_line(&mut line)
+        .with_context(|| format!("Failed to read {label}"))?;
+
+    let value = line.trim().to_string();
+    if value.is_empty() {
+        return Err(anyhow!("{label} cannot be empty"));
+    }
+    Ok(value)
+}
+
+fn login(mut args: LoginArgs, config: &mut Config, config_path: Option<&Path>) -> Result<()> {
     // Migrate any existing plaintext credentials to encrypted storage
     if let Ok(count) = atlassian_cli_auth::migrate_plaintext_to_encrypted() {
         if count > 0 {
@@ -205,8 +251,28 @@ fn login(args: LoginArgs, config: &mut Config, config_path: Option<&Path>) -> Re
         }
     }
 
-    if args.profile.trim().is_empty() {
+    // The CLI's own errors say "Run `atlassian-cli auth login`", and the
+    // published guides say the same, so the bare command has to work. Missing
+    // values are prompted for on a terminal and remain hard errors without one,
+    // so scripted use keeps failing loudly.
+    args.profile = Some(resolve_value(
+        args.profile.clone(),
+        "Profile name",
+        "profile",
+    )?);
+    if args.profile_name().trim().is_empty() {
         return Err(anyhow!("Profile name cannot be empty"));
+    }
+
+    if !args.bitbucket {
+        args.base_url = Some(resolve_value(
+            args.base_url.clone(),
+            "Atlassian site base URL (e.g. https://example.atlassian.net)",
+            "base-url",
+        )?);
+    }
+    if !args.bearer {
+        args.email = Some(resolve_value(args.email.clone(), "Account email", "email")?);
     }
 
     let token = match &args.token {
@@ -251,16 +317,19 @@ fn login_jira_confluence(
         .as_ref()
         .ok_or_else(|| anyhow!("--email is required for Jira/Confluence login"))?;
 
-    let profile_entry = config.profiles.entry(args.profile.clone()).or_default();
+    let profile_entry = config
+        .profiles
+        .entry(args.profile_name().to_string())
+        .or_default();
     profile_entry.base_url = Some(base_url.to_string());
     profile_entry.email = Some(email.clone());
     profile_entry.api_token = None;
 
     if args.default || config.default_profile.is_none() {
-        config.default_profile = Some(args.profile.clone());
+        config.default_profile = Some(args.profile_name().to_string());
     }
 
-    let secret_key = token_key(&args.profile);
+    let secret_key = token_key(args.profile_name());
     atlassian_cli_auth::set_secret_encrypted(&secret_key, token)
         .context("Failed to store token in encrypted credentials file")?;
 
@@ -269,7 +338,7 @@ fn login_jira_confluence(
         .context("Unable to persist configuration file")?;
 
     tracing::info!(
-        profile = %args.profile,
+        profile = %args.profile_name(),
         base_url = %base_url,
         "Profile saved and token stored securely"
     );
@@ -282,7 +351,10 @@ fn login_bitbucket(
     config: &mut Config,
     config_path: Option<&Path>,
 ) -> Result<()> {
-    let profile_entry = config.profiles.entry(args.profile.clone()).or_default();
+    let profile_entry = config
+        .profiles
+        .entry(args.profile_name().to_string())
+        .or_default();
 
     // Update workspace if provided
     if args.workspace.is_some() {
@@ -310,11 +382,11 @@ fn login_bitbucket(
     }
 
     if args.default || config.default_profile.is_none() {
-        config.default_profile = Some(args.profile.clone());
+        config.default_profile = Some(args.profile_name().to_string());
     }
 
     // Store Bitbucket token with _bitbucket suffix
-    let secret_key = bitbucket_token_key(&args.profile);
+    let secret_key = bitbucket_token_key(args.profile_name());
     atlassian_cli_auth::set_secret_encrypted(&secret_key, token)
         .context("Failed to store Bitbucket token in encrypted credentials file")?;
 
@@ -324,7 +396,7 @@ fn login_bitbucket(
 
     let auth_type = if args.bearer { "Bearer" } else { "Basic" };
     tracing::info!(
-        profile = %args.profile,
+        profile = %args.profile_name(),
         workspace = ?args.workspace,
         auth_type = auth_type,
         "Bitbucket credentials saved successfully"

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -19,11 +19,15 @@ use tracing_subscriber::{fmt, EnvFilter};
 #[command(name = "atlassian-cli", version, about = "Unified Atlassian Cloud CLI", long_about = None)]
 struct Cli {
     /// Profile to use from config file
-    #[arg(short, long)]
+    //
+    // global: --format has always been accepted after the subcommand, so users
+    // and most of the documentation write `... issue list --profile prod` too.
+    // It was rejected, which made a large share of the published examples fail.
+    #[arg(short, long, global = true)]
     profile: Option<String>,
 
     /// Path to config file (defaults to ~/.atlassian-cli/config.yaml)
-    #[arg(long)]
+    #[arg(long, global = true)]
     config: Option<PathBuf>,
 
     /// Output format for command results (table, json, yaml, csv, quiet, markdown)

--- a/crates/cli/tests/cli_integration.rs
+++ b/crates/cli/tests/cli_integration.rs
@@ -447,3 +447,71 @@ fn test_jira_attachment_download_rejects_output_with_issue() {
         "expected a conflict error, got: {stderr}"
     );
 }
+
+/// `--format` has always been global, so users and most of the published
+/// examples write `--profile` after the subcommand too. It used to be rejected,
+/// which broke a large share of the documented commands and every example
+/// script in `docs/examples/`.
+#[test]
+fn test_profile_and_config_are_accepted_after_the_subcommand() {
+    let temp_dir = tempdir().expect("Failed to create temp dir");
+    let config_path = temp_dir.path().join("config.yaml");
+    std::fs::write(
+        &config_path,
+        "default_profile: t\nprofiles:\n  t:\n    email: a@b.c\n    base_url: http://127.0.0.1:1\n",
+    )
+    .expect("Failed to write config");
+
+    // Deeply nested subcommands too, not just the first level.
+    for args in [
+        vec!["jira", "issue", "get", "T-1"],
+        vec!["confluence", "attachment", "list", "123"],
+        vec!["jira", "attachment", "download", "10001", "--output", "-"],
+    ] {
+        let output = Command::new("cargo")
+            .args(["run", "--quiet", "--"])
+            .args(&args)
+            .args(["--profile", "t", "--config", config_path.to_str().unwrap()])
+            .env("ATLASSIAN_CLI_TOKEN_T", "x")
+            .output()
+            .expect("Failed to execute command");
+
+        // Exit code 2 is a clap usage error. Anything else means the flags were
+        // accepted and the command failed at connect, which is the point.
+        assert_ne!(
+            output.status.code(),
+            Some(2),
+            "trailing --profile/--config rejected for {args:?}: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+}
+
+/// `auth login` used to be rejected by the argument parser when run bare, even
+/// though the CLI's own errors ("Run `atlassian-cli auth login` first") and the
+/// published guides both tell users to do exactly that. Missing values are now
+/// prompted for, and without a terminal it stays a hard error rather than
+/// hanging on stdin.
+#[test]
+fn test_auth_login_without_flags_is_not_a_parse_error() {
+    let output = Command::new("cargo")
+        .args(["run", "--quiet", "--", "auth", "login"])
+        .stdin(std::process::Stdio::null())
+        .output()
+        .expect("Failed to execute command");
+
+    assert_ne!(
+        output.status.code(),
+        Some(2),
+        "bare `auth login` should reach the command, not fail argument parsing"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("--profile"),
+        "should name the flag to pass when it cannot prompt, got: {stderr}"
+    );
+    assert!(
+        !output.status.success(),
+        "it must still fail without a terminal rather than proceeding"
+    );
+}

--- a/todo.md
+++ b/todo.md
@@ -1447,3 +1447,10 @@ Patch for a defect shipped in 0.5.0 plus the documentation repair.
 - `jira api -X PUT` was rejected; only lowercase `-X put` parsed, while the README and the command's own help showed uppercase.
 - `docs/index.md` added; 0.5.0 docs un-staled; `docs/status.md` refreshed.
 - 19 broken `--output json` invocations across all 9 example scripts and 45 broken README command examples fixed, with `tests/docs_examples.rs` added so they cannot rot silently again.
+
+## 2026-08-20 — CLI fixes found while auditing atlassiancli.com
+
+Validated all 1,924 command examples on the site against the real binary (checker lives at `atlassiancli-site/test/check_commands.py`). Two of the failures were the CLI's fault, not the docs':
+
+- `--profile` and `--config` were not global, while `--format` was. So `... issue list --profile prod`, which is what users and most published examples write, was rejected. Both are now `global = true`. This alone accounted for 36 broken site examples plus every shipped example script.
+- `auth login` run bare failed argument parsing, even though the CLI's own errors say "Run `atlassian-cli auth login` first" and the guides repeat it. Missing `--profile`/`--base-url`/`--email` are now prompted for, matching how `--token` already behaved. Without a terminal it stays a hard error rather than hanging on stdin, so CI keeps failing loudly.


### PR DESCRIPTION
Both found by parsing all 1,924 command examples on atlassiancli.com against the real binary while updating the site's command references.

## `--profile` and `--config` were not global

`--format` was, so `... issue list --profile prod` looks like it should work. It was rejected outright.

That single inconsistency accounted for **36 broken examples on the site**, plus **every script in `docs/examples/`**, all of which pass `--profile` after the subcommand. Both flags are now `global = true`. No short-flag collisions: nothing else defines `-p`.

## `auth login` failed when run bare

The CLI's own errors say *"No profile configured. Run `atlassian-cli auth login` first"* (`main.rs:253`, `:306`), and the published guides repeat it. That exact command then failed argument parsing on missing `--profile` and `--base-url`, which is why ~48 places document it bare.

Missing `--profile`, `--base-url` and `--email` are now prompted for, matching how `--token` already behaved. **Without a terminal it stays a hard error** rather than hanging on stdin, so scripts and CI keep failing loudly:

```
$ atlassian-cli auth login < /dev/null
Error: Missing --profile. Pass it on the command line (no terminal available to prompt for Profile name).
```

## Tests

- Trailing `--profile`/`--config` accepted at several nesting depths, asserting exit code is not 2 (clap usage error).
- Bare `auth login` reaches the command rather than failing the parse, still fails without a terminal, and names the flag to pass.

582 tests green, fmt and clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)