### PR TITLE
feat(confluence): list inline comments and thread replies

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,7 +189,9 @@ crates/
    atlassian-cli confluence page add-label 12345 documentation
    atlassian-cli confluence page remove-label 12345 outdated
    atlassian-cli confluence page comments 12345
+   atlassian-cli confluence page comments 12345 --replies   # walk each thread
    atlassian-cli confluence page add-comment 12345 "Great work!"
+   atlassian-cli confluence page add-comment 12345 "Agreed" --parent 98765 --kind inline
    atlassian-cli confluence page get-restrictions 12345
    atlassian-cli confluence page add-restriction 12345 --operation update --subject-type user --subject-id 5b10a2844c20165700ede21g
    atlassian-cli confluence page remove-restriction 12345 --operation update --subject-type user --subject-id 5b10a2844c20165700ede21g

--- a/crates/cli/src/commands/confluence/mod.rs
+++ b/crates/cli/src/commands/confluence/mod.rs
@@ -166,6 +166,24 @@ enum FolderCommands {
     },
 }
 
+/// `--kind` for `page add-comment`. Mirrors `pages::CommentKind`, which is the
+/// API-facing type; keeping them separate stops clap derives leaking into the
+/// module that talks to Confluence.
+#[derive(Copy, Clone, Debug, PartialEq, Eq, clap::ValueEnum)]
+enum CommentKindArg {
+    Footer,
+    Inline,
+}
+
+impl From<CommentKindArg> for pages::CommentKind {
+    fn from(value: CommentKindArg) -> Self {
+        match value {
+            CommentKindArg::Footer => pages::CommentKind::Footer,
+            CommentKindArg::Inline => pages::CommentKind::Inline,
+        }
+    }
+}
+
 #[derive(Subcommand, Debug, Clone)]
 enum PageCommands {
     /// List pages
@@ -259,19 +277,45 @@ enum PageCommands {
         label: String,
     },
     /// List page comments
+    #[command(long_about = "List a page's comments.\n\n\
+        Covers both footer comments and inline ones (the highlight-and-comment kind), which\n\
+        Confluence keeps in separate collections. The `kind` column says which a comment is,\n\
+        and is also what you pass to `add-comment --kind` when replying.\n\n\
+        Examples:\n  \
+        confluence page comments 12345\n  \
+        confluence page comments 12345 --full\n  \
+        confluence page comments 12345 --replies    # walk each thread")]
     Comments {
         /// Page ID
         page_id: String,
         /// Show full comment body instead of truncated preview
         #[arg(long)]
         full: bool,
+        /// Also fetch replies to each comment. One request per thread root
+        #[arg(long)]
+        replies: bool,
     },
-    /// Add comment to page
+    /// Add a comment to a page, or reply to an existing thread
+    #[command(
+        long_about = "Add a comment to a page, or reply to an existing thread.\n\n\
+        Examples:\n  \
+        confluence page add-comment 12345 \"Looks good\"\n  \
+        confluence page add-comment 12345 \"Agreed\" --parent 98765\n  \
+        confluence page add-comment 12345 \"Agreed\" --parent 98765 --kind inline\n\n\
+        --kind must match the thread you are replying to; Confluence will not accept a footer\n\
+        reply to an inline thread. `page comments` shows each comment's kind."
+    )]
     AddComment {
         /// Page ID
         page_id: String,
         /// Comment text
         comment: String,
+        /// Reply to this comment instead of starting a new thread
+        #[arg(long)]
+        parent: Option<String>,
+        /// Which collection the comment belongs to. Must match the parent when replying
+        #[arg(long, value_enum, default_value_t = CommentKindArg::Footer)]
+        kind: CommentKindArg,
     },
     /// Get page restrictions
     GetRestrictions {
@@ -645,11 +689,19 @@ pub async fn execute(
             PageCommands::RemoveLabel { page_id, label } => {
                 pages::remove_page_label(&ctx, &page_id, &label).await
             }
-            PageCommands::Comments { page_id, full } => {
-                pages::list_page_comments(&ctx, &page_id, full).await
-            }
-            PageCommands::AddComment { page_id, comment } => {
-                pages::add_page_comment(&ctx, &page_id, &comment).await
+            PageCommands::Comments {
+                page_id,
+                full,
+                replies,
+            } => pages::list_page_comments(&ctx, &page_id, full, replies).await,
+            PageCommands::AddComment {
+                page_id,
+                comment,
+                parent,
+                kind,
+            } => {
+                pages::add_page_comment(&ctx, &page_id, &comment, parent.as_deref(), kind.into())
+                    .await
             }
             PageCommands::GetRestrictions { page_id } => {
                 pages::get_page_restrictions(&ctx, &page_id).await

--- a/crates/cli/src/commands/confluence/pages.rs
+++ b/crates/cli/src/commands/confluence/pages.rs
@@ -513,6 +513,80 @@ struct CommentBodyValue {
 struct CommentsResponse {
     #[serde(default)]
     results: Vec<Comment>,
+    /// Confluence v2 paginates with an opaque cursor in `_links.next`. Ignoring
+    /// it silently truncated every listing at the default page size, so a page
+    /// with 84 comments reported 25.
+    #[serde(rename = "_links", default)]
+    links: Option<CommentLinks>,
+}
+
+#[derive(Deserialize)]
+struct CommentLinks {
+    #[serde(default)]
+    next: Option<String>,
+}
+
+/// Where a comment lives on the page.
+///
+/// Confluence keeps these in separate collections with separate endpoints, and
+/// only footer comments were ever fetched, so pages that use inline comments
+/// (the highlight-and-comment kind) looked empty from the CLI.
+#[derive(Copy, Clone, PartialEq, Eq, Debug)]
+pub enum CommentKind {
+    Footer,
+    Inline,
+}
+
+impl CommentKind {
+    fn as_str(self) -> &'static str {
+        match self {
+            CommentKind::Footer => "footer",
+            CommentKind::Inline => "inline",
+        }
+    }
+
+    /// The v2 collection this kind lives in, used for both listing replies and
+    /// creating them.
+    fn collection(self) -> &'static str {
+        match self {
+            CommentKind::Footer => "footer-comments",
+            CommentKind::Inline => "inline-comments",
+        }
+    }
+}
+
+/// Follow `_links.next` until the collection is exhausted.
+///
+/// The cap is a safety net against a server that keeps handing back a cursor;
+/// at the v2 default of 25 per page it allows 5,000 comments, far past anything
+/// a real page carries.
+async fn fetch_all_comments(ctx: &ConfluenceContext<'_>, first_path: &str) -> Result<Vec<Comment>> {
+    const MAX_PAGES: usize = 200;
+
+    let mut all = Vec::new();
+    let mut path = first_path.to_string();
+
+    for page in 0..MAX_PAGES {
+        let response: CommentsResponse = ctx
+            .client
+            .get(&path)
+            .await
+            .with_context(|| format!("Failed to fetch {path}"))?;
+        all.extend(response.results);
+
+        match response.links.and_then(|l| l.next) {
+            Some(next) if !next.is_empty() => path = next,
+            _ => return Ok(all),
+        }
+
+        if page + 1 == MAX_PAGES {
+            tracing::warn!(
+                fetched = all.len(),
+                "Stopped following comment pagination at the safety cap"
+            );
+        }
+    }
+    Ok(all)
 }
 
 /// The comment's creation timestamp, which the v2 API nests under `version`.
@@ -557,71 +631,162 @@ fn comment_body_preview(body: &str) -> String {
 /// Preview length, matching `jira issue comments`.
 const COMMENT_PREVIEW_CHARS: usize = 50;
 
-// List page comments
+/// A comment plus where it came from, so the two collections can be merged into
+/// one listing without losing which is which.
+struct LocatedComment {
+    comment: Comment,
+    kind: CommentKind,
+    /// The comment this one replies to. `None` for a thread root.
+    parent: Option<String>,
+}
+
+/// List page comments.
+///
+/// Fetches both collections, because Confluence keeps footer and inline
+/// comments apart and only footer comments were ever read: a page using inline
+/// comments looked empty from the CLI even with dozens of them in the browser.
+///
+/// `replies` walks each thread. That is one request per root comment, so it is
+/// opt-in rather than the default.
 pub async fn list_page_comments(
     ctx: &ConfluenceContext<'_>,
     page_id: &str,
     full: bool,
+    replies: bool,
 ) -> Result<()> {
-    // Request the storage-format body so callers actually get the comment text;
-    // previously only metadata was returned.
-    let response: CommentsResponse = ctx
-        .client
-        .get(&format!(
-            "/wiki/api/v2/pages/{}/footer-comments?body-format=storage",
-            page_id
-        ))
-        .await
-        .with_context(|| format!("Failed to list comments for page {}", page_id))?;
+    let mut located: Vec<LocatedComment> = Vec::new();
+
+    for kind in [CommentKind::Footer, CommentKind::Inline] {
+        // body-format=storage so callers get the text, not just metadata.
+        let path = format!(
+            "/wiki/api/v2/pages/{}/{}?body-format=storage",
+            page_id,
+            kind.collection()
+        );
+        let roots = fetch_all_comments(ctx, &path).await.with_context(|| {
+            format!("Failed to list {} for page {}", kind.collection(), page_id)
+        })?;
+
+        for root in roots {
+            let root_id = root.id.clone();
+            located.push(LocatedComment {
+                comment: root,
+                kind,
+                parent: None,
+            });
+
+            if replies {
+                let child_path = format!(
+                    "/wiki/api/v2/{}/{}/children?body-format=storage",
+                    kind.collection(),
+                    root_id
+                );
+                let children = fetch_all_comments(ctx, &child_path)
+                    .await
+                    .with_context(|| format!("Failed to list replies to comment {root_id}"))?;
+                for child in children {
+                    located.push(LocatedComment {
+                        comment: child,
+                        kind,
+                        parent: Some(root_id.clone()),
+                    });
+                }
+            }
+        }
+    }
 
     #[derive(Serialize)]
     struct Row<'a> {
         id: &'a str,
         title: &'a str,
         created_at: &'a str,
+        /// footer or inline. Also tells you which value to pass to
+        /// `add-comment --kind` when replying.
+        kind: &'static str,
+        /// The comment this replies to, absent for a thread root.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        parent: Option<&'a str>,
         #[serde(skip_serializing_if = "Option::is_none")]
         body_preview: Option<String>,
         #[serde(skip_serializing_if = "Option::is_none")]
         body: Option<String>,
     }
 
-    let rows: Vec<Row<'_>> = response
-        .results
+    let rows: Vec<Row<'_>> = located
         .iter()
-        .map(|c| {
-            let text = comment_body_markdown(c);
+        .map(|l| {
+            let text = comment_body_markdown(&l.comment);
             let (body_preview, body) = if full {
                 (None, Some(text))
             } else {
                 (Some(comment_body_preview(&text)), None)
             };
             Row {
-                id: c.id.as_str(),
-                title: c.title.as_str(),
-                created_at: comment_created_at(c),
+                id: l.comment.id.as_str(),
+                title: l.comment.title.as_str(),
+                created_at: comment_created_at(&l.comment),
+                kind: l.kind.as_str(),
+                parent: l.parent.as_deref(),
                 body_preview,
                 body,
             }
         })
         .collect();
 
-    ctx.renderer.render(&rows)
+    ctx.renderer
+        .render_list_or_empty(&rows, "No comments found")
 }
 
-// Add page comment
-pub async fn add_page_comment(
-    ctx: &ConfluenceContext<'_>,
-    page_id: &str,
-    comment: &str,
-) -> Result<()> {
-    let payload = json!({
+/// Escape text for a storage-format (XHTML) body.
+///
+/// The comment was previously interpolated raw into `<p>{}</p>`, so a comment
+/// containing `<`, `>` or `&` produced invalid storage XHTML and Confluence
+/// either rejected it or mangled it.
+fn escape_storage_text(text: &str) -> String {
+    let mut out = String::with_capacity(text.len());
+    for c in text.chars() {
+        match c {
+            '&' => out.push_str("&amp;"),
+            '<' => out.push_str("&lt;"),
+            '>' => out.push_str("&gt;"),
+            _ => out.push(c),
+        }
+    }
+    out
+}
+
+/// Build the body for creating a comment or a reply.
+///
+/// A reply carries `parentCommentId` and is POSTed to the collection its parent
+/// lives in: Confluence will not accept a footer reply to an inline thread.
+fn comment_payload(page_id: &str, comment: &str, parent: Option<&str>) -> serde_json::Value {
+    let mut payload = json!({
         "pageId": page_id,
         "status": "current",
         "body": {
             "representation": "storage",
-            "value": format!("<p>{}</p>", comment)
+            "value": format!("<p>{}</p>", escape_storage_text(comment))
         }
     });
+    if let Some(parent) = parent {
+        payload["parentCommentId"] = json!(parent);
+    }
+    payload
+}
+
+/// Add a comment to a page, or reply to an existing thread.
+///
+/// `kind` selects the collection. It matters for replies: an inline thread only
+/// accepts replies posted to `inline-comments`. The `kind` column on
+/// `page comments` tells you which to pass.
+pub async fn add_page_comment(
+    ctx: &ConfluenceContext<'_>,
+    page_id: &str,
+    comment: &str,
+    parent: Option<&str>,
+    kind: CommentKind,
+) -> Result<()> {
+    let payload = comment_payload(page_id, comment, parent);
 
     #[derive(Deserialize)]
     struct CreateResponse {
@@ -630,15 +795,28 @@ pub async fn add_page_comment(
 
     let response: CreateResponse = ctx
         .client
-        .post("/wiki/api/v2/footer-comments", &payload)
+        .post(&format!("/wiki/api/v2/{}", kind.collection()), &payload)
         .await
-        .with_context(|| format!("Failed to add comment to page {}", page_id))?;
+        .with_context(|| match parent {
+            Some(parent) => format!("Failed to reply to comment {parent}"),
+            None => format!("Failed to add comment to page {}", page_id),
+        })?;
 
-    tracing::info!(page_id = %page_id, comment_id = %response.id, "Comment added successfully");
+    tracing::info!(
+        page_id = %page_id,
+        comment_id = %response.id,
+        kind = kind.as_str(),
+        is_reply = parent.is_some(),
+        "Comment added successfully"
+    );
+    let message = match parent {
+        Some(parent) => format!("Replied to comment {parent} on page {page_id}"),
+        None => format!("Added comment to page {page_id}"),
+    };
     render_success(
         ctx.renderer,
-        &format!("✅ Added comment to page {page_id} (ID: {})", response.id),
-        &MutationResult::with_id(format!("Added comment to page {page_id}"), &response.id),
+        &format!("✅ {message} (ID: {})", response.id),
+        &MutationResult::with_id(message, &response.id),
     )
 }
 

--- a/crates/cli/tests/confluence_comments_e2e.rs
+++ b/crates/cli/tests/confluence_comments_e2e.rs
@@ -1,0 +1,359 @@
+//! End-to-end tests for `confluence page comments` and `add-comment` (#122).
+//!
+//! The reported bug was invisible at the transport level: the command fetched a
+//! real endpoint successfully and returned an empty list, because it only ever
+//! asked for footer comments. What matters is therefore *which* endpoints the
+//! command calls and what it does with the answers, so these drive the built
+//! binary and assert on the requests the mock actually received.
+
+use std::path::Path;
+use std::process::Command;
+
+use tempfile::TempDir;
+use wiremock::matchers::{body_partial_json, method, path as path_matcher, query_param};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+const BIN: &str = env!("CARGO_BIN_EXE_atlassian-cli");
+
+fn write_config(dir: &Path, base_url: &str) -> std::path::PathBuf {
+    let config_path = dir.join("config.yaml");
+    std::fs::write(
+        &config_path,
+        format!(
+            "default_profile: local\nprofiles:\n  local:\n    email: dev@example.com\n    base_url: {base_url}\n"
+        ),
+    )
+    .unwrap();
+    config_path
+}
+
+fn run(config: &Path, args: &[&str]) -> std::process::Output {
+    Command::new(BIN)
+        .arg("--config")
+        .arg(config)
+        .args(args)
+        .env("ATLASSIAN_CLI_TOKEN_LOCAL", "fake-token")
+        .output()
+        .expect("failed to run the CLI")
+}
+
+fn comment(id: &str, title: &str, body: &str) -> serde_json::Value {
+    serde_json::json!({
+        "id": id,
+        "title": title,
+        "version": {"createdAt": "2026-08-21T10:00:00.000Z"},
+        "body": {"storage": {"value": format!("<p>{body}</p>")}}
+    })
+}
+
+/// The reported bug: a page whose comments are all inline listed as empty.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn inline_comments_are_listed_alongside_footer_comments() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path_matcher("/wiki/api/v2/pages/12345/footer-comments"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "results": [comment("1", "Re: page", "A footer comment")]
+        })))
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path_matcher("/wiki/api/v2/pages/12345/inline-comments"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "results": [
+                comment("2", "Re: selection", "An inline comment"),
+                comment("3", "Re: selection", "Another inline comment")
+            ]
+        })))
+        .mount(&server)
+        .await;
+
+    let dir = TempDir::new().unwrap();
+    let config = write_config(dir.path(), &server.uri());
+
+    let out = run(
+        &config,
+        &[
+            "confluence",
+            "page",
+            "comments",
+            "12345",
+            "--format",
+            "json",
+        ],
+    );
+    assert!(
+        out.status.success(),
+        "{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    let rows: serde_json::Value = serde_json::from_slice(&out.stdout).unwrap();
+    let rows = rows.as_array().unwrap();
+    assert_eq!(rows.len(), 3, "both collections should be listed: {rows:?}");
+    assert_eq!(rows[0]["kind"], "footer");
+    assert_eq!(rows[1]["kind"], "inline");
+    assert_eq!(rows[2]["id"], "3");
+    // A thread root has no parent, and the key is omitted rather than null.
+    assert!(rows[0].get("parent").is_none());
+}
+
+/// Confluence v2 paginates with an opaque cursor. Ignoring it capped every
+/// listing at the default page size, which is how a page with 84 comments
+/// reported 25.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn comment_pagination_is_followed_to_the_end() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path_matcher("/wiki/api/v2/pages/12345/footer-comments"))
+        .and(query_param("cursor", "page2"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "results": [comment("2", "Second", "Second page")]
+        })))
+        .mount(&server)
+        .await;
+    // Registered second so the cursor-bearing mock wins; this one answers the
+    // first request and hands back the cursor.
+    Mock::given(method("GET"))
+        .and(path_matcher("/wiki/api/v2/pages/12345/footer-comments"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "results": [comment("1", "First", "First page")],
+            "_links": {"next": "/wiki/api/v2/pages/12345/footer-comments?body-format=storage&cursor=page2"}
+        })))
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path_matcher("/wiki/api/v2/pages/12345/inline-comments"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({"results": []})))
+        .mount(&server)
+        .await;
+
+    let dir = TempDir::new().unwrap();
+    let config = write_config(dir.path(), &server.uri());
+
+    let out = run(
+        &config,
+        &[
+            "confluence",
+            "page",
+            "comments",
+            "12345",
+            "--format",
+            "json",
+        ],
+    );
+    assert!(
+        out.status.success(),
+        "{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    let rows: serde_json::Value = serde_json::from_slice(&out.stdout).unwrap();
+    assert_eq!(
+        rows.as_array().unwrap().len(),
+        2,
+        "both pages should be fetched: {rows:?}"
+    );
+}
+
+/// `--replies` walks each thread and links children to their root.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn replies_are_fetched_and_linked_to_their_parent() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path_matcher("/wiki/api/v2/pages/12345/footer-comments"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "results": [comment("10", "Root", "Question?")]
+        })))
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path_matcher("/wiki/api/v2/footer-comments/10/children"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "results": [comment("11", "Re: Root", "Answer.")]
+        })))
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path_matcher("/wiki/api/v2/pages/12345/inline-comments"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({"results": []})))
+        .mount(&server)
+        .await;
+
+    let dir = TempDir::new().unwrap();
+    let config = write_config(dir.path(), &server.uri());
+
+    let out = run(
+        &config,
+        &[
+            "confluence",
+            "page",
+            "comments",
+            "12345",
+            "--replies",
+            "--format",
+            "json",
+        ],
+    );
+    assert!(
+        out.status.success(),
+        "{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    let rows: serde_json::Value = serde_json::from_slice(&out.stdout).unwrap();
+    let rows = rows.as_array().unwrap();
+    assert_eq!(rows.len(), 2);
+    assert_eq!(rows[1]["id"], "11");
+    assert_eq!(rows[1]["parent"], "10", "a reply must name its thread root");
+}
+
+/// Without `--replies`, the per-thread requests must not happen at all.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn replies_are_not_fetched_by_default() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path_matcher("/wiki/api/v2/footer-comments/10/children"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({"results": []})))
+        .expect(0)
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path_matcher("/wiki/api/v2/pages/12345/footer-comments"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "results": [comment("10", "Root", "Question?")]
+        })))
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path_matcher("/wiki/api/v2/pages/12345/inline-comments"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({"results": []})))
+        .mount(&server)
+        .await;
+
+    let dir = TempDir::new().unwrap();
+    let config = write_config(dir.path(), &server.uri());
+
+    let out = run(&config, &["confluence", "page", "comments", "12345"]);
+    assert!(out.status.success());
+}
+
+/// A reply goes to the collection its parent lives in: Confluence will not
+/// accept a footer reply to an inline thread.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn a_reply_posts_to_its_parents_collection() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path_matcher("/wiki/api/v2/inline-comments"))
+        .and(body_partial_json(serde_json::json!({
+            "pageId": "12345",
+            "parentCommentId": "98765"
+        })))
+        .respond_with(ResponseTemplate::new(201).set_body_json(serde_json::json!({"id": "99"})))
+        .expect(1)
+        .mount(&server)
+        .await;
+    Mock::given(method("POST"))
+        .and(path_matcher("/wiki/api/v2/footer-comments"))
+        .respond_with(ResponseTemplate::new(201))
+        .expect(0)
+        .mount(&server)
+        .await;
+
+    let dir = TempDir::new().unwrap();
+    let config = write_config(dir.path(), &server.uri());
+
+    let out = run(
+        &config,
+        &[
+            "confluence",
+            "page",
+            "add-comment",
+            "12345",
+            "Agreed",
+            "--parent",
+            "98765",
+            "--kind",
+            "inline",
+        ],
+    );
+    assert!(
+        out.status.success(),
+        "{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+/// A plain comment still posts to footer-comments with no parent, unchanged.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn a_top_level_comment_is_unchanged() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path_matcher("/wiki/api/v2/footer-comments"))
+        .and(body_partial_json(serde_json::json!({
+            "pageId": "12345",
+            "status": "current"
+        })))
+        .respond_with(ResponseTemplate::new(201).set_body_json(serde_json::json!({"id": "99"})))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let dir = TempDir::new().unwrap();
+    let config = write_config(dir.path(), &server.uri());
+
+    let out = run(
+        &config,
+        &["confluence", "page", "add-comment", "12345", "Looks good"],
+    );
+    assert!(
+        out.status.success(),
+        "{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+/// Storage format is XHTML, so a comment containing markup characters has to be
+/// escaped or Confluence rejects or mangles it.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn comment_text_is_escaped_for_storage_format() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path_matcher("/wiki/api/v2/footer-comments"))
+        .and(body_partial_json(serde_json::json!({
+            "body": {
+                "representation": "storage",
+                "value": "<p>a &lt; b &amp;&amp; c &gt; d</p>"
+            }
+        })))
+        .respond_with(ResponseTemplate::new(201).set_body_json(serde_json::json!({"id": "99"})))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let dir = TempDir::new().unwrap();
+    let config = write_config(dir.path(), &server.uri());
+
+    let out = run(
+        &config,
+        &[
+            "confluence",
+            "page",
+            "add-comment",
+            "12345",
+            "a < b && c > d",
+        ],
+    );
+    assert!(
+        out.status.success(),
+        "{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}

--- a/docs/22082026_confluence_inline_comments.md
+++ b/docs/22082026_confluence_inline_comments.md
@@ -1,0 +1,72 @@
+# Confluence inline comments and threads (issue #122)
+
+Status: shipped in 0.7.0 (PR pending).
+
+## Problem
+
+`confluence page comments <PAGE_ID>` only called
+`GET /wiki/api/v2/pages/{id}/footer-comments`. Confluence keeps inline comments,
+the highlight-and-comment kind attached to selected text, in a separate
+collection, so a page using them returned an empty list even with dozens of
+comments visible in the browser. The reporter had a page with 84 comments, none
+of them footer comments.
+
+Two further gaps came out of the same code path:
+
+- **Pagination was ignored.** v2 paginates with an opaque cursor in
+  `_links.next`, which the command never followed, so every listing was capped
+  at the default page size. Even a footer-only page would have reported 25 of 84.
+- **Comment text was not escaped.** `add-comment` interpolated the text straight
+  into `<p>{}</p>`, so a comment containing `<`, `>` or `&` produced invalid
+  storage XHTML.
+
+## What changed
+
+```
+confluence page comments <PAGE_ID> [--full] [--replies]
+confluence page add-comment <PAGE_ID> <TEXT> [--parent <ID>] [--kind footer|inline]
+```
+
+- Both collections are fetched and merged. A `kind` column says which a comment
+  is, and doubles as the value to pass to `add-comment --kind` when replying.
+- `_links.next` is followed to the end, with a 200-page safety cap (5,000
+  comments at the v2 default) against a server that keeps handing back a cursor.
+- `--replies` walks each thread via `/{collection}/{id}/children` and fills in a
+  `parent` column. That is one request per thread root, so it is opt-in rather
+  than the default.
+- `--parent` replies into an existing thread. The reply is POSTed to the
+  collection its parent lives in, because Confluence will not accept a footer
+  reply to an inline thread. `--kind` selects it explicitly rather than the CLI
+  guessing.
+- Comment text is escaped for storage format.
+
+## Not done
+
+Creating a *new* inline comment. That needs
+`inlineCommentProperties.textSelection` plus a match index identifying which
+occurrence of the selected text to anchor to, which has no sensible
+command-line spelling: the caller would have to know the exact text run and its
+ordinal in the page body. Replying to an existing inline thread, which is the
+common case, is supported.
+
+## Tests
+
+`crates/cli/tests/confluence_comments_e2e.rs` drives the built binary against a
+mock, because the bug was invisible at transport level: the command fetched a
+real endpoint successfully and returned an empty list. The tests assert on which
+endpoints are called, not just that a call succeeded.
+
+Covered: inline and footer merged into one listing; cursor pagination followed
+to the end; `--replies` linking children to their root; replies *not* fetched
+without the flag (asserted with `.expect(0)`); a reply posting to its parent's
+collection and not the other one; a plain comment unchanged; and storage-format
+escaping.
+
+The first two were verified to fail when their fix is reverted.
+
+## Untested
+
+Everything here is mock-tested. I have no Confluence instance with inline
+comments to run it against, so the exact v2 response shapes for
+`inline-comments` and `/children` are taken from the API reference rather than
+observed. The reporter offered to verify.

--- a/docs/index.md
+++ b/docs/index.md
@@ -46,6 +46,7 @@ changes made, newest last; `docs/todo.md` is the forward-looking roadmap.
 | Document | Date | What it covers |
 | --- | --- | --- |
 | [16082026_bb_pr_reviewer_status.md](16082026_bb_pr_reviewer_status.md) | 2026-08-16 | `bb pr reviewers` listing with approval status, `--all`, and the `--add` endpoint fix |
+| [22082026_confluence_inline_comments.md](22082026_confluence_inline_comments.md) | 2026-08-22 | Confluence inline comments, thread replies, cursor pagination and storage-format escaping |
 | [20082026_bitbucket_pr_inline_comments.md](20082026_bitbucket_pr_inline_comments.md) | 2026-08-20 | Inline pull request comments: `bb pr comment --path/--line/--side`, and the `location` column on `pr comments` |
 | [10082026_raw_api_passthrough.md](10082026_raw_api_passthrough.md) | 2026-08-10 | `jira api` raw authenticated REST passthrough, `ApiClient::request_raw`, origin and redirect safety |
 | [10082026_jira_attachments.md](10082026_jira_attachments.md) | 2026-08-10 | `jira attachment` group: list, get, download (single, stdout, bulk), upload, delete |

--- a/todo.md
+++ b/todo.md
@@ -1576,3 +1576,15 @@ Minor, not patch: new commands, and two breaking-in-form changes.
 - Every list command's empty result changed shape under machine formats (#110).
 - `bb pr reviewers --add` repaired (#104), flaky colours test serialised (#111), example scripts repaired with a regression test (#105 via #112).
 - Backlog cleared: 8 open PRs and 6 open issues resolved, leaving zero of each.
+
+## 2026-08-22 — Confluence inline comments and threads (closes #122)
+
+`confluence page comments` only fetched `/wiki/api/v2/pages/{id}/footer-comments`, so pages using inline comments returned an empty list. Reporter had a page with 84 comments, none of them footer comments.
+
+- Both collections fetched and merged, with a `kind` column.
+- `_links.next` cursor pagination followed, with a 200-page cap. This was a second, hidden bug: every listing was capped at the default page size, so even a footer-only page would have shown 25 of 84.
+- `--replies` walks each thread via `/{collection}/{id}/children` and fills in `parent`. Opt-in, since it is one request per root.
+- `--parent` replies into a thread, POSTed to the parent's own collection; `--kind` selects it explicitly rather than the CLI guessing. Confluence rejects a footer reply to an inline thread.
+- Comment text is now escaped for storage format; it was interpolated raw into `<p>{}</p>`, so `<`, `>` or `&` produced invalid XHTML.
+- Not done: creating a new inline comment, which needs `inlineCommentProperties.textSelection` plus a match index and has no sensible command-line spelling. Replying to an existing inline thread is supported.
+- All mock-tested; no instance with inline comments available to verify the real v2 response shapes.


### PR DESCRIPTION
Closes #122.

`confluence page comments` only called `/wiki/api/v2/pages/{id}/footer-comments`. Confluence keeps inline comments — the highlight-and-comment kind attached to selected text — in a separate collection, so a page using them returned an empty list even with dozens visible in the browser. @georghildebrand reported a page with 84 comments, none of them footer comments.

## Two more bugs on the same path

- **Pagination was ignored.** v2 paginates with an opaque cursor in `_links.next`, which the command never followed, so every listing was capped at the default page size. Even a footer-only page would have shown 25 of those 84.
- **Comment text was not escaped.** `add-comment` interpolated straight into `<p>{}</p>`, so a comment containing `<`, `>` or `&` produced invalid storage XHTML.

## What this adds

```
confluence page comments <PAGE_ID> [--full] [--replies]
confluence page add-comment <PAGE_ID> <TEXT> [--parent <ID>] [--kind footer|inline]
```

- Both collections fetched and merged, with a `kind` column that doubles as the value to pass to `--kind` when replying.
- `_links.next` followed to the end, with a 200-page cap (5,000 comments at the v2 default) against a server that keeps handing back a cursor.
- `--replies` walks each thread via `/{collection}/{id}/children` and fills in `parent`. One request per thread root, so opt-in.
- `--parent` replies into a thread. The reply is POSTed to the collection its parent lives in, because Confluence will not accept a footer reply to an inline thread. `--kind` selects that explicitly rather than the CLI guessing from an id.

## Deliberately not included

Creating a *new* inline comment. It needs `inlineCommentProperties.textSelection` plus a match index identifying which occurrence of the selected text to anchor to, and I could not find a command-line spelling that is not a footgun: the caller would have to know the exact text run and its ordinal in the page body. Replying to an existing inline thread, the common case, is supported.

## Testing

`crates/cli/tests/confluence_comments_e2e.rs` drives the built binary, because this bug was invisible at transport level: the command fetched a real endpoint successfully and returned nothing. The tests assert on *which* endpoints get called.

Seven cases: inline and footer merged; cursor pagination followed; `--replies` linking children to roots; replies **not** fetched without the flag (`.expect(0)`); a reply posting to its parent's collection and not the other (`.expect(0)` on the wrong one); a plain comment unchanged; storage-format escaping.

The inline-merge and pagination tests were each verified to fail when their fix is reverted.

## Untested, stated plainly

All of this is mock-tested. I have no Confluence instance with inline comments, so the exact v2 response shapes for `inline-comments` and `/children` come from the API reference rather than observation. @georghildebrand offered to help verify, and this is the part worth a real run before trusting.

646 tests green, fmt and clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)