### PR TITLE
chore: release 0.7.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -183,7 +183,7 @@ dependencies = [
 
 [[package]]
 name = "atlassian-cli"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "anyhow",
  "atlassian-cli-api",
@@ -214,7 +214,7 @@ dependencies = [
 
 [[package]]
 name = "atlassian-cli-api"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -236,7 +236,7 @@ dependencies = [
 
 [[package]]
 name = "atlassian-cli-auth"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -256,7 +256,7 @@ dependencies = [
 
 [[package]]
 name = "atlassian-cli-bulk"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "anyhow",
  "criterion",
@@ -269,7 +269,7 @@ dependencies = [
 
 [[package]]
 name = "atlassian-cli-config"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "anyhow",
  "dirs",
@@ -283,7 +283,7 @@ dependencies = [
 
 [[package]]
 name = "atlassian-cli-output"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.7.1"
+version = "0.7.2"
 edition = "2021"
 authors = ["atlassian-cli contributors"]
 license = "MIT"

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -23,11 +23,11 @@ serde_json.workspace = true
 serde_yaml.workspace = true
 
 # Internal crates
-atlassian-cli-api = { path = "../api", version = "0.7.1" }
-atlassian-cli-auth = { path = "../auth", version = "0.7.1" }
-atlassian-cli-config = { path = "../config", version = "0.7.1" }
-atlassian-cli-output = { path = "../output", version = "0.7.1" }
-atlassian-cli-bulk = { path = "../bulk", version = "0.7.1" }
+atlassian-cli-api = { path = "../api", version = "0.7.2" }
+atlassian-cli-auth = { path = "../auth", version = "0.7.2" }
+atlassian-cli-config = { path = "../config", version = "0.7.2" }
+atlassian-cli-output = { path = "../output", version = "0.7.2" }
+atlassian-cli-bulk = { path = "../bulk", version = "0.7.2" }
 
 # CLI helpers
 url.workspace = true

--- a/todo.md
+++ b/todo.md
@@ -1617,3 +1617,9 @@ Patch: one user-facing fix, no new surface.
 
 - Base URLs carrying a path lost their last segment, because `Url::join` replaces the base's final segment unless the base ends with `/` (#125, @shohi). This broke the API-gateway form that scoped API tokens require (`https://api.atlassian.com/ex/jira/<cloudId>`) and, by the same root cause, any self-hosted product behind a context path such as `https://example.com/bamboo`. Normalised once in `ApiClient::new`, so configs written before the fix are corrected on load rather than needing a hand-edit.
 - Verified no currently-working profile moves: Jira, Confluence, attachment download links, Bitbucket and Opsgenie all resolve byte-identically, and that is now a table test.
+
+## 2026-08-22 — Release 0.7.2
+
+Patch. `auth login --help` printed the value of `ATLASSIAN_API_TOKEN` (#126, @shohi): clap renders an `env` annotation's *value* in help output unless told not to, so anyone with the variable exported disclosed their token by asking for help, including in CI logs, where masking covers registered secrets rather than arbitrary command output. Fixed with `hide_env_values`; the variable is still advertised, just not its value.
+
+Verified against the published 0.7.1 binary, not only a local build. `env = "` appears exactly once in the workspace, so this is the whole of the exposure; the per-profile and Bitbucket token fallbacks are read via `std::env::var` and never reach help output.


### PR DESCRIPTION
Patch, shipping a credential-disclosure fix. Worth releasing promptly rather than batching.

## `auth login --help` printed the API token (#126, @shohi)

clap renders an `env` annotation's *value* in help output unless told otherwise:

```
$ ATLASSIAN_API_TOKEN='SUPER-SECRET-TOKEN-VALUE' atlassian-cli auth login --help
      --token <TOKEN>  ...  [env: ATLASSIAN_API_TOKEN=SUPER-SECRET-TOKEN-VALUE]
```

So anyone with the variable exported disclosed their token by asking for help — on a screen share, in a pasted bug report, or in CI logs, where masking covers registered secrets rather than arbitrary command output. Atlassian API tokens are bearer-equivalent and long-lived, so the exposure lasts until someone notices and revokes.

Fixed with `hide_env_values`. The variable is still advertised in help, so the documented fallback stays discoverable; only its value is suppressed.

## Scope

Reproduced against the binary published as 0.7.1, not only a local build. `env = "` appears exactly once in the workspace, on this argument, and it is the only secret-bearing arg — so this is the whole of the exposure. The per-profile `ATLASSIAN_CLI_TOKEN_{PROFILE}` and Bitbucket fallbacks are read through `std::env::var`, which never reaches help output.

The regression test asserts both directions: the value is gone, and the variable is still named. That second half matters, or a later "fix" could drop the `env` annotation and quietly remove the fallback.

651 tests green, fmt and clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)