### PR TITLE
fix: keep the base URL path when joining request paths

### DIFF
--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -1144,6 +1144,61 @@ mod tests {
         );
     }
 
+    /// The same fix covers a self-hosted product behind a context path, which is
+    /// the ordinary way Bamboo is deployed. Before this, `/rest/api/latest/plan`
+    /// against `https://example.com/bamboo` resolved to `https://example.com/rest/...`
+    /// and 404'd.
+    #[test]
+    fn test_resolve_url_keeps_a_context_path() {
+        let client = ApiClient::new("https://example.com/bamboo").unwrap();
+
+        assert_eq!(
+            client
+                .resolve_url("/rest/api/latest/plan")
+                .unwrap()
+                .as_str(),
+            "https://example.com/bamboo/rest/api/latest/plan"
+        );
+    }
+
+    /// Guard against the fix shifting any URL a working profile already resolves.
+    /// Every shape below is byte-identical before and after normalisation; only
+    /// the previously broken path-bearing bases move.
+    #[test]
+    fn test_normalisation_does_not_move_existing_product_urls() {
+        for (base, path, expected) in [
+            (
+                "https://x.atlassian.net",
+                "/rest/api/3/myself",
+                "https://x.atlassian.net/rest/api/3/myself",
+            ),
+            (
+                "https://x.atlassian.net",
+                "/wiki/download/attachments/1/f.png?version=1",
+                "https://x.atlassian.net/wiki/download/attachments/1/f.png?version=1",
+            ),
+            (
+                "https://api.bitbucket.org",
+                "/2.0/repositories/w/r",
+                "https://api.bitbucket.org/2.0/repositories/w/r",
+            ),
+            // Opsgenie's base already carries a path and already ends in a
+            // slash, and its request paths are relative, so it is untouched.
+            (
+                "https://api.opsgenie.com/v2/",
+                "alerts/123",
+                "https://api.opsgenie.com/v2/alerts/123",
+            ),
+        ] {
+            let client = ApiClient::new(base).unwrap();
+            assert_eq!(
+                client.resolve_url(path).unwrap().as_str(),
+                expected,
+                "{base} + {path}"
+            );
+        }
+    }
+
     /// Regression: comparing scheme and host but not port let any other port on
     /// the same host receive the profile's credentials.
     #[tokio::test]

--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -62,6 +62,22 @@ fn same_origin(a: &Url, b: &Url) -> bool {
         && a.port_or_known_default() == b.port_or_known_default()
 }
 
+/// Make a base URL end with `/`.
+///
+/// `Url::join` drops the base's last path segment unless the base ends with
+/// `/`. Idempotent.
+pub fn normalize_base_url(mut url: Url) -> Url {
+    if url.cannot_be_a_base() {
+        return url;
+    }
+
+    let path = url.path();
+    if !path.ends_with('/') {
+        url.set_path(&format!("{path}/"));
+    }
+    url
+}
+
 /// The `Retry-After` delay in seconds, when the server sent one. The HTTP-date
 /// form is ignored; Atlassian sends seconds.
 fn retry_after(response: &reqwest::Response) -> Option<Duration> {
@@ -138,6 +154,8 @@ impl ApiClient {
                 ));
             }
         }
+
+        let url = normalize_base_url(url);
 
         let client = Client::builder()
             .user_agent(format!("atlassian-cli/{}", env!("CARGO_PKG_VERSION")))
@@ -1088,6 +1106,42 @@ mod tests {
                 Ok(url) => assert_eq!(url.host_str(), Some("site.atlassian.net"), "{bad}"),
             }
         }
+    }
+
+    /// Regression: a base URL carrying a path lost its last segment, so the
+    /// API-gateway form used by scoped API tokens dropped the cloud id.
+    #[test]
+    fn test_resolve_url_keeps_the_base_path() {
+        let client = ApiClient::new("https://api.atlassian.com/ex/jira/cloud-id").unwrap();
+
+        assert_eq!(
+            client.base_url(),
+            "https://api.atlassian.com/ex/jira/cloud-id/"
+        );
+        assert_eq!(
+            client.resolve_url("/rest/api/3/myself").unwrap().as_str(),
+            "https://api.atlassian.com/ex/jira/cloud-id/rest/api/3/myself"
+        );
+        assert_eq!(
+            client.resolve_url("rest/api/3/myself").unwrap().as_str(),
+            "https://api.atlassian.com/ex/jira/cloud-id/rest/api/3/myself"
+        );
+
+        // A base written with the trailing slash resolves the same way.
+        let client = ApiClient::new("https://api.atlassian.com/ex/jira/cloud-id/").unwrap();
+
+        assert_eq!(
+            client.base_url(),
+            "https://api.atlassian.com/ex/jira/cloud-id/"
+        );
+        assert_eq!(
+            client.resolve_url("/rest/api/3/myself").unwrap().as_str(),
+            "https://api.atlassian.com/ex/jira/cloud-id/rest/api/3/myself"
+        );
+        assert_eq!(
+            client.resolve_url("rest/api/3/myself").unwrap().as_str(),
+            "https://api.atlassian.com/ex/jira/cloud-id/rest/api/3/myself"
+        );
     }
 
     /// Regression: comparing scheme and host but not port let any other port on

--- a/crates/cli/src/commands/auth.rs
+++ b/crates/cli/src/commands/auth.rs
@@ -312,6 +312,8 @@ fn login_jira_confluence(
         ));
     }
 
+    let base_url = atlassian_cli_api::normalize_base_url(base_url);
+
     let email = args
         .email
         .as_ref()

--- a/crates/cli/src/commands/confluence/attachments.rs
+++ b/crates/cli/src/commands/confluence/attachments.rs
@@ -94,7 +94,8 @@ pub async fn upload_attachment(
     };
 
     // Note: This uses the raw reqwest client for multipart upload
-    let base_url = ctx.client.base_url();
+    // base_url() keeps its trailing slash, so trim before joining.
+    let base_url = ctx.client.base_url().trim_end_matches('/');
 
     let mut request = ctx
         .client

--- a/crates/cli/tests/confluence_comments_e2e.rs
+++ b/crates/cli/tests/confluence_comments_e2e.rs
@@ -357,3 +357,44 @@ async fn comment_text_is_escaped_for_storage_format() {
         String::from_utf8_lossy(&out.stderr)
     );
 }
+
+/// The upload URL is built by hand from `base_url()`, which keeps its trailing
+/// slash, so it used to produce `host//wiki/...`. wiremock matches the path as
+/// sent, so a doubled slash simply fails to match and this test catches it.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn attachment_upload_does_not_double_the_slash() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path_matcher(
+            "/wiki/rest/api/content/12345/child/attachment",
+        ))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "results": [{"id": "att1", "title": "note.txt"}]
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let dir = TempDir::new().unwrap();
+    let config = write_config(dir.path(), &server.uri());
+    let file = dir.path().join("note.txt");
+    std::fs::write(&file, b"hello").unwrap();
+
+    let out = run(
+        &config,
+        &[
+            "confluence",
+            "attachment",
+            "upload",
+            "12345",
+            "--file",
+            file.to_str().unwrap(),
+        ],
+    );
+    assert!(
+        out.status.success(),
+        "{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}

--- a/todo.md
+++ b/todo.md
@@ -1596,3 +1596,11 @@ Minor: both changes add flags and columns.
 - `bb pr comment --path/--line/--side` for inline PR comments, and a `location` column on `pr comments` (#121, @alcantaraleo, closes #120).
 - `confluence page comments` now covers inline comments as well as footer ones, follows cursor pagination, and gains `--replies`; `add-comment` gains `--parent`/`--kind` (#123, closes #122).
 - Doc status lines brought up to date, including #104's, which still named a merged branch.
+
+## 2026-08-22 — Base URLs with a path lost their last segment
+
+`Url::join` drops the base's last path segment unless the base ends with `/`, so `https://api.atlassian.com/ex/jira/<cloudId>` + `/rest/api/3/myself` ate the cloud id. This hits the API-gateway URL form, which scoped API tokens require.
+
+- New `normalize_base_url` appends the slash. Applied in `ApiClient::new` and in `auth login`, so old configs are fixed on load and new ones are stored right.
+- `test_resolve_url_keeps_the_base_path` covers a path-bearing base with and without the trailing slash.
+- `confluence attachment upload` now trims the trailing slash before concatenating, as the Jira one already did.


### PR DESCRIPTION
## Description
A `base_url` that carries a path silently lost its last segment. `ApiClient::safe_join`
strips the leading slash and does a relative `Url::join`, and RFC 3986 relative
resolution replaces the base's last segment unless the base ends with `/`:

    base_url = https://api.atlassian.com/ex/jira/<cloudId>
    path     = /rest/api/3/myself
    actual   = https://api.atlassian.com/ex/jira/rest/api/3/myself   <- cloudId eaten
    expected = https://api.atlassian.com/ex/jira/<cloudId>/rest/api/3/myself

This hits anyone using the API-gateway URL form, which scoped API tokens require.
The workaround today is adding the trailing slash by hand in `~/.atlassian-cli/config.yaml`.

A new `normalize_base_url` appends the slash. It runs in `ApiClient::new`, so existing
configs are fixed on load however the URL reached them, and in `auth login`
(`login_jira_confluence`), so new profiles are stored already normalized. It is
idempotent, so a base already written with the slash is unaffected.

Also fixes an adjacent latent bug: `confluence attachment upload` concatenated
`base_url()` with `/wiki/...`, but `base_url()` has always kept its trailing slash,
so the URL carried a `//`. It now trims first, as the Jira attachment upload already did.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring

## Related Issues
N/A — reported directly, no tracking issue.

## Testing
- [x] Added/updated unit tests
- [ ] Added/updated integration tests
- [ ] Tested manually (describe below)

`test_resolve_url_keeps_the_base_path` in `crates/api/src/lib.rs` sits next to the
existing `resolve_url` tests and covers a path-bearing base written both with and
without the trailing slash, each joined with and without a leading slash on the path.
It fails on `main` and passes here.

### Manual Testing
No live instance was exercised in this change; the reporter confirmed that the
hand-written trailing slash works, which is exactly what this normalizes.

```bash
make pre-commit   # cargo fmt + clippy --all-targets --all-features + cargo test — all green
```

## Checklist
- [x] Code follows project style (ran `cargo fmt`)
- [x] All clippy warnings addressed (ran `cargo clippy`)
- [x] All tests pass (ran `cargo test`)
- [x] Updated `todo.md` with changes
- [ ] Updated documentation if needed
- [x] No security vulnerabilities introduced
