### PR TITLE
fix(auth): stop `auth login --help` printing the API token

### DIFF
--- a/crates/cli/src/commands/auth.rs
+++ b/crates/cli/src/commands/auth.rs
@@ -152,7 +152,9 @@ pub struct LoginArgs {
     #[arg(long)]
     pub email: Option<String>,
     /// API token to store securely (falls back to ATLASSIAN_API_TOKEN env or interactive prompt).
-    #[arg(long, env = "ATLASSIAN_API_TOKEN")]
+    // `hide_env_values` keeps `--help` from printing the token itself; clap
+    // shows the variable's value by default.
+    #[arg(long, env = "ATLASSIAN_API_TOKEN", hide_env_values = true)]
     pub token: Option<String>,
     /// Mark this profile as the default one.
     #[arg(long)]

--- a/crates/cli/tests/cli_integration.rs
+++ b/crates/cli/tests/cli_integration.rs
@@ -76,6 +76,30 @@ fn test_auth_help() {
     assert!(stdout.contains("Authentication commands"));
 }
 
+/// Regression: `--token` carries a clap `env` annotation, and clap prints the
+/// variable's value in `--help` unless told not to. Anyone with the token
+/// exported leaked it by asking for help, CI logs included.
+#[test]
+fn test_auth_login_help_hides_the_token_env_value() {
+    let output = Command::new("cargo")
+        .args(["run", "--quiet", "--", "auth", "login", "--help"])
+        .env("ATLASSIAN_API_TOKEN", "super-secret-token-value")
+        .output()
+        .expect("Failed to execute command");
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        !stdout.contains("super-secret-token-value"),
+        "auth login --help leaked the token value. Got: {stdout}"
+    );
+    // The variable is still advertised, just without its value.
+    assert!(
+        stdout.contains("ATLASSIAN_API_TOKEN"),
+        "auth login --help should still name the env var. Got: {stdout}"
+    );
+}
+
 #[test]
 fn test_output_format_flag() {
     let output = Command::new("cargo")

--- a/todo.md
+++ b/todo.md
@@ -1604,3 +1604,11 @@ Minor: both changes add flags and columns.
 - New `normalize_base_url` appends the slash. Applied in `ApiClient::new` and in `auth login`, so old configs are fixed on load and new ones are stored right.
 - `test_resolve_url_keeps_the_base_path` covers a path-bearing base with and without the trailing slash.
 - `confluence attachment upload` now trims the trailing slash before concatenating, as the Jira one already did.
+
+## 2026-08-22 — `auth login --help` printed the API token
+
+`--token` carries a clap `env` annotation, and clap prints the variable's value, so anyone with `ATLASSIAN_API_TOKEN` exported leaked it by asking for help — CI logs included, where log masking does not cover arbitrary command output.
+
+- `hide_env_values = true` on the arg. Help still names the variable, just not its value.
+- `test_auth_login_help_hides_the_token_env_value` runs `--help` with the variable set and asserts the value is absent; it fails without the fix.
+- Only `env` annotation in the workspace. `ATLASSIAN_CLI_TOKEN_{PROFILE}` is read via `std::env::var`, which never reaches help output.


### PR DESCRIPTION
## Description
`auth login --help` printed the value of `ATLASSIAN_API_TOKEN`.

`--token` carries a clap `env` annotation, and clap renders the variable's *value* in help
output by default:

    --token <TOKEN>  ...  [env: ATLASSIAN_API_TOKEN=<the actual token>]

So anyone with the variable exported disclosed their token just by asking for help — on a
screen share, in a pasted bug report, or in CI logs, where masking covers registered secrets
and not arbitrary command output. Atlassian API tokens are bearer-equivalent and long-lived,
so the whole credential stays exposed until manually revoked.

Fix is `hide_env_values = true` on the arg: help still advertises the variable, just not its
value, so the documented env fallback stays discoverable.

Scope check: this is the only `env` annotation in the workspace. The per-profile
`ATLASSIAN_CLI_TOKEN_{PROFILE}` fallback is read through `std::env::var`, which never reaches
help output.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring

## Related Issues
None — found while auditing credential handling. No user-visible flag, output shape or config
key changes; only what `--help` prints.

## Testing
- [ ] Added/updated unit tests
- [x] Added/updated integration tests
- [x] Tested manually (describe below)

`test_auth_login_help_hides_the_token_env_value` in `crates/cli/tests/cli_integration.rs` runs
`auth login --help` with `ATLASSIAN_API_TOKEN` set to a sentinel and asserts the value is
absent while the variable name is still present. It drives the built binary rather than clap's
API, because the leak lives in rendered help text. Confirmed it fails when the fix is reverted:

    test test_auth_login_help_hides_the_token_env_value ... FAILED
    auth login --help leaked the token value.

### Manual Testing
```bash
$ ATLASSIAN_API_TOKEN=super-secret-token-value cargo run --quiet -- auth login --help

# before
--token <TOKEN>   API token to store securely (falls back to ATLASSIAN_API_TOKEN env or
                  interactive prompt) [env: ATLASSIAN_API_TOKEN=super-secret-token-value]

# after
--token <TOKEN>   API token to store securely (falls back to ATLASSIAN_API_TOKEN env or
                  interactive prompt) [env: ATLASSIAN_API_TOKEN]
```

## Checklist
- [x] Code follows project style (ran `cargo fmt`)
- [x] All clippy warnings addressed (ran `cargo clippy -p atlassian-cli --tests --all-features -- -D warnings`, clean)
- [x] All tests pass (ran `cargo test -p atlassian-cli`, all green)
- [x] Updated `todo.md` with changes
- [ ] Updated documentation if needed — no doc change: the env var is still named in help, and its behaviour is unchanged
- [x] No security vulnerabilities introduced
