### PR TITLE
chore: release 0.6.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -183,7 +183,7 @@ dependencies = [
 
 [[package]]
 name = "atlassian-cli"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "atlassian-cli-api",
@@ -214,7 +214,7 @@ dependencies = [
 
 [[package]]
 name = "atlassian-cli-api"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -236,7 +236,7 @@ dependencies = [
 
 [[package]]
 name = "atlassian-cli-auth"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -256,7 +256,7 @@ dependencies = [
 
 [[package]]
 name = "atlassian-cli-bulk"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "criterion",
@@ -269,7 +269,7 @@ dependencies = [
 
 [[package]]
 name = "atlassian-cli-config"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "dirs",
@@ -283,7 +283,7 @@ dependencies = [
 
 [[package]]
 name = "atlassian-cli-output"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.5.1"
+version = "0.6.0"
 edition = "2021"
 authors = ["atlassian-cli contributors"]
 license = "MIT"

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -23,11 +23,11 @@ serde_json.workspace = true
 serde_yaml.workspace = true
 
 # Internal crates
-atlassian-cli-api = { path = "../api", version = "0.5.1" }
-atlassian-cli-auth = { path = "../auth", version = "0.5.1" }
-atlassian-cli-config = { path = "../config", version = "0.5.1" }
-atlassian-cli-output = { path = "../output", version = "0.5.1" }
-atlassian-cli-bulk = { path = "../bulk", version = "0.5.1" }
+atlassian-cli-api = { path = "../api", version = "0.6.0" }
+atlassian-cli-auth = { path = "../auth", version = "0.6.0" }
+atlassian-cli-config = { path = "../config", version = "0.6.0" }
+atlassian-cli-output = { path = "../output", version = "0.6.0" }
+atlassian-cli-bulk = { path = "../bulk", version = "0.6.0" }
 
 # CLI helpers
 url.workspace = true

--- a/todo.md
+++ b/todo.md
@@ -1556,3 +1556,13 @@ it most needs to handle.
   Bitbucket builds its client from `BITBUCKET_API_URL` rather than the profile base URL. The
   same renderer path is proved through Jira in `crates/cli/tests/empty_list_output_e2e.rs`,
   which captures real stdout from the built binary.
+
+## 2026-08-20 — Release 0.6.0
+
+Minor, not patch: new commands, and two breaking-in-form changes.
+
+- `jira issue transitions` (#101), `bb pr comment --parent` (#109), `bb pr resolve-comment` / `reopen-comment` (#113).
+- `jira issue comments update|delete` take the issue key as a leading positional (#100). The old form could not work against Jira Cloud.
+- Every list command's empty result changed shape under machine formats (#110).
+- `bb pr reviewers --add` repaired (#104), flaky colours test serialised (#111), example scripts repaired with a regression test (#105 via #112).
+- Backlog cleared: 8 open PRs and 6 open issues resolved, leaving zero of each.


### PR DESCRIPTION
Clears the backlog: 8 open PRs and 6 open issues resolved, leaving zero of each.

Minor rather than patch, because it adds commands and changes two existing surfaces.

## New

- `jira issue transitions <KEY>` — list the transitions available on an issue (#101)
- `bb pr comment --parent <ID>` — threaded replies (#109, @ptqa)
- `bb pr resolve-comment` / `reopen-comment` (#113, @ptqa)

## Changed

- **`jira issue comments update|delete` now take the issue key first** (#100). Breaking in form only: the old spelling targeted `/rest/api/3/comment/{id}`, which Jira Cloud does not have, so it always 404'd.
- **Empty list results changed shape** (#110). JSON and YAML give `[]`, Quiet and CSV give nothing, Table and Markdown keep the human message. Previously every format printed prose, so `| jq` failed on empty results.

## Fixed

- `bb pr reviewers --add` had never worked; it used an endpoint that does not exist (#104)
- Flaky `colors` test: four tests mutating process-global env vars, now serialised (#111, @alcantaraleo)
- Every example script repaired, with a regression test that parses them in CI (#105, @alcantaraleo)
- `--profile`/`--config` accepted after the subcommand; `auth login` prompts instead of failing (#117)
- h2 bumped for RUSTSEC-2026-0258 (#116); dependabot no longer reopens the generated release workflow (#115)

618 tests green, fmt and clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)