### PR TITLE
chore: release 0.7.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -183,7 +183,7 @@ dependencies = [
 
 [[package]]
 name = "atlassian-cli"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "atlassian-cli-api",
@@ -214,7 +214,7 @@ dependencies = [
 
 [[package]]
 name = "atlassian-cli-api"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -236,7 +236,7 @@ dependencies = [
 
 [[package]]
 name = "atlassian-cli-auth"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -256,7 +256,7 @@ dependencies = [
 
 [[package]]
 name = "atlassian-cli-bulk"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "criterion",
@@ -269,7 +269,7 @@ dependencies = [
 
 [[package]]
 name = "atlassian-cli-config"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "dirs",
@@ -283,7 +283,7 @@ dependencies = [
 
 [[package]]
 name = "atlassian-cli-output"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.6.0"
+version = "0.7.0"
 edition = "2021"
 authors = ["atlassian-cli contributors"]
 license = "MIT"

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -23,11 +23,11 @@ serde_json.workspace = true
 serde_yaml.workspace = true
 
 # Internal crates
-atlassian-cli-api = { path = "../api", version = "0.6.0" }
-atlassian-cli-auth = { path = "../auth", version = "0.6.0" }
-atlassian-cli-config = { path = "../config", version = "0.6.0" }
-atlassian-cli-output = { path = "../output", version = "0.6.0" }
-atlassian-cli-bulk = { path = "../bulk", version = "0.6.0" }
+atlassian-cli-api = { path = "../api", version = "0.7.0" }
+atlassian-cli-auth = { path = "../auth", version = "0.7.0" }
+atlassian-cli-config = { path = "../config", version = "0.7.0" }
+atlassian-cli-output = { path = "../output", version = "0.7.0" }
+atlassian-cli-bulk = { path = "../bulk", version = "0.7.0" }
 
 # CLI helpers
 url.workspace = true

--- a/docs/16082026_bb_pr_reviewer_status.md
+++ b/docs/16082026_bb_pr_reviewer_status.md
@@ -1,6 +1,6 @@
 # Bitbucket PR reviewer status and reviewer updates
 
-Status: implemented on branch `fix/bb-pr-reviewers-followup`, on top of PR #103 (merged).
+Status: shipped in 0.6.0 (PR #104), on top of PR #103.
 
 ## Problem
 

--- a/docs/20082026_bitbucket_pr_inline_comments.md
+++ b/docs/20082026_bitbucket_pr_inline_comments.md
@@ -1,5 +1,7 @@
 # Bitbucket PR Inline Comments
 
+Status: shipped in 0.7.0 (PR #121).
+
 ## Date: 2026-08-20
 
 ## Problem

--- a/docs/22082026_confluence_inline_comments.md
+++ b/docs/22082026_confluence_inline_comments.md
@@ -1,6 +1,6 @@
 # Confluence inline comments and threads (issue #122)
 
-Status: shipped in 0.7.0 (PR pending).
+Status: shipped in 0.7.0 (PR #123).
 
 ## Problem
 

--- a/todo.md
+++ b/todo.md
@@ -1588,3 +1588,11 @@ Minor, not patch: new commands, and two breaking-in-form changes.
 - Comment text is now escaped for storage format; it was interpolated raw into `<p>{}</p>`, so `<`, `>` or `&` produced invalid XHTML.
 - Not done: creating a new inline comment, which needs `inlineCommentProperties.textSelection` plus a match index and has no sensible command-line spelling. Replying to an existing inline thread is supported.
 - All mock-tested; no instance with inline comments available to verify the real v2 response shapes.
+
+## 2026-08-22 — Release 0.7.0
+
+Minor: both changes add flags and columns.
+
+- `bb pr comment --path/--line/--side` for inline PR comments, and a `location` column on `pr comments` (#121, @alcantaraleo, closes #120).
+- `confluence page comments` now covers inline comments as well as footer ones, follows cursor pagination, and gains `--replies`; `add-comment` gains `--parent`/`--kind` (#123, closes #122).
+- Doc status lines brought up to date, including #104's, which still named a merged branch.


### PR DESCRIPTION
Minor: both changes add flags and columns, not only fix behaviour.

## Bitbucket inline PR comments (#121, @alcantaraleo, closes #120)

`bb pr comment` gains `--path`, `--line` and `--side`, turning it into an inline comment anchored to a file and optionally a line on either side of the diff. Passing none of them leaves the existing top-level behaviour untouched. `bb pr comments` gains a `location` column so inline and top-level comments are distinguishable.

Composes with the `--parent` threading from 0.6.0: a comment can be a reply, inline, both, or neither.

## Confluence inline comments and threads (#123, closes #122)

`confluence page comments` only ever fetched footer comments, so a page using inline comments returned an empty list. It now fetches both collections and merges them, with a `kind` column.

Fixing that surfaced two more bugs on the same path:
- **Pagination was ignored.** v2 uses an opaque `_links.next` cursor the command never followed, so every listing was capped at the default page size. The reporter's 84-comment page would have shown 25 even if all had been footer comments.
- **Comment text was not escaped**, so `<`, `>` or `&` produced invalid storage XHTML.

Also adds `--replies` to walk threads, and `--parent`/`--kind` on `add-comment` to reply into one.

## Note on verification

The Confluence work is mock-tested only. I have no instance with inline comments, so the v2 response shapes for `inline-comments` and `/children` come from the API reference rather than observation. The reporter offered to verify against the real page; that is the part worth a live run before trusting.

646 tests green, fmt and clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)