### PR TITLE
chore: release 0.7.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -183,7 +183,7 @@ dependencies = [
 
 [[package]]
 name = "atlassian-cli"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "anyhow",
  "atlassian-cli-api",
@@ -214,7 +214,7 @@ dependencies = [
 
 [[package]]
 name = "atlassian-cli-api"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -236,7 +236,7 @@ dependencies = [
 
 [[package]]
 name = "atlassian-cli-auth"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -256,7 +256,7 @@ dependencies = [
 
 [[package]]
 name = "atlassian-cli-bulk"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "anyhow",
  "criterion",
@@ -269,7 +269,7 @@ dependencies = [
 
 [[package]]
 name = "atlassian-cli-config"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "anyhow",
  "dirs",
@@ -283,7 +283,7 @@ dependencies = [
 
 [[package]]
 name = "atlassian-cli-output"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.7.0"
+version = "0.7.1"
 edition = "2021"
 authors = ["atlassian-cli contributors"]
 license = "MIT"

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -23,11 +23,11 @@ serde_json.workspace = true
 serde_yaml.workspace = true
 
 # Internal crates
-atlassian-cli-api = { path = "../api", version = "0.7.0" }
-atlassian-cli-auth = { path = "../auth", version = "0.7.0" }
-atlassian-cli-config = { path = "../config", version = "0.7.0" }
-atlassian-cli-output = { path = "../output", version = "0.7.0" }
-atlassian-cli-bulk = { path = "../bulk", version = "0.7.0" }
+atlassian-cli-api = { path = "../api", version = "0.7.1" }
+atlassian-cli-auth = { path = "../auth", version = "0.7.1" }
+atlassian-cli-config = { path = "../config", version = "0.7.1" }
+atlassian-cli-output = { path = "../output", version = "0.7.1" }
+atlassian-cli-bulk = { path = "../bulk", version = "0.7.1" }
 
 # CLI helpers
 url.workspace = true

--- a/todo.md
+++ b/todo.md
@@ -1604,3 +1604,10 @@ Minor: both changes add flags and columns.
 - New `normalize_base_url` appends the slash. Applied in `ApiClient::new` and in `auth login`, so old configs are fixed on load and new ones are stored right.
 - `test_resolve_url_keeps_the_base_path` covers a path-bearing base with and without the trailing slash.
 - `confluence attachment upload` now trims the trailing slash before concatenating, as the Jira one already did.
+
+## 2026-08-22 — Release 0.7.1
+
+Patch: one user-facing fix, no new surface.
+
+- Base URLs carrying a path lost their last segment, because `Url::join` replaces the base's final segment unless the base ends with `/` (#125, @shohi). This broke the API-gateway form that scoped API tokens require (`https://api.atlassian.com/ex/jira/<cloudId>`) and, by the same root cause, any self-hosted product behind a context path such as `https://example.com/bamboo`. Normalised once in `ApiClient::new`, so configs written before the fix are corrected on load rather than needing a hand-edit.
+- Verified no currently-working profile moves: Jira, Confluence, attachment download links, Bitbucket and Opsgenie all resolve byte-identically, and that is now a table test.


### PR DESCRIPTION
Patch: one user-facing fix, no new surface. #125 landed about an hour after 0.7.0 went out.

## Base URLs carrying a path lost their last segment (#125, @shohi)

`Url::join` replaces the base's final path segment unless the base ends with `/`, so:

```
base   https://api.atlassian.com/ex/jira/<cloudId>
path   /rest/api/3/myself
got    https://api.atlassian.com/ex/jira/rest/api/3/myself     <- cloud id eaten
want   https://api.atlassian.com/ex/jira/<cloudId>/rest/api/3/myself
```

That breaks the API-gateway URL form scoped API tokens require, and by the same root cause any self-hosted product behind a context path, e.g. Bamboo at `https://example.com/bamboo`. The workaround was hand-editing a trailing slash into `~/.atlassian-cli/config.yaml`.

The base is normalised once in `ApiClient::new`, so a config written before the fix is corrected on load rather than needing an edit, and in `auth login` so new profiles are stored already normalised.

## Nothing else moves

Every base the CLI actually constructs resolves byte-identically: Jira and Confluence on a bare origin, Confluence attachment download links with a query string, Bitbucket, and Opsgenie — whose base already carries `/v2/` and already ends in a slash, which is the case that would have doubled the prefix had either been untrue. That is pinned by a table test rather than left for a future reader to re-derive.

650 tests green, fmt and clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)