### PR TITLE
feat(jira): --fields on issue get and issue search

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,12 @@ crates/
    # Jira - Issues
    atlassian-cli jira issue search --jql "project = DEV order by created desc" --limit 5
    atlassian-cli jira issue get DEV-123
+   # Pick the fields you want, by id or by the display name from `jira fields list`.
+   # Columns come back in the order you ask for them; `all` returns everything.
+   atlassian-cli jira issue get DEV-123 --fields summary,status
+   atlassian-cli jira issue get DEV-123 --fields "Story Points" --format json
+   atlassian-cli jira issue get DEV-123 --fields all --format json
+   atlassian-cli jira issue search --project DEV --fields status,"Story Points" --format csv
    atlassian-cli jira issue create --project DEV --issue-type Task --summary "Test task"
    # Custom fields — discover IDs via `jira fields list`:
    atlassian-cli jira issue create --project DEV --issue-type Task --summary "cf test" \

--- a/crates/cli/src/commands/jira/field_selection.rs
+++ b/crates/cli/src/commands/jira/field_selection.rs
@@ -1,0 +1,725 @@
+//! `--fields` on `jira issue get` and `jira issue search`.
+//!
+//! Jira returns every navigable field on a single issue and `view_issue` threw
+//! all but eight of them away, while `search_issues` asked for a hardcoded five.
+//! Custom fields, which is where most teams keep the data they actually want,
+//! were unreachable without dropping to `jira api`.
+//!
+//! Two things make this more than a passthrough:
+//!
+//! - **Names, not just ids.** Nobody knows `customfield_10016` is Story Points.
+//!   The display names from `/rest/api/3/field` are accepted, and resolved to
+//!   ids before the request. An ambiguous name is an error rather than a guess:
+//!   several fields sharing a name is the normal state of a mature Jira site,
+//!   and the copies hold different values.
+//! - **Order.** The columns come back in the order they were typed, which means
+//!   the tabular formats cannot use the renderer's default alphabetical union.
+//!
+//! JSON and YAML stay exactly what Jira sent. Only the tabular formats flatten
+//! wrapper objects into a label, and that is a rendering decision, not a
+//! transformation of the data.
+
+use anyhow::{anyhow, bail, Context, Result};
+use atlassian_cli_output::OutputFormat;
+use serde::Deserialize;
+use serde_json::{Map, Value};
+
+use super::utils::JiraContext;
+
+/// Jira's own name for "every field", and what `--fields all` becomes.
+const ALL_FIELDS: &str = "*all";
+
+/// The key column, always present and always first.
+const KEY_COLUMN: &str = "key";
+
+/// One field definition from `/rest/api/3/field`.
+#[derive(Debug, Clone, Deserialize)]
+pub(crate) struct FieldDef {
+    pub id: String,
+    #[serde(default)]
+    pub name: String,
+}
+
+/// A requested field, resolved.
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct ResolvedField {
+    /// Exactly what the user typed. Used as the column header and the JSON key,
+    /// so the two always agree and a script can predict both.
+    pub token: String,
+    /// What goes in the `fields=` parameter.
+    pub id: String,
+}
+
+/// What to ask Jira for.
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) enum FieldSelection {
+    /// A wildcard. The response's own keys become the columns, so the order is
+    /// Jira's rather than the user's.
+    Raw(String),
+    /// An explicit, ordered list.
+    Explicit(Vec<ResolvedField>),
+}
+
+impl FieldSelection {
+    /// The value of the `fields` query parameter.
+    pub fn query_value(&self) -> String {
+        match self {
+            FieldSelection::Raw(raw) => raw.clone(),
+            FieldSelection::Explicit(fields) => fields
+                .iter()
+                .map(|f| f.id.as_str())
+                .collect::<Vec<_>>()
+                .join(","),
+        }
+    }
+}
+
+/// Whether a token asks for everything, or uses Jira's own wildcard syntax.
+///
+/// `all` is the documented spelling because a bare `*all` is a glob: zsh, the
+/// default shell on macOS, refuses the whole command line with "no matches
+/// found" before the CLI ever starts. Anything already starting with `*` or `-`
+/// is passed through untouched, which buys `*navigable` and the exclusion form
+/// `'*all,-comment'` at no cost.
+fn is_wildcard(token: &str) -> bool {
+    let trimmed = token.trim();
+    trimmed.eq_ignore_ascii_case("all") || trimmed.starts_with('*') || trimmed.starts_with('-')
+}
+
+fn wildcard_value(token: &str) -> String {
+    let trimmed = token.trim();
+    if trimmed.eq_ignore_ascii_case("all") {
+        ALL_FIELDS.to_string()
+    } else {
+        trimmed.to_string()
+    }
+}
+
+/// Whether any token might be a display name, and so needs the field list.
+///
+/// Only `customfield_<digits>` is unambiguously an id. `summary` and `status`
+/// are ids too, but nothing local can prove that: a site can perfectly well
+/// have a custom field named "Status", and guessing would resolve to the wrong
+/// one silently.
+pub(crate) fn needs_field_lookup(tokens: &[String]) -> bool {
+    !tokens.iter().all(|token| {
+        let token = token.trim();
+        token
+            .strip_prefix("customfield_")
+            .is_some_and(|digits| !digits.is_empty() && digits.chars().all(|c| c.is_ascii_digit()))
+    })
+}
+
+/// Resolve what the user typed against the site's field definitions.
+///
+/// Pure, so the interesting behaviour is testable without a mock server.
+pub(crate) fn match_fields(tokens: &[String], defs: &[FieldDef]) -> Result<Vec<ResolvedField>> {
+    let mut resolved: Vec<ResolvedField> = Vec::with_capacity(tokens.len());
+
+    for token in tokens {
+        let trimmed = token.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+
+        // A repeated field is a repeated column, which is meaningless. Keep the
+        // first position rather than erroring: unlike `--field key=value` on
+        // create, a duplicate here is not a conflict, just noise.
+        if resolved.iter().any(|r| r.token == trimmed) {
+            continue;
+        }
+
+        resolved.push(resolve_one(trimmed, defs)?);
+    }
+
+    if resolved.is_empty() {
+        bail!("--fields was given no field names");
+    }
+
+    Ok(resolved)
+}
+
+fn resolve_one(token: &str, defs: &[FieldDef]) -> Result<ResolvedField> {
+    // An id wins over a custom field that happens to share the name. Ids are
+    // what scripts pass, and a site cannot create a custom field whose *id*
+    // collides with a system one.
+    if let Some(def) = defs.iter().find(|d| d.id.eq_ignore_ascii_case(token)) {
+        return Ok(ResolvedField {
+            token: token.to_string(),
+            id: def.id.clone(),
+        });
+    }
+
+    let by_name: Vec<&FieldDef> = defs
+        .iter()
+        .filter(|d| d.name.trim().eq_ignore_ascii_case(token))
+        .collect();
+
+    match by_name.as_slice() {
+        [single] => Ok(ResolvedField {
+            token: token.to_string(),
+            id: single.id.clone(),
+        }),
+        [] => Err(anyhow!(
+            "Unknown field '{token}'. Run `atlassian-cli jira fields list` to see \
+             the fields available on this site."
+        )),
+        // Several custom fields sharing a display name is ordinary on a site
+        // that has been in use for a while, and they belong to different
+        // screens and hold different values. Choosing one would be wrong in a
+        // way the user cannot see from the output.
+        many => {
+            let candidates = many
+                .iter()
+                .map(|d| format!("  {}  {}", d.id, d.name))
+                .collect::<Vec<_>>()
+                .join("\n");
+            Err(anyhow!(
+                "Field name '{token}' is ambiguous on this site. Candidates:\n{candidates}\n\
+                 Pass the id instead, for example --fields {}.",
+                many[0].id
+            ))
+        }
+    }
+}
+
+/// Turn the tokens into a selection, fetching the field list only if needed.
+pub(crate) async fn resolve_field_ids(
+    ctx: &JiraContext<'_>,
+    tokens: &[String],
+) -> Result<FieldSelection> {
+    if let Some(wildcard) = tokens.iter().find(|t| is_wildcard(t)) {
+        // One wildcard makes the whole selection a wildcard: mixing `all` with
+        // named fields cannot narrow anything, and Jira reads the parameter as
+        // one list anyway, so we hand it over whole.
+        let value = if tokens.len() == 1 {
+            wildcard_value(wildcard)
+        } else {
+            tokens
+                .iter()
+                .map(|t| wildcard_value(t))
+                .collect::<Vec<_>>()
+                .join(",")
+        };
+        tracing::debug!(fields = %value, "requesting fields by wildcard");
+        return Ok(FieldSelection::Raw(value));
+    }
+
+    if !needs_field_lookup(tokens) {
+        tracing::debug!("every requested field is a custom field id, skipping the field lookup");
+        let resolved = tokens
+            .iter()
+            .map(|t| ResolvedField {
+                token: t.trim().to_string(),
+                id: t.trim().to_string(),
+            })
+            .collect();
+        return Ok(FieldSelection::Explicit(resolved));
+    }
+
+    let defs: Vec<FieldDef> = ctx
+        .client
+        .get("/rest/api/3/field")
+        .await
+        .context("Failed to list this site's fields to resolve --fields")?;
+    tracing::debug!(count = defs.len(), "fetched field definitions");
+
+    let resolved = match_fields(tokens, &defs)?;
+    tracing::debug!(
+        fields = %resolved.iter().map(|r| r.id.as_str()).collect::<Vec<_>>().join(","),
+        "resolved --fields"
+    );
+    Ok(FieldSelection::Explicit(resolved))
+}
+
+/// One issue as returned when we asked for specific fields.
+#[derive(Debug, Deserialize)]
+struct RawIssue {
+    key: String,
+    #[serde(default)]
+    fields: Map<String, Value>,
+}
+
+/// Build one output row: `key` first, then the requested fields in order.
+///
+/// A requested field the response does not carry becomes `Null`, which renders
+/// as an empty cell. That is the honest answer for a field the site does not
+/// have on that issue type, and erroring would make a wide `--fields` list
+/// unusable across mixed issue types.
+fn project_issue(issue: &RawIssue, selection: &FieldSelection) -> (Value, Vec<String>) {
+    let mut row = Map::new();
+    let mut columns = vec![KEY_COLUMN.to_string()];
+    row.insert(KEY_COLUMN.to_string(), Value::String(issue.key.clone()));
+
+    match selection {
+        FieldSelection::Raw(_) => {
+            // Jira chose the keys, so it chooses the order too.
+            for (name, value) in &issue.fields {
+                if name == KEY_COLUMN {
+                    continue;
+                }
+                columns.push(name.clone());
+                row.insert(name.clone(), value.clone());
+            }
+        }
+        FieldSelection::Explicit(fields) => {
+            for field in fields {
+                // `key` is not inside `fields`, and is already the first column.
+                if field.token == KEY_COLUMN || field.id == KEY_COLUMN {
+                    continue;
+                }
+                let value = issue.fields.get(&field.id).cloned().unwrap_or(Value::Null);
+                if value.is_null() && !issue.fields.contains_key(&field.id) {
+                    tracing::warn!(
+                        field = %field.id,
+                        issue = %issue.key,
+                        "requested field is absent from the response"
+                    );
+                }
+                columns.push(field.token.clone());
+                row.insert(field.token.clone(), value);
+            }
+        }
+    }
+
+    (Value::Object(row), columns)
+}
+
+/// Flatten one Jira field value for a table cell.
+///
+/// Custom field values are nearly always a wrapper object: a select option is
+/// `{"value":"Internal"}`, a user is `{"displayName":"Ada"}`, a priority or a
+/// sprint is `{"name":"High"}`. Printing the JSON is lossless and unreadable,
+/// so the tabular formats get the label instead. JSON and YAML never call this.
+pub(crate) fn friendly_scalar(value: &Value) -> String {
+    match value {
+        Value::Null => String::new(),
+        Value::String(s) => s.clone(),
+        Value::Number(n) => n.to_string(),
+        Value::Bool(b) => b.to_string(),
+        Value::Array(items) => items
+            .iter()
+            // One level only. An array of arrays is rare enough that recursing
+            // would cost more in surprise than it saves in width.
+            .map(|item| match item {
+                Value::Array(_) => compact(item),
+                other => friendly_scalar(other),
+            })
+            .filter(|s| !s.is_empty())
+            .collect::<Vec<_>>()
+            .join(", "),
+        Value::Object(obj) => {
+            // Rich text, which is every description-like field.
+            if obj.get("type").and_then(Value::as_str) == Some("doc") {
+                return super::issues::extract_adf_text(value);
+            }
+
+            // displayName first, so a user object never falls through to a
+            // sibling `name`. `key` last: it is an identifier, useful only when
+            // nothing more readable exists.
+            for label in ["displayName", "name", "value", "filename", "key"] {
+                if let Some(text) = obj.get(label).and_then(Value::as_str) {
+                    if !text.is_empty() {
+                        return text.to_string();
+                    }
+                }
+            }
+
+            // Nothing recognised: show the data rather than lose it.
+            compact(value)
+        }
+    }
+}
+
+fn compact(value: &Value) -> String {
+    serde_json::to_string(value).unwrap_or_default()
+}
+
+/// Apply `friendly_scalar` to every cell, for the formats people read.
+fn humanize(row: &Value, format: OutputFormat) -> Value {
+    if !matches!(
+        format,
+        OutputFormat::Table | OutputFormat::Csv | OutputFormat::Markdown
+    ) {
+        return row.clone();
+    }
+
+    match row {
+        Value::Object(obj) => Value::Object(
+            obj.iter()
+                .map(|(k, v)| (k.clone(), Value::String(friendly_scalar(v))))
+                .collect(),
+        ),
+        other => other.clone(),
+    }
+}
+
+/// `jira issue get --fields`.
+pub(crate) async fn view_issue_fields(
+    ctx: &JiraContext<'_>,
+    key: &str,
+    tokens: &[String],
+) -> Result<()> {
+    let selection = resolve_field_ids(ctx, tokens).await?;
+
+    let issue: RawIssue = ctx
+        .client
+        .get(&format!(
+            "/rest/api/3/issue/{key}?fields={}",
+            urlencoding::encode(&selection.query_value())
+        ))
+        .await
+        .with_context(|| format!("Failed to fetch issue {key}"))?;
+
+    let (row, columns) = project_issue(&issue, &selection);
+
+    match ctx.renderer.format() {
+        // A single issue as a horizontal table is a scroll bar. Two columns of
+        // field and value read like the curated view the flag replaces, and the
+        // order is just row order, so it needs no column plumbing.
+        OutputFormat::Table | OutputFormat::Csv | OutputFormat::Markdown => {
+            if ctx.renderer.format() == OutputFormat::Markdown {
+                ctx.renderer.render_raw(&format!("# {}\n", issue.key))?;
+            }
+
+            let obj = row.as_object().expect("project_issue returns an object");
+            let pairs: Vec<Value> = columns
+                .iter()
+                .filter_map(|column| {
+                    obj.get(column).map(|value| {
+                        serde_json::json!({
+                            "field": column,
+                            "value": friendly_scalar(value),
+                        })
+                    })
+                })
+                .collect();
+
+            ctx.renderer
+                .render_rows_ordered(&pairs, &["field".to_string(), "value".to_string()])
+        }
+        // Byte for byte what Jira sent, as a flat object: an array of
+        // field/value pairs would be hostile to `jq`.
+        _ => ctx.renderer.render(&row),
+    }
+}
+
+/// `jira issue search --fields`, given the JQL the caller already built.
+pub(crate) async fn search_rows(
+    ctx: &JiraContext<'_>,
+    jql: &str,
+    limit: usize,
+    tokens: &[String],
+) -> Result<()> {
+    let selection = resolve_field_ids(ctx, tokens).await?;
+
+    #[derive(Deserialize)]
+    struct SearchResponse {
+        #[serde(default)]
+        issues: Vec<RawIssue>,
+    }
+
+    let query = format!(
+        "/rest/api/3/search/jql?jql={}&maxResults={}&fields={}",
+        urlencoding::encode(jql),
+        limit.min(1000),
+        urlencoding::encode(&selection.query_value())
+    );
+
+    let response: SearchResponse = ctx
+        .client
+        .get(&query)
+        .await
+        .context("Failed to execute search")?;
+
+    if response.issues.is_empty() {
+        ctx.verify_auth().await?;
+        tracing::info!("No issues found");
+    }
+
+    let mut columns: Vec<String> = vec![KEY_COLUMN.to_string()];
+    let mut rows = Vec::with_capacity(response.issues.len());
+
+    for issue in &response.issues {
+        let (row, row_columns) = project_issue(issue, &selection);
+        // Under a wildcard the columns come from the payload, and issue types
+        // differ in which fields they carry, so the set is the union.
+        for column in row_columns {
+            if !columns.contains(&column) {
+                columns.push(column);
+            }
+        }
+        rows.push(humanize(&row, ctx.renderer.format()));
+    }
+
+    match ctx.renderer.format() {
+        OutputFormat::Table | OutputFormat::Csv | OutputFormat::Markdown => {
+            ctx.renderer.render_rows_ordered(&rows, &columns)
+        }
+        _ => ctx.renderer.render(&rows),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn defs() -> Vec<FieldDef> {
+        vec![
+            FieldDef {
+                id: "summary".into(),
+                name: "Summary".into(),
+            },
+            FieldDef {
+                id: "status".into(),
+                name: "Status".into(),
+            },
+            FieldDef {
+                id: "customfield_10016".into(),
+                name: "Story Points".into(),
+            },
+            FieldDef {
+                id: "customfield_10020".into(),
+                name: "Sprint".into(),
+            },
+        ]
+    }
+
+    fn tokens(values: &[&str]) -> Vec<String> {
+        values.iter().map(|v| v.to_string()).collect()
+    }
+
+    #[test]
+    fn custom_field_ids_alone_need_no_lookup() {
+        assert!(!needs_field_lookup(&tokens(&[
+            "customfield_10016",
+            "customfield_10020"
+        ])));
+    }
+
+    #[test]
+    fn any_possible_name_triggers_a_lookup() {
+        assert!(needs_field_lookup(&tokens(&[
+            "customfield_10016",
+            "status"
+        ])));
+        assert!(needs_field_lookup(&tokens(&["summary"])));
+        // Not a real id: a site could have a field named exactly this.
+        assert!(needs_field_lookup(&tokens(&["customfield_abc"])));
+        assert!(needs_field_lookup(&tokens(&["customfield_"])));
+    }
+
+    #[test]
+    fn all_is_a_wildcard_whatever_its_case() {
+        for token in ["all", "ALL", "All", " all "] {
+            assert!(is_wildcard(token), "{token} should be a wildcard");
+            assert_eq!(wildcard_value(token), ALL_FIELDS);
+        }
+    }
+
+    #[test]
+    fn jira_wildcards_pass_through_untouched() {
+        for token in ["*all", "*navigable", "-comment"] {
+            assert!(is_wildcard(token));
+            assert_eq!(wildcard_value(token), token);
+        }
+    }
+
+    #[test]
+    fn a_field_id_resolves_to_itself() {
+        let resolved = match_fields(&tokens(&["summary"]), &defs()).unwrap();
+        assert_eq!(resolved[0].id, "summary");
+        assert_eq!(resolved[0].token, "summary");
+    }
+
+    #[test]
+    fn a_display_name_resolves_case_insensitively() {
+        let resolved = match_fields(&tokens(&["story points"]), &defs()).unwrap();
+        assert_eq!(resolved[0].id, "customfield_10016");
+        // The header stays what the user typed, so it matches the JSON key.
+        assert_eq!(resolved[0].token, "story points");
+    }
+
+    /// A site can name a custom field "Summary". The id must still win, or
+    /// every existing script quietly starts reading a different field.
+    #[test]
+    fn an_id_wins_over_a_custom_field_with_the_same_name() {
+        let mut defs = defs();
+        defs.push(FieldDef {
+            id: "customfield_10099".into(),
+            name: "Summary".into(),
+        });
+
+        let resolved = match_fields(&tokens(&["summary"]), &defs).unwrap();
+        assert_eq!(resolved[0].id, "summary");
+    }
+
+    #[test]
+    fn an_unknown_name_points_at_the_fields_command() {
+        let error = match_fields(&tokens(&["stroy points"]), &defs()).unwrap_err();
+        let message = error.to_string();
+        assert!(message.contains("stroy points"), "{message}");
+        assert!(message.contains("jira fields list"), "{message}");
+    }
+
+    /// The case a naive `.find()` gets wrong: it would silently pick one of
+    /// two fields holding different numbers.
+    #[test]
+    fn an_ambiguous_name_errors_and_lists_every_candidate() {
+        let mut defs = defs();
+        defs.push(FieldDef {
+            id: "customfield_10032".into(),
+            name: "Story Points".into(),
+        });
+
+        let error = match_fields(&tokens(&["Story Points"]), &defs).unwrap_err();
+        let message = error.to_string();
+        assert!(message.contains("ambiguous"), "{message}");
+        assert!(message.contains("customfield_10016"), "{message}");
+        assert!(message.contains("customfield_10032"), "{message}");
+    }
+
+    #[test]
+    fn duplicate_tokens_collapse_and_keep_their_first_position() {
+        let resolved = match_fields(&tokens(&["status", "summary", "status"]), &defs()).unwrap();
+        let ids: Vec<&str> = resolved.iter().map(|r| r.id.as_str()).collect();
+        assert_eq!(ids, vec!["status", "summary"]);
+    }
+
+    #[test]
+    fn resolution_preserves_the_order_typed() {
+        let resolved =
+            match_fields(&tokens(&["Story Points", "status", "summary"]), &defs()).unwrap();
+        let ids: Vec<&str> = resolved.iter().map(|r| r.id.as_str()).collect();
+        assert_eq!(ids, vec!["customfield_10016", "status", "summary"]);
+    }
+
+    #[test]
+    fn the_query_value_joins_ids_in_order() {
+        let selection = FieldSelection::Explicit(
+            match_fields(&tokens(&["status", "Story Points"]), &defs()).unwrap(),
+        );
+        assert_eq!(selection.query_value(), "status,customfield_10016");
+        assert_eq!(FieldSelection::Raw("*all".into()).query_value(), "*all");
+    }
+
+    fn raw_issue(fields: Value) -> RawIssue {
+        RawIssue {
+            key: "DEV-1".to_string(),
+            fields: fields.as_object().unwrap().clone(),
+        }
+    }
+
+    #[test]
+    fn projection_puts_key_first_and_keeps_the_requested_order() {
+        let issue = raw_issue(json!({"status": {"name": "Done"}, "summary": "Fix it"}));
+        let selection = FieldSelection::Explicit(
+            match_fields(&tokens(&["summary", "status"]), &defs()).unwrap(),
+        );
+
+        let (row, columns) = project_issue(&issue, &selection);
+
+        assert_eq!(columns, vec!["key", "summary", "status"]);
+        assert_eq!(row["key"], json!("DEV-1"));
+        assert_eq!(row["summary"], json!("Fix it"));
+    }
+
+    #[test]
+    fn projection_yields_null_for_a_field_the_response_omitted() {
+        let issue = raw_issue(json!({"summary": "Fix it"}));
+        let selection = FieldSelection::Explicit(
+            match_fields(&tokens(&["summary", "Story Points"]), &defs()).unwrap(),
+        );
+
+        let (row, columns) = project_issue(&issue, &selection);
+
+        assert_eq!(columns, vec!["key", "summary", "Story Points"]);
+        assert_eq!(row["Story Points"], Value::Null);
+    }
+
+    /// `key` lives at the top level of the response, not inside `fields`, so
+    /// asking for it must not produce a second, empty column.
+    #[test]
+    fn projection_does_not_duplicate_the_key_column() {
+        let issue = raw_issue(json!({"summary": "Fix it"}));
+        let selection = FieldSelection::Explicit(vec![
+            ResolvedField {
+                token: "key".into(),
+                id: "key".into(),
+            },
+            ResolvedField {
+                token: "summary".into(),
+                id: "summary".into(),
+            },
+        ]);
+
+        let (_, columns) = project_issue(&issue, &selection);
+
+        assert_eq!(columns, vec!["key", "summary"]);
+    }
+
+    #[test]
+    fn friendly_scalar_passes_scalars_through() {
+        assert_eq!(friendly_scalar(&json!("text")), "text");
+        assert_eq!(friendly_scalar(&json!(5)), "5");
+        assert_eq!(friendly_scalar(&json!(true)), "true");
+        assert_eq!(friendly_scalar(&Value::Null), "");
+    }
+
+    #[test]
+    fn friendly_scalar_reads_the_usual_wrapper_objects() {
+        assert_eq!(friendly_scalar(&json!({"value": "Internal"})), "Internal");
+        assert_eq!(friendly_scalar(&json!({"name": "High"})), "High");
+        assert_eq!(friendly_scalar(&json!({"displayName": "Ada"})), "Ada");
+        assert_eq!(friendly_scalar(&json!({"filename": "log.txt"})), "log.txt");
+        assert_eq!(friendly_scalar(&json!({"key": "DEV-2"})), "DEV-2");
+    }
+
+    /// A user object carries both, and the display name is the readable one.
+    #[test]
+    fn friendly_scalar_prefers_display_name_over_a_sibling_name() {
+        let user = json!({"name": "ada.l", "displayName": "Ada Lovelace"});
+        assert_eq!(friendly_scalar(&user), "Ada Lovelace");
+    }
+
+    #[test]
+    fn friendly_scalar_extracts_rich_text() {
+        let adf = json!({
+            "type": "doc",
+            "version": 1,
+            "content": [{
+                "type": "paragraph",
+                "content": [{"type": "text", "text": "Hello there"}]
+            }]
+        });
+        assert_eq!(friendly_scalar(&adf).trim(), "Hello there");
+    }
+
+    #[test]
+    fn friendly_scalar_joins_arrays_of_options() {
+        let labels = json!([{"value": "one"}, {"value": "two"}]);
+        assert_eq!(friendly_scalar(&labels), "one, two");
+        assert_eq!(friendly_scalar(&json!(["a", "b"])), "a, b");
+        assert_eq!(friendly_scalar(&json!([])), "");
+    }
+
+    /// Never lose data: an object with no label we know still shows its
+    /// contents, exactly as the renderer would have.
+    #[test]
+    fn friendly_scalar_falls_back_to_compact_json() {
+        let odd = json!({"unexpected": 1});
+        assert_eq!(friendly_scalar(&odd), "{\"unexpected\":1}");
+    }
+
+    #[test]
+    fn humanize_leaves_json_untouched_and_flattens_tables() {
+        let row = json!({"points": {"value": "Internal"}});
+
+        let as_json = humanize(&row, OutputFormat::Json);
+        assert_eq!(as_json["points"], json!({"value": "Internal"}));
+
+        let as_table = humanize(&row, OutputFormat::Table);
+        assert_eq!(as_table["points"], json!("Internal"));
+    }
+}

--- a/crates/cli/src/commands/jira/field_selection.rs
+++ b/crates/cli/src/commands/jira/field_selection.rs
@@ -129,7 +129,21 @@ pub(crate) fn match_fields(tokens: &[String], defs: &[FieldDef]) -> Result<Vec<R
             continue;
         }
 
-        resolved.push(resolve_one(trimmed, defs)?);
+        let candidate = resolve_one(trimmed, defs)?;
+
+        // Two spellings of one field, `--fields customfield_10016,"Story Points"`
+        // or `summary,Summary`, are still one field. Without this the id went
+        // to Jira twice and the same value printed in two columns.
+        if resolved.iter().any(|r| r.id == candidate.id) {
+            tracing::debug!(
+                token = %candidate.token,
+                id = %candidate.id,
+                "field already requested under another name, skipping"
+            );
+            continue;
+        }
+
+        resolved.push(candidate);
     }
 
     if resolved.is_empty() {
@@ -188,7 +202,24 @@ pub(crate) async fn resolve_field_ids(
     ctx: &JiraContext<'_>,
     tokens: &[String],
 ) -> Result<FieldSelection> {
+    // `--fields ""` and `--fields ,` reach here as blank tokens. Checked before
+    // anything else so the user is told immediately, rather than after paying
+    // for a field-list request that cannot help.
+    if tokens.iter().all(|t| t.trim().is_empty()) {
+        bail!("--fields was given no field names");
+    }
+
     if let Some(wildcard) = tokens.iter().find(|t| is_wildcard(t)) {
+        if tokens.len() > 1 {
+            // Jira reads `*all,summary` as everything, so the named fields do
+            // not narrow anything. Say so rather than quietly returning far
+            // more than was asked for.
+            tracing::warn!(
+                "a wildcard in --fields returns every field, so the other names \
+                 do not narrow the result"
+            );
+        }
+
         // One wildcard makes the whole selection a wildcard: mixing `all` with
         // named fields cannot narrow anything, and Jira reads the parameter as
         // one list anyway, so we hand it over whole.
@@ -435,6 +466,14 @@ pub(crate) async fn search_rows(
     if response.issues.is_empty() {
         ctx.verify_auth().await?;
         tracing::info!("No issues found");
+        // Hand an empty result to the shared helper rather than falling through
+        // to the ordered renderer, which would print "[]" under table, CSV,
+        // markdown and quiet. Every other list command prints the message for
+        // the formats people read and nothing at all for the line-oriented
+        // ones; #110 was this exact inconsistency, across ~70 commands.
+        return ctx
+            .renderer
+            .render_list_or_empty(&Vec::<Value>::new(), "No issues found");
     }
 
     let mut columns: Vec<String> = vec![KEY_COLUMN.to_string()];
@@ -585,6 +624,20 @@ mod tests {
         let resolved = match_fields(&tokens(&["status", "summary", "status"]), &defs()).unwrap();
         let ids: Vec<&str> = resolved.iter().map(|r| r.id.as_str()).collect();
         assert_eq!(ids, vec!["status", "summary"]);
+    }
+
+    /// Two spellings of one field are one field. Otherwise the id went to Jira
+    /// twice and the value printed in two identical columns.
+    #[test]
+    fn two_names_for_the_same_field_collapse_to_one_column() {
+        let resolved = match_fields(&tokens(&["summary", "Summary"]), &defs()).unwrap();
+        assert_eq!(resolved.len(), 1);
+        assert_eq!(resolved[0].token, "summary", "the first spelling wins");
+
+        let resolved =
+            match_fields(&tokens(&["customfield_10016", "Story Points"]), &defs()).unwrap();
+        assert_eq!(resolved.len(), 1);
+        assert_eq!(resolved[0].id, "customfield_10016");
     }
 
     #[test]

--- a/crates/cli/src/commands/jira/issues.rs
+++ b/crates/cli/src/commands/jira/issues.rs
@@ -69,6 +69,7 @@ pub async fn search_issues(
     text: Option<&str>,
     show_query: bool,
     limit: usize,
+    fields: &[String],
 ) -> Result<()> {
     // Build JQL from filters or use raw JQL
     let final_jql = if let Some(raw_jql) = jql {
@@ -114,6 +115,12 @@ pub async fn search_issues(
         if jql.is_none() {
             println!();
         }
+    }
+
+    // A chosen field list replaces the fixed five columns, and takes its own
+    // path over raw JSON. The default below is left exactly as it was.
+    if !fields.is_empty() {
+        return super::field_selection::search_rows(ctx, &final_jql, limit, fields).await;
     }
 
     #[derive(Deserialize)]
@@ -968,7 +975,7 @@ const ADF_MAX_DEPTH: usize = 64;
 
 /// Recursively extract plain text from an ADF (Atlassian Document Format) JSON value.
 /// Handles paragraphs, headings, lists, code blocks, hard breaks, inline nodes, and nested content.
-fn extract_adf_text(value: &Value) -> String {
+pub(super) fn extract_adf_text(value: &Value) -> String {
     extract_adf_inner(value, 0)
 }
 

--- a/crates/cli/src/commands/jira/mod.rs
+++ b/crates/cli/src/commands/jira/mod.rs
@@ -11,6 +11,7 @@ mod attachments;
 mod audit;
 mod automation;
 mod bulk;
+mod field_selection;
 mod fields_workflows;
 mod issues;
 mod projects;
@@ -98,7 +99,15 @@ enum JiraCommands {
 enum IssueCommands {
     /// Search issues using JQL or filter parameters
     #[command(
-        long_about = "Search issues using JQL or filter parameters.\n\nExamples:\n  jira issue search --project PROJ --status Open\n  jira issue search --assignee @me --priority High\n  jira issue search --jql 'project = PROJ AND status = Open ORDER BY created DESC'\n  jira issue search --status Open --status \"In Progress\" --limit 50"
+        long_about = "Search issues using JQL or filter parameters.\n\nExamples:\n  \
+        jira issue search --project PROJ --status Open\n  \
+        jira issue search --assignee @me --priority High\n  \
+        jira issue search --jql 'project = PROJ AND status = Open ORDER BY created DESC'\n  \
+        jira issue search --status Open --status \"In Progress\" --limit 50\n  \
+        jira issue search --project PROJ --fields status,\"Story Points\" --format csv\n\n\
+        --fields replaces the default columns rather than adding to them, and accepts field\n\
+        ids, the display names shown by `jira fields list`, or `all`. Columns come back in\n\
+        the order you ask for them, with key always first."
     )]
     Search {
         /// Raw JQL query (conflicts with filter flags)
@@ -141,12 +150,32 @@ enum IssueCommands {
         /// Maximum number of issues to return
         #[arg(long, default_value_t = 25)]
         limit: usize,
+
+        /// Fields to return: ids or names from `jira fields list`, or `all`
+        #[arg(long, value_delimiter = ',', value_name = "FIELD")]
+        fields: Vec<String>,
     },
 
     /// Fetch a single issue
+    #[command(long_about = "Fetch a single issue.\n\nExamples:\n  \
+        jira issue get DEV-123\n  \
+        jira issue get DEV-123 --fields summary,status\n  \
+        jira issue get DEV-123 --fields \"Story Points\" --format json\n  \
+        jira issue get DEV-123 --fields all --format json\n\n\
+        --fields accepts field ids (summary, customfield_10016) and the display names shown\n\
+        by `jira fields list`, matched without regard to case. Columns come back in the\n\
+        order you ask for them. `all` returns every field Jira will give.\n\n\
+        Without --fields the curated view is unchanged. With it you get exactly the fields\n\
+        you asked for, so the description and attachment sections are not added back.\n\
+        JSON and YAML return Jira's values untouched; the table, CSV and markdown formats\n\
+        flatten wrapper objects to their label.")]
     Get {
         /// Issue key (e.g. DEV-123)
         key: String,
+
+        /// Fields to return: ids or names from `jira fields list`, or `all`
+        #[arg(long, value_delimiter = ',', value_name = "FIELD")]
+        fields: Vec<String>,
     },
 
     /// List the transitions currently available on an issue
@@ -949,6 +978,7 @@ pub async fn execute(args: JiraArgs, client: ApiClient, renderer: &OutputRendere
                 text,
                 show_query,
                 limit,
+                fields,
             } => {
                 issues::search_issues(
                     &ctx,
@@ -962,10 +992,17 @@ pub async fn execute(args: JiraArgs, client: ApiClient, renderer: &OutputRendere
                     text.as_deref(),
                     show_query,
                     limit,
+                    &fields,
                 )
                 .await
             }
-            IssueCommands::Get { key } => issues::view_issue(&ctx, &key).await,
+            IssueCommands::Get { key, fields } => {
+                if fields.is_empty() {
+                    issues::view_issue(&ctx, &key).await
+                } else {
+                    field_selection::view_issue_fields(&ctx, &key, &fields).await
+                }
+            }
             IssueCommands::Transitions { key } => issues::list_transitions(&ctx, &key).await,
             IssueCommands::Create {
                 project,

--- a/crates/cli/tests/jira_fields_e2e.rs
+++ b/crates/cli/tests/jira_fields_e2e.rs
@@ -1,0 +1,503 @@
+//! End-to-end tests for `--fields` on `jira issue get` and `jira issue search`,
+//! driving the real binary against a mock Jira.
+//!
+//! What matters here is the request the *command* builds and the output it
+//! prints: which ids reach the `fields` parameter, whether the field list is
+//! fetched at all, and whether JSON stays lossless while the tabular formats
+//! flatten. None of that is visible from a test that drives `ApiClient`.
+
+use std::path::Path;
+use std::process::Command;
+
+use tempfile::TempDir;
+use wiremock::matchers::{method, path as path_matcher, query_param, query_param_is_missing};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+const BIN: &str = env!("CARGO_BIN_EXE_atlassian-cli");
+
+fn write_config(dir: &Path, base_url: &str) -> std::path::PathBuf {
+    let config_path = dir.join("config.yaml");
+    std::fs::write(
+        &config_path,
+        format!(
+            "default_profile: local\nprofiles:\n  local:\n    email: dev@example.com\n    base_url: {base_url}\n"
+        ),
+    )
+    .unwrap();
+    config_path
+}
+
+fn run(config: &Path, args: &[&str]) -> std::process::Output {
+    let dir = config.parent().unwrap_or_else(|| Path::new("."));
+    Command::new(BIN)
+        .arg("--config")
+        .arg(config)
+        .env("HOME", dir)
+        .env("ATLASSIAN_CLI_CONFIG_DIR", dir)
+        .env_remove("XDG_CONFIG_HOME")
+        .env_remove("ATLASSIAN_API_TOKEN")
+        .env_remove("ATLASSIAN_BITBUCKET_TOKEN")
+        .env_remove("BITBUCKET_TOKEN")
+        .env("ATLASSIAN_CLI_TOKEN_LOCAL", "fake-token")
+        .args(args)
+        .output()
+        .expect("failed to run the CLI")
+}
+
+fn stdout(out: &std::process::Output) -> String {
+    String::from_utf8_lossy(&out.stdout).to_string()
+}
+
+fn assert_ok(out: &std::process::Output) {
+    assert!(
+        out.status.success(),
+        "command failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+/// `/rest/api/3/field`, with two fields sharing a display name so the ambiguity
+/// path is reachable from the same fixture.
+async fn mock_field_list(server: &MockServer, times: u64) {
+    Mock::given(method("GET"))
+        .and(path_matcher("/rest/api/3/field"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([
+            {"id": "summary", "name": "Summary", "custom": false},
+            {"id": "status", "name": "Status", "custom": false},
+            {"id": "customfield_10016", "name": "Story Points", "custom": true},
+            {"id": "customfield_10099", "name": "Team", "custom": true},
+            {"id": "customfield_10100", "name": "Team", "custom": true},
+        ])))
+        .expect(times)
+        .mount(server)
+        .await;
+}
+
+fn issue_body(fields: serde_json::Value) -> serde_json::Value {
+    serde_json::json!({ "key": "DEV-1", "id": "10001", "fields": fields })
+}
+
+#[tokio::test]
+async fn get_with_fields_requests_only_the_resolved_ids() {
+    let server = MockServer::start().await;
+    mock_field_list(&server, 1).await;
+
+    Mock::given(method("GET"))
+        .and(path_matcher("/rest/api/3/issue/DEV-1"))
+        .and(query_param("fields", "status,customfield_10016"))
+        .respond_with(
+            ResponseTemplate::new(200).set_body_json(issue_body(serde_json::json!({
+                "status": {"name": "In Progress"},
+                "customfield_10016": 5,
+            }))),
+        )
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let dir = TempDir::new().unwrap();
+    let config = write_config(dir.path(), &server.uri());
+
+    let out = run(
+        &config,
+        &[
+            "jira",
+            "issue",
+            "get",
+            "DEV-1",
+            "--fields",
+            "status,Story Points",
+        ],
+    );
+
+    assert_ok(&out);
+    let text = stdout(&out);
+    assert!(text.contains("In Progress"), "{text}");
+    assert!(text.contains('5'), "{text}");
+}
+
+/// The fast path: nothing but custom field ids, so the field list is not worth
+/// a round trip.
+#[tokio::test]
+async fn get_with_custom_field_ids_skips_the_field_lookup() {
+    let server = MockServer::start().await;
+    mock_field_list(&server, 0).await;
+
+    Mock::given(method("GET"))
+        .and(path_matcher("/rest/api/3/issue/DEV-1"))
+        .and(query_param("fields", "customfield_10016"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_json(issue_body(serde_json::json!({ "customfield_10016": 8 }))),
+        )
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let dir = TempDir::new().unwrap();
+    let config = write_config(dir.path(), &server.uri());
+
+    let out = run(
+        &config,
+        &[
+            "jira",
+            "issue",
+            "get",
+            "DEV-1",
+            "--fields",
+            "customfield_10016",
+        ],
+    );
+
+    assert_ok(&out);
+}
+
+#[tokio::test]
+async fn get_all_asks_jira_for_every_field() {
+    let server = MockServer::start().await;
+    mock_field_list(&server, 0).await;
+
+    Mock::given(method("GET"))
+        .and(path_matcher("/rest/api/3/issue/DEV-1"))
+        .and(query_param("fields", "*all"))
+        .respond_with(
+            ResponseTemplate::new(200).set_body_json(issue_body(serde_json::json!({
+                "summary": "Everything",
+                "customfield_10016": 3,
+            }))),
+        )
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let dir = TempDir::new().unwrap();
+    let config = write_config(dir.path(), &server.uri());
+
+    let out = run(
+        &config,
+        &["jira", "issue", "get", "DEV-1", "--fields", "all"],
+    );
+
+    assert_ok(&out);
+    assert!(stdout(&out).contains("Everything"));
+}
+
+/// Without the flag, nothing changes: no `fields` parameter, and the curated
+/// view is what prints.
+#[tokio::test]
+async fn get_without_fields_sends_no_fields_parameter() {
+    let server = MockServer::start().await;
+    mock_field_list(&server, 0).await;
+
+    Mock::given(method("GET"))
+        .and(path_matcher("/rest/api/3/issue/DEV-1"))
+        .and(query_param_is_missing("fields"))
+        .respond_with(
+            ResponseTemplate::new(200).set_body_json(issue_body(serde_json::json!({
+                "summary": "Curated",
+                "status": {"name": "Open"},
+                "reporter": {"displayName": "Ada"},
+            }))),
+        )
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let dir = TempDir::new().unwrap();
+    let config = write_config(dir.path(), &server.uri());
+
+    let out = run(
+        &config,
+        &["jira", "issue", "get", "DEV-1", "--format", "markdown"],
+    );
+
+    assert_ok(&out);
+    let text = stdout(&out);
+    // The curated markdown view, which --fields deliberately does not produce.
+    assert!(text.contains("| Reporter |"), "{text}");
+    assert!(text.contains("## Description"), "{text}");
+}
+
+/// JSON must be exactly what Jira sent. Flattening there would make the format
+/// people pipe into `jq` the lossy one.
+#[tokio::test]
+async fn get_json_keeps_the_raw_field_value() {
+    let server = MockServer::start().await;
+    // `customfield_10099` is already an id, so no field list is fetched.
+    mock_field_list(&server, 0).await;
+
+    Mock::given(method("GET"))
+        .and(path_matcher("/rest/api/3/issue/DEV-1"))
+        .and(query_param("fields", "customfield_10099"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(issue_body(
+            serde_json::json!({ "customfield_10099": {"value": "Internal", "id": "42"} }),
+        )))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let dir = TempDir::new().unwrap();
+    let config = write_config(dir.path(), &server.uri());
+
+    let out = run(
+        &config,
+        &[
+            "jira",
+            "issue",
+            "get",
+            "DEV-1",
+            "--fields",
+            "customfield_10099",
+            "--format",
+            "json",
+        ],
+    );
+
+    assert_ok(&out);
+    let parsed: serde_json::Value = serde_json::from_str(&stdout(&out)).expect("stdout is JSON");
+    assert_eq!(
+        parsed["customfield_10099"],
+        serde_json::json!({"value": "Internal", "id": "42"}),
+        "the wrapper object should survive untouched"
+    );
+    assert_eq!(parsed["key"], serde_json::json!("DEV-1"));
+}
+
+/// The same payload in a table shows the label, not the JSON.
+#[tokio::test]
+async fn get_table_flattens_a_wrapper_object_to_its_label() {
+    let server = MockServer::start().await;
+    // `customfield_10099` is already an id, so no field list is fetched.
+    mock_field_list(&server, 0).await;
+
+    Mock::given(method("GET"))
+        .and(path_matcher("/rest/api/3/issue/DEV-1"))
+        .and(query_param("fields", "customfield_10099"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(issue_body(
+            serde_json::json!({ "customfield_10099": {"value": "Internal", "id": "42"} }),
+        )))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let dir = TempDir::new().unwrap();
+    let config = write_config(dir.path(), &server.uri());
+
+    let out = run(
+        &config,
+        &[
+            "jira",
+            "issue",
+            "get",
+            "DEV-1",
+            "--fields",
+            "customfield_10099",
+        ],
+    );
+
+    assert_ok(&out);
+    let text = stdout(&out);
+    assert!(text.contains("Internal"), "{text}");
+    assert!(!text.contains("{\"value\""), "raw JSON in a table: {text}");
+}
+
+/// An unknown name is caught before the issue is fetched, so the user is not
+/// billed a request to be told they made a typo.
+#[tokio::test]
+async fn an_unknown_field_name_fails_before_any_issue_request() {
+    let server = MockServer::start().await;
+    mock_field_list(&server, 1).await;
+
+    Mock::given(method("GET"))
+        .and(path_matcher("/rest/api/3/issue/DEV-1"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(issue_body(serde_json::json!({}))))
+        .expect(0)
+        .mount(&server)
+        .await;
+
+    let dir = TempDir::new().unwrap();
+    let config = write_config(dir.path(), &server.uri());
+
+    let out = run(
+        &config,
+        &["jira", "issue", "get", "DEV-1", "--fields", "stroy points"],
+    );
+
+    assert!(!out.status.success(), "an unknown field should fail");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(stderr.contains("stroy points"), "{stderr}");
+    assert!(stderr.contains("jira fields list"), "{stderr}");
+}
+
+/// Two fields named "Team" hold different values, so guessing is not an option.
+#[tokio::test]
+async fn an_ambiguous_field_name_lists_the_candidate_ids() {
+    let server = MockServer::start().await;
+    mock_field_list(&server, 1).await;
+
+    Mock::given(method("GET"))
+        .and(path_matcher("/rest/api/3/issue/DEV-1"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(issue_body(serde_json::json!({}))))
+        .expect(0)
+        .mount(&server)
+        .await;
+
+    let dir = TempDir::new().unwrap();
+    let config = write_config(dir.path(), &server.uri());
+
+    let out = run(
+        &config,
+        &["jira", "issue", "get", "DEV-1", "--fields", "Team"],
+    );
+
+    assert!(!out.status.success(), "an ambiguous field should fail");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(stderr.contains("ambiguous"), "{stderr}");
+    assert!(stderr.contains("customfield_10099"), "{stderr}");
+    assert!(stderr.contains("customfield_10100"), "{stderr}");
+}
+
+fn search_response() -> serde_json::Value {
+    serde_json::json!({
+        "issues": [
+            {
+                "key": "DEV-1",
+                "fields": {
+                    "summary": "First",
+                    "status": {"name": "Open"},
+                    "customfield_10016": 5,
+                }
+            },
+            {
+                "key": "DEV-2",
+                "fields": {
+                    "summary": "Second",
+                    "status": {"name": "Done"},
+                }
+            }
+        ],
+        "isLast": true
+    })
+}
+
+/// The default five columns, unchanged.
+#[tokio::test]
+async fn search_without_fields_keeps_the_default_columns() {
+    let server = MockServer::start().await;
+    mock_field_list(&server, 0).await;
+
+    Mock::given(method("GET"))
+        .and(path_matcher("/rest/api/3/search/jql"))
+        .and(query_param(
+            "fields",
+            "key,summary,status,assignee,issuetype",
+        ))
+        .respond_with(ResponseTemplate::new(200).set_body_json(search_response()))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let dir = TempDir::new().unwrap();
+    let config = write_config(dir.path(), &server.uri());
+
+    let out = run(
+        &config,
+        &[
+            "jira",
+            "issue",
+            "search",
+            "--jql",
+            "project = DEV",
+            "--format",
+            "csv",
+        ],
+    );
+
+    assert_ok(&out);
+    let text = stdout(&out);
+    let header = text.lines().next().unwrap_or_default();
+    assert_eq!(header, "assignee,issue_type,key,status,summary", "{text}");
+}
+
+/// `--fields` replaces those columns, and the order typed is the order printed.
+/// Alphabetical sorting would have put `key,status,Story Points` in a different
+/// order every time the selection changed.
+#[tokio::test]
+async fn search_with_fields_replaces_the_columns_and_keeps_their_order() {
+    let server = MockServer::start().await;
+    mock_field_list(&server, 1).await;
+
+    Mock::given(method("GET"))
+        .and(path_matcher("/rest/api/3/search/jql"))
+        .and(query_param("fields", "status,customfield_10016"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(search_response()))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let dir = TempDir::new().unwrap();
+    let config = write_config(dir.path(), &server.uri());
+
+    let out = run(
+        &config,
+        &[
+            "jira",
+            "issue",
+            "search",
+            "--jql",
+            "project = DEV",
+            "--fields",
+            "status,Story Points",
+            "--format",
+            "csv",
+        ],
+    );
+
+    assert_ok(&out);
+    let text = stdout(&out);
+    let lines: Vec<&str> = text.lines().map(str::trim).collect();
+    assert_eq!(lines[0], "key,status,Story Points");
+    assert_eq!(lines[1], "DEV-1,Open,5");
+    // DEV-2 has no story points: an empty cell, not a missing column.
+    assert_eq!(lines[2], "DEV-2,Done,");
+}
+
+#[tokio::test]
+async fn search_with_fields_json_keeps_raw_values() {
+    let server = MockServer::start().await;
+    mock_field_list(&server, 1).await;
+
+    Mock::given(method("GET"))
+        .and(path_matcher("/rest/api/3/search/jql"))
+        .and(query_param("fields", "status"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(search_response()))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let dir = TempDir::new().unwrap();
+    let config = write_config(dir.path(), &server.uri());
+
+    let out = run(
+        &config,
+        &[
+            "jira",
+            "issue",
+            "search",
+            "--jql",
+            "project = DEV",
+            "--fields",
+            "status",
+            "--format",
+            "json",
+        ],
+    );
+
+    assert_ok(&out);
+    let parsed: serde_json::Value = serde_json::from_str(&stdout(&out)).expect("stdout is JSON");
+    assert_eq!(
+        parsed[0]["status"],
+        serde_json::json!({"name": "Open"}),
+        "the status object should survive untouched"
+    );
+}

--- a/crates/cli/tests/jira_fields_e2e.rs
+++ b/crates/cli/tests/jira_fields_e2e.rs
@@ -357,6 +357,81 @@ async fn an_ambiguous_field_name_lists_the_candidate_ids() {
     assert!(stderr.contains("customfield_10100"), "{stderr}");
 }
 
+/// `--fields ""` and `--fields ,` are a mistake, and the user should be told
+/// before paying for a field-list request that cannot help.
+#[tokio::test]
+async fn a_blank_field_list_fails_without_calling_jira_at_all() {
+    for argument in ["", ",", "  "] {
+        let server = MockServer::start().await;
+        mock_field_list(&server, 0).await;
+
+        Mock::given(method("GET"))
+            .and(path_matcher("/rest/api/3/issue/DEV-1"))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_json(issue_body(serde_json::json!({}))),
+            )
+            .expect(0)
+            .mount(&server)
+            .await;
+
+        let dir = TempDir::new().unwrap();
+        let config = write_config(dir.path(), &server.uri());
+
+        let out = run(
+            &config,
+            &["jira", "issue", "get", "DEV-1", "--fields", argument],
+        );
+
+        assert!(!out.status.success(), "'{argument}' should fail");
+        assert!(
+            String::from_utf8_lossy(&out.stderr).contains("no field names"),
+            "{}",
+            String::from_utf8_lossy(&out.stderr)
+        );
+    }
+}
+
+/// An id and its display name are the same field, and must reach Jira once.
+#[tokio::test]
+async fn the_same_field_twice_is_requested_once() {
+    let server = MockServer::start().await;
+    mock_field_list(&server, 1).await;
+
+    Mock::given(method("GET"))
+        .and(path_matcher("/rest/api/3/issue/DEV-1"))
+        .and(query_param("fields", "customfield_10016"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_json(issue_body(serde_json::json!({ "customfield_10016": 5 }))),
+        )
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let dir = TempDir::new().unwrap();
+    let config = write_config(dir.path(), &server.uri());
+
+    let out = run(
+        &config,
+        &[
+            "jira",
+            "issue",
+            "get",
+            "DEV-1",
+            "--fields",
+            "customfield_10016,Story Points",
+        ],
+    );
+
+    assert_ok(&out);
+    let text = stdout(&out);
+    assert_eq!(
+        text.matches('5').count(),
+        1,
+        "the value should appear in one column only: {text}"
+    );
+}
+
 fn search_response() -> serde_json::Value {
     serde_json::json!({
         "issues": [
@@ -460,6 +535,67 @@ async fn search_with_fields_replaces_the_columns_and_keeps_their_order() {
     assert_eq!(lines[1], "DEV-1,Open,5");
     // DEV-2 has no story points: an empty cell, not a missing column.
     assert_eq!(lines[2], "DEV-2,Done,");
+}
+
+/// An empty result must look the same with `--fields` as without it. #110 was
+/// this exact inconsistency across ~70 list commands: prose for the formats
+/// people read, nothing for the line-oriented ones, `[]` only for JSON and YAML.
+#[tokio::test]
+async fn an_empty_result_matches_the_other_list_commands() {
+    let server = MockServer::start().await;
+    // One per format below: the lookup is not cached across processes.
+    mock_field_list(&server, 5).await;
+
+    Mock::given(method("GET"))
+        .and(path_matcher("/rest/api/3/search/jql"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "issues": [], "isLast": true
+        })))
+        .mount(&server)
+        .await;
+
+    // `search_issues` verifies auth when a result is empty, to tell an empty
+    // project from a broken token.
+    Mock::given(method("GET"))
+        .and(path_matcher("/rest/api/3/myself"))
+        .respond_with(
+            ResponseTemplate::new(200).set_body_json(serde_json::json!({"accountId": "abc"})),
+        )
+        .mount(&server)
+        .await;
+
+    let dir = TempDir::new().unwrap();
+    let config = write_config(dir.path(), &server.uri());
+
+    for (format, expected) in [
+        ("table", "No issues found"),
+        ("markdown", "No issues found"),
+        ("csv", ""),
+        ("quiet", ""),
+        ("json", "[]"),
+    ] {
+        let out = run(
+            &config,
+            &[
+                "jira",
+                "issue",
+                "search",
+                "--jql",
+                "project = DEV",
+                "--fields",
+                "status",
+                "--format",
+                format,
+            ],
+        );
+
+        assert_ok(&out);
+        assert_eq!(
+            stdout(&out).trim(),
+            expected,
+            "--format {format} should print {expected:?}"
+        );
+    }
 }
 
 #[tokio::test]

--- a/crates/output/src/lib.rs
+++ b/crates/output/src/lib.rs
@@ -144,8 +144,48 @@ impl OutputRenderer {
         self.render_list(items)
     }
 
+    /// Render rows with the columns given, in the order given.
+    ///
+    /// `render` derives columns as the sorted union of the rows' keys, which is
+    /// right when the caller has no opinion about them. A caller who let the
+    /// user choose does have one: `jira issue search --fields status,summary`
+    /// should read back in that order, and alphabetical sorting would silently
+    /// reverse it.
+    ///
+    /// Only the tabular formats take the order. JSON and YAML go through the
+    /// untouched path, because `serde_json::Map` is a `BTreeMap` and their key
+    /// order is alphabetical no matter what we do here.
+    pub fn render_rows_ordered(&self, rows: &[Value], columns: &[String]) -> Result<()> {
+        let value = Value::Array(rows.to_vec());
+
+        match self.format {
+            OutputFormat::Table => {
+                if !self.render_table_with(&value, Some(columns))? {
+                    println!("{}", serde_json::to_string_pretty(&value)?);
+                }
+            }
+            OutputFormat::Csv => {
+                if !self.render_csv_with(&value, Some(columns))? {
+                    println!("{}", serde_json::to_string_pretty(&value)?);
+                }
+            }
+            OutputFormat::Markdown => {
+                if !self.render_markdown_table_with(&value, Some(columns))? {
+                    self.render_markdown_single(&value)?;
+                }
+            }
+            _ => self.render(&value)?,
+        }
+
+        Ok(())
+    }
+
     fn render_table(&self, value: &Value) -> Result<bool> {
-        let (headers, rows) = match Self::coerce_rows(value) {
+        self.render_table_with(value, None)
+    }
+
+    fn render_table_with(&self, value: &Value, columns: Option<&[String]>) -> Result<bool> {
+        let (headers, rows) = match Self::coerce_rows_with(value, columns) {
             Some(data) => data,
             None => return Ok(false),
         };
@@ -162,7 +202,11 @@ impl OutputRenderer {
     }
 
     fn render_csv(&self, value: &Value) -> Result<bool> {
-        let (headers, rows) = match Self::coerce_rows(value) {
+        self.render_csv_with(value, None)
+    }
+
+    fn render_csv_with(&self, value: &Value, columns: Option<&[String]>) -> Result<bool> {
+        let (headers, rows) = match Self::coerce_rows_with(value, columns) {
             Some(data) => data,
             None => return Ok(false),
         };
@@ -242,7 +286,15 @@ impl OutputRenderer {
     }
 
     fn render_markdown_table(&self, value: &Value) -> Result<bool> {
-        let (headers, rows) = match Self::coerce_rows(value) {
+        self.render_markdown_table_with(value, None)
+    }
+
+    fn render_markdown_table_with(
+        &self,
+        value: &Value,
+        columns: Option<&[String]>,
+    ) -> Result<bool> {
+        let (headers, rows) = match Self::coerce_rows_with(value, columns) {
             Some(data) => data,
             None => return Ok(false),
         };
@@ -300,24 +352,45 @@ impl OutputRenderer {
         }
     }
 
+    /// Headers as the sorted union of every row's keys. The shape all ~70 list
+    /// commands use; only field selection passes explicit columns.
+    #[cfg(test)]
     fn coerce_rows(value: &Value) -> Option<(Vec<String>, Vec<Vec<String>>)> {
+        Self::coerce_rows_with(value, None)
+    }
+
+    /// Flatten an array of objects into headers and string cells.
+    ///
+    /// With `columns`, those are the headers verbatim: keys not listed are
+    /// dropped and listed keys missing from a row render empty, the same as any
+    /// other absent key. Without them, headers are the sorted union of every
+    /// row's keys, which is what all ~70 existing list commands rely on.
+    fn coerce_rows_with(
+        value: &Value,
+        columns: Option<&[String]>,
+    ) -> Option<(Vec<String>, Vec<Vec<String>>)> {
         let rows = match value {
             Value::Array(rows) if !rows.is_empty() => rows,
             _ => return None,
         };
 
-        let mut headers = BTreeSet::new();
-        for row in rows {
-            if let Value::Object(obj) = row {
-                headers.extend(obj.keys().cloned());
+        let headers_vec: Vec<String> = match columns {
+            Some(columns) => columns.to_vec(),
+            None => {
+                let mut headers = BTreeSet::new();
+                for row in rows {
+                    if let Value::Object(obj) = row {
+                        headers.extend(obj.keys().cloned());
+                    }
+                }
+                headers.into_iter().collect()
             }
-        }
+        };
 
-        if headers.is_empty() {
+        if headers_vec.is_empty() {
             return None;
         }
 
-        let headers_vec: Vec<String> = headers.into_iter().collect();
         let mut data = Vec::with_capacity(rows.len());
         for row in rows {
             let mut record = Vec::with_capacity(headers_vec.len());
@@ -414,6 +487,56 @@ mod tests {
     fn test_coerce_rows_not_array() {
         let value = json!({"id": "1", "name": "Alice"});
         assert!(OutputRenderer::coerce_rows(&value).is_none());
+    }
+
+    /// The default contract, pinned so field selection cannot change it for the
+    /// ~70 commands that derive their own columns.
+    #[test]
+    fn coerce_rows_without_columns_sorts_headers_alphabetically() {
+        let value = json!([{"zebra": "1", "apple": "2"}]);
+        let (headers, _) = OutputRenderer::coerce_rows(&value).unwrap();
+        assert_eq!(headers, vec!["apple".to_string(), "zebra".to_string()]);
+    }
+
+    /// The whole point of the explicit form: the user typed an order.
+    #[test]
+    fn coerce_rows_with_columns_preserves_the_given_order() {
+        let value = json!([{"apple": "2", "zebra": "1"}]);
+        let columns = vec!["zebra".to_string(), "apple".to_string()];
+
+        let (headers, rows) = OutputRenderer::coerce_rows_with(&value, Some(&columns)).unwrap();
+
+        assert_eq!(headers, columns);
+        assert_eq!(rows[0], vec!["1".to_string(), "2".to_string()]);
+    }
+
+    #[test]
+    fn coerce_rows_with_columns_drops_keys_not_listed() {
+        let value = json!([{"wanted": "yes", "unwanted": "no"}]);
+        let columns = vec!["wanted".to_string()];
+
+        let (headers, rows) = OutputRenderer::coerce_rows_with(&value, Some(&columns)).unwrap();
+
+        assert_eq!(headers, columns);
+        assert_eq!(rows[0], vec!["yes".to_string()]);
+    }
+
+    /// A field the site does not have, or that the API omitted, is an empty
+    /// cell rather than a missing column or an error.
+    #[test]
+    fn coerce_rows_with_columns_fills_absent_keys_with_empty() {
+        let value = json!([{"present": "here"}]);
+        let columns = vec!["present".to_string(), "absent".to_string()];
+
+        let (_, rows) = OutputRenderer::coerce_rows_with(&value, Some(&columns)).unwrap();
+
+        assert_eq!(rows[0], vec!["here".to_string(), String::new()]);
+    }
+
+    #[test]
+    fn coerce_rows_with_empty_columns_renders_nothing() {
+        let value = json!([{"id": "1"}]);
+        assert!(OutputRenderer::coerce_rows_with(&value, Some(&[])).is_none());
     }
 
     #[test]

--- a/docs/26082026_jira_field_selection.md
+++ b/docs/26082026_jira_field_selection.md
@@ -1,0 +1,220 @@
+# `--fields` on `jira issue get` and `jira issue search`
+
+Status: in progress on `feat/jira-field-selection` (issue #132).
+
+## Problem
+
+`jira issue get` deserialized eight named fields and discarded everything else,
+even though it sent no `fields` parameter and so received every navigable field
+Jira had. `jira issue search` asked for a hardcoded
+`fields=key,summary,status,assignee,issuetype`.
+
+Custom fields, which is where most teams keep the data they actually care about,
+were unreachable. The only workaround was `jira api /rest/api/3/issue/KEY`, which
+returns the raw payload and loses every convenience of the command.
+
+Reported in #132, which also asked for display names rather than
+`customfield_10016`, since nobody knows their own site's field ids.
+
+## Surface
+
+```bash
+jira issue get DEV-123 --fields summary,status
+jira issue get DEV-123 --fields "Story Points" --format json
+jira issue get DEV-123 --fields all --format json
+jira issue search --project DEV --fields status,"Story Points" --format csv
+```
+
+One flag, `--fields`, on both commands. `Vec<String>` with
+`value_delimiter = ','`, so `--fields a,b`, `--fields a --fields b` and a mix all
+work, matching `jira bulk export --fields`.
+
+Not `--field`: on `issue create` and `issue update` that already means *set*
+`KEY=JSON_VALUE`. Reusing the singular for *select* would be a real footgun.
+
+**`all` is the documented spelling for everything.** A bare `*all` is a glob, and
+zsh refuses the whole command line with "no matches found" before the CLI starts.
+Any token already starting with `*` or `-` is passed to Jira untouched, so
+`--fields '*navigable'` and the exclusion form `--fields '*all,-comment'` work at
+no extra cost.
+
+On `search`, `--fields` **replaces** the default five columns rather than adding
+to them, otherwise narrowing output would be impossible. `key` is always the
+first column and is never duplicated.
+
+**Without `--fields`, both commands behave exactly as before**, pinned by test.
+
+## Design notes
+
+### A separate raw path, not `#[serde(flatten)]`
+
+`IssueFields` is strongly typed with no catch-all. Adding
+`#[serde(flatten)] extra: BTreeMap<String, Value>` was rejected twice over:
+
+- The default `jira issue get` sends no `fields` parameter and so receives the
+  entire issue, comments and worklogs included. Flatten would allocate and retain
+  all of it on every plain `get`, for output that discards it.
+- It collides with the existing `#[serde(rename = "customfield_10020")] sprint`.
+  That key would be consumed by `sprint` and therefore missing from `extra`, so
+  `--fields customfield_10020` would silently return nothing.
+
+`--fields` instead takes its own path over
+`RawIssue { key: String, fields: serde_json::Map<String, Value> }`. The existing
+types and render paths are not edited at all, so the default output is unchanged
+by construction rather than by review. `jira bulk export` already worked this
+way.
+
+Jira does the projection server-side, so nothing unrequested is downloaded.
+
+### Name resolution, and why ambiguity is an error
+
+`GET /rest/api/3/field` is fetched only when a token could be a display name,
+which means unless every token matches `customfield_<digits>`. That is the only
+shape that is unambiguously an id: `summary` and `status` are ids too, but a site
+can perfectly well have a custom field named "Status", and nothing local can tell
+the difference.
+
+Matching is, per token: wildcard passthrough, then case-insensitive exact match
+on `id`, then case-insensitive exact match on `name`. An id wins over a custom
+field sharing its display name, or every existing script would quietly start
+reading a different field.
+
+**Several fields sharing a name is the normal state of a mature Jira site**, and
+the copies belong to different screens and hold different values. Picking one
+would be wrong in a way the output cannot show, so it is an error listing every
+candidate:
+
+```
+Field name 'Story Points' is ambiguous on this site. Candidates:
+  customfield_10016  Story Points
+  customfield_10032  Story Points
+Pass the id instead, for example --fields customfield_10016.
+```
+
+Unknown names and ambiguous names both fail before the issue is fetched, so a
+typo does not cost a request.
+
+No prefix or fuzzy matching. Partial matches against a 300-field list produce
+confident wrong answers, and this flag feeds scripts.
+
+Output keys are the token as typed, so the table header and the JSON key always
+agree. The cost, worth knowing: a display name with a space is awkward under
+`jq` (`jq '.["Story Points"]'`), and the fix is to pass the id.
+
+A requested field the response does not carry is an empty cell and a
+`tracing::warn!`, not an error. Issue types differ in which fields they have, so
+erroring would make any wide selection unusable across a mixed result set.
+
+### Column order
+
+`coerce_rows` derives columns as an alphabetical `BTreeSet` union, and
+`serde_json::Map` is a `BTreeMap`, so `--fields status,summary` would have
+printed `summary` first.
+
+Enabling `serde_json/preserve_order` was rejected: it would change JSON, YAML,
+CSV and table key order for all ~70 existing commands, breaking `--format csv`
+consumers as a side effect of a Jira feature, and it would not even fix this,
+since `coerce_rows` re-sorts regardless.
+
+Instead `crates/output` gained one public method,
+`OutputRenderer::render_rows_ordered(rows, columns)`, backed by
+`coerce_rows_with(value, Option<&[String]>)`. `coerce_rows(value)` is unchanged
+behaviour, so every existing call site and test is untouched. When columns are
+given they are authoritative: unlisted keys are dropped, listed-but-missing
+render empty. JSON and YAML are deliberately left alone, because their key order
+is alphabetical no matter what we do.
+
+`jira issue get --fields` sidesteps ordering entirely by rendering the tabular
+formats as a two-column vertical table of field and value, which is also far more
+readable than a twelve-column horizontal scroll:
+
+```
+╭──────────────┬─────────────────────╮
+│ field        │ value               │
+├──────────────┼─────────────────────┤
+│ key          │ DEV-1               │
+│ summary      │ Fix the login error │
+│ Story Points │ 5                   │
+│ Department   │ Platform            │
+╰──────────────┴─────────────────────╯
+```
+
+Its JSON and YAML stay a flat object, since an array of field/value pairs would
+be hostile to `jq`.
+
+### Flattening is a rendering decision only
+
+A custom field value is nearly always a wrapper object: a select option is
+`{"value":"Internal"}`, a user is `{"displayName":"Ada"}`, a priority or sprint
+is `{"name":"High"}`. Printing the JSON into a table cell is lossless and
+unreadable.
+
+`friendly_scalar` handles the table, CSV and markdown formats only: scalars pass
+through, rich text goes through the existing ADF extractor, other objects take
+the first non-empty string among `displayName`, `name`, `value`, `filename`,
+`key`, and arrays map one level and join with `, `. Anything unrecognised falls
+back to compact JSON, so data is never lost.
+
+`value_to_string` in `crates/output` was deliberately not taught any of this: it
+serves Bitbucket and Confluence too, where `{"value": ...}` means nothing in
+particular.
+
+**JSON and YAML never call it and are byte for byte what Jira sent.** The format
+people pipe into `jq` must not be the lossy one.
+
+### The curated markdown view
+
+`view_issue`'s hand-built markdown is not reached when `--fields` is given:
+dispatch routes to `view_issue_fields` first, so the curated path is untouched
+code. The `--fields` markdown output is a `# KEY` heading plus the generic
+two-column table.
+
+Conditionally re-adding the Description and Attachments sections when the
+selection happens to include those fields would make the output shape depend on
+the selection in a way nobody can predict. `--fields` means "these and nothing
+else"; users who want the curated view omit the flag.
+
+## Limitations
+
+- **`--fields all` returns Jira's raw ids as keys** (`customfield_10016`, not
+  "Story Points"). Mapping them back would force the `/field` fetch on every
+  call and make JSON keys unstable across sites.
+- **No caching of the field list.** One `GET /rest/api/3/field` per invocation
+  that uses a display name. There is no caching infrastructure in the workspace,
+  and the config directory is deliberately limited to three files. A
+  process-lifetime cache is the next step if this is ever a complaint, not a
+  disk one.
+- **No `--expand`.** `renderedFields`, `changelog` and `names` are a separate
+  feature with a separate output shape.
+- **`--fields all` on a large search is a large response.** `--limit` (default
+  25) is the only control.
+- Not added to `issue create`/`update`, JSM or Confluence.
+
+## Tests
+
+- **Unit, `field_selection.rs`** (22): the id-only fast path and the cases that
+  must still trigger a lookup; `all` as a wildcard in any case; Jira wildcards
+  and exclusions passing through; id winning over a same-named custom field;
+  unknown name pointing at `jira fields list`; **ambiguous name listing every
+  candidate id**, which a naive `.find()` would fail; duplicate tokens collapsing
+  in place; order preserved; the full `friendly_scalar` table including ADF,
+  arrays, `displayName` preferred over a sibling `name`, and the compact-JSON
+  fallback; projection putting `key` first, not duplicating it, and yielding null
+  for an absent field.
+- **Unit, `crates/output`** (5): explicit columns preserve order, drop unlisted
+  keys and fill absent ones with empty; empty columns render nothing; and the
+  default union is still alphabetical, pinning the contract for the other ~70
+  commands.
+- **Command-level e2e, `crates/cli/tests/jira_fields_e2e.rs`** (11): only the
+  resolved ids reach the `fields` parameter; the field list is never fetched for
+  an id-only selection; `all` becomes `*all`; no `fields` parameter and the
+  curated markdown view without the flag; `--format json` keeps the raw wrapper
+  object while `--format table` shows the label; unknown and ambiguous names fail
+  with the issue mock hit zero times; the default search columns are unchanged;
+  and `--fields` replaces them with the CSV header exactly
+  `key,status,Story Points`, an absent value rendering as an empty cell.
+
+Both of the load-bearing behaviours were verified by reverting them: ignoring the
+explicit columns turns the CSV header into `Story Points,key,status`, and
+replacing the ambiguity check with `.find()` makes the site silently answer with
+one of two different fields.

--- a/docs/26082026_jira_field_selection.md
+++ b/docs/26082026_jira_field_selection.md
@@ -174,6 +174,28 @@ selection happens to include those fields would make the output shape depend on
 the selection in a way nobody can predict. `--fields` means "these and nothing
 else"; users who want the curated view omit the flag.
 
+### Found in self-review, after the first pass
+
+Three defects surfaced by running the built binary against a mock Jira and
+reading what it actually sent, rather than by reading the code:
+
+- **A blank selection cost a request.** `--fields ""` and `--fields ,` reach the
+  resolver as empty tokens, which are not custom field ids, so the field list
+  was fetched before the "no field names" error. Now checked first.
+- **Two spellings of one field became two columns.** `--fields summary,Summary`
+  and `--fields customfield_10016,"Story Points"` sent the id to Jira twice and
+  printed the same value twice, because duplicates were detected on the token
+  rather than on the resolved id.
+- **An empty result printed `[]`.** Under table, CSV, markdown and quiet, a
+  search returning nothing printed `[]`, where every other list command prints
+  "No issues found" for the formats people read and nothing at all for the
+  line-oriented ones. That is exactly the inconsistency #110 fixed across ~70
+  commands, reintroduced on a new path. The empty case now goes through the same
+  `render_list_or_empty` helper.
+
+A wildcard mixed with named fields (`--fields all,summary`) now warns: Jira reads
+it as everything, so the named fields do not narrow anything.
+
 ## Limitations
 
 - **`--fields all` returns Jira's raw ids as keys** (`customfield_10016`, not

--- a/docs/c4model.md
+++ b/docs/c4model.md
@@ -208,6 +208,9 @@ one atomic rename, then the original is renamed to `.migrated`.
   `JiraAttachment` model used by `issues.rs` for `issue get`
 - `projects.rs` - Project management, roles
 - `fields_workflows.rs` - Custom fields, workflow transitions
+- `field_selection.rs` - `--fields` on `issue get`/`issue search`: display name to
+  id resolution via `/rest/api/3/field`, ordered projection, and value flattening
+  for the tabular formats only
 - `automation.rs` - Automation rules management
 - `webhooks.rs` - Webhook CRUD
 - `audit.rs` - Audit log retrieval

--- a/docs/index.md
+++ b/docs/index.md
@@ -45,6 +45,7 @@ changes made, newest last; `docs/todo.md` is the forward-looking roadmap.
 
 | Document | Date | What it covers |
 | --- | --- | --- |
+| [26082026_jira_field_selection.md](26082026_jira_field_selection.md) | 2026-08-26 | `--fields` on `jira issue get` and `search`: ids or display names, ordered columns, and ordered rendering in `crates/output` |
 | [26082026_auth_product_dispatch.md](26082026_auth_product_dispatch.md) | 2026-08-26 | `auth whoami`/`test`/`status` dispatch on the profile's product, the `--space` filter fix, and 401s that keep the server's reason |
 | [16082026_bb_pr_reviewer_status.md](16082026_bb_pr_reviewer_status.md) | 2026-08-16 | `bb pr reviewers` listing with approval status, `--all`, and the `--add` endpoint fix |
 | [23082026_xdg_config_paths.md](23082026_xdg_config_paths.md) | 2026-08-23 | XDG config directory resolution, `--config-dir`, legacy migration and 0600/0700 permissions |

--- a/todo.md
+++ b/todo.md
@@ -1777,3 +1777,11 @@ Verified live against a local mock Jira: only the resolved ids reach the wire (`
 Both load-bearing behaviours were verified by reverting them: ignoring the explicit columns turns the CSV header into `Story Points,key,status`, and replacing the ambiguity check with `.find()` makes the site answer silently with one of two different fields.
 
 775 tests pass. Documented in `docs/26082026_jira_field_selection.md`, with `docs/index.md`, `docs/c4model.md` and README updated.
+
+Self-review of the above, by running the binary against a mock Jira and reading what it actually sent, found three defects the tests had not:
+
+- `--fields ""` and `--fields ,` fetched the field list before erroring, since an empty token is not a custom field id. Now rejected before any request.
+- `--fields summary,Summary` sent `fields=summary,summary` and printed two identical columns: duplicates were detected on the token, not the resolved id.
+- An empty search result printed `[]` under table, CSV, markdown and quiet, where every other list command prints "No issues found" or nothing. That is #110 reintroduced on a new path; the empty case now goes through `render_list_or_empty`.
+
+Each has a test verified to fail against the pre-fix code. A wildcard mixed with named fields now warns, since Jira reads `*all,summary` as everything. 779 tests pass.

--- a/todo.md
+++ b/todo.md
@@ -1758,3 +1758,22 @@ Each was reproduced first, and each fix has a test proved to fail without it.
 Documented in `docs/26082026_auth_product_dispatch.md`, including the limitation the heuristic cannot fix: a Confluence-only profile whose `base_url` is the plain site is indistinguishable from a Jira one.
 
 Worth its own issue: a `base_url` ending in `/wiki` still breaks every other Confluence command, which build `/wiki/api/v2/...` themselves and hit the same doubling. `auth login` should normalise the suffix off at save time.
+
+### Issue #132: `--fields` on `jira issue get` and `jira issue search`
+
+`jira issue get` sent no `fields` parameter, so Jira returned every navigable field and serde discarded all but eight of them. `jira issue search` asked for a hardcoded five. Custom fields, where most teams keep the data they care about, were unreachable without dropping to `jira api`.
+
+- One flag, `--fields`, comma-separated and repeatable, on both commands. Accepts field ids, the display names from `jira fields list`, and `all`. Not `--field`: that already means *set* `KEY=JSON_VALUE` on create and update, and reusing the singular for select would be a footgun.
+- `all` rather than `*all` as the documented spelling, because a bare `*all` is a glob and zsh refuses the command line before the CLI starts. Tokens already starting with `*` or `-` pass through, so `'*navigable'` and `'*all,-comment'` work for free.
+- **Rejected `#[serde(flatten)]` on `IssueFields`** twice over: the default `get` receives the whole issue, comments and worklogs included, so flatten would retain all of it for output that discards it; and it collides with the existing `customfield_10020` rename, whose key would be consumed by `sprint` and therefore missing from the map, so `--fields customfield_10020` would silently return nothing. `--fields` takes its own path over raw JSON instead, which leaves the default output unchanged by construction rather than by review.
+- **An ambiguous display name is an error listing every candidate id.** Several fields named "Story Points" is the normal state of a mature Jira site, and they hold different numbers, so picking one would be wrong in a way the output cannot show. Unknown and ambiguous names both fail before the issue is fetched.
+- The field list is fetched only when a token could be a name, meaning unless every token is `customfield_<digits>`. That is the only shape that is unambiguously an id: a site can have a custom field named "Status".
+- **Column order needed the shared renderer.** `coerce_rows` unions keys into an alphabetical `BTreeSet`, so `--fields status,summary` would print `summary` first. Enabling `serde_json/preserve_order` was rejected: it would change key order for all ~70 commands and break `--format csv` consumers as a side effect of a Jira feature, and would not even fix this since `coerce_rows` re-sorts anyway. Added `render_rows_ordered` and `coerce_rows_with(value, Option<&[String]>)`; the no-columns path is byte-identical, pinned by a test.
+- **Flattening is a rendering decision only.** Wrapper objects (`{"value":"Internal"}`, `{"displayName":"Ada"}`) become their label in table, CSV and markdown. JSON and YAML are byte for byte what Jira sent: the format people pipe into `jq` must not be the lossy one. `value_to_string` in `crates/output` was left alone; it serves Bitbucket and Confluence, where `{"value":...}` means nothing in particular.
+- `jira issue get --fields` renders as a two-column vertical table, which avoids the ordering problem entirely and reads better than a twelve-column scroll.
+
+Verified live against a local mock Jira: only the resolved ids reach the wire (`fields=summary%2Ccustomfield_10016%2Ccustomfield_10050`), ADF descriptions extract to text, arrays join, the wrapper object flattens in the table and stays raw in JSON, CSV column order matches what was typed, an absent field warns and renders empty, and the default `get` still sends no `fields` parameter and prints the curated view.
+
+Both load-bearing behaviours were verified by reverting them: ignoring the explicit columns turns the CSV header into `Story Points,key,status`, and replacing the ambiguity check with `.find()` makes the site answer silently with one of two different fields.
+
+775 tests pass. Documented in `docs/26082026_jira_field_selection.md`, with `docs/index.md`, `docs/c4model.md` and README updated.


### PR DESCRIPTION
Closes #132.

## Problem

`jira issue get` sent no `fields` parameter, so Jira returned every navigable field and serde discarded all but eight of them. `jira issue search` asked for a hardcoded `fields=key,summary,status,assignee,issuetype`. Custom fields, which is where most teams keep the data they actually care about, were unreachable without dropping to `jira api` and losing every convenience of the command.

@oesteban-vx also asked for display names rather than `customfield_10016`, since nobody knows their own site's field ids.

## Surface

```bash
jira issue get DEV-123 --fields summary,status
jira issue get DEV-123 --fields "Story Points" --format json
jira issue get DEV-123 --fields all --format json
jira issue search --project DEV --fields status,"Story Points" --format csv
```

Comma-separated and repeatable, matching `jira bulk export --fields`. Not `--field`: on `issue create`/`update` that already means *set* `KEY=JSON_VALUE`, and reusing the singular for *select* would be a footgun.

`all` is the documented spelling for everything, because a bare `*all` is a glob and zsh refuses the whole command line before the CLI starts. Tokens already starting with `*` or `-` pass through, so `'*navigable'` and `'*all,-comment'` work for free.

**Without `--fields`, both commands behave exactly as before**, pinned by test.

## Decisions worth reviewing

**Rejected `#[serde(flatten)]` on `IssueFields`**, twice over: the default `get` receives the entire issue including comments and worklogs, so a flatten map would retain all of it for output that discards it; and it collides with the existing `#[serde(rename = "customfield_10020")] sprint`, whose key would be consumed by `sprint` and therefore be missing from the map, so `--fields customfield_10020` would silently return nothing. `--fields` takes its own path over raw JSON, so the default output is unchanged by construction rather than by review.

**An ambiguous display name is an error listing every candidate id.** Several fields named "Story Points" is the normal state of a mature Jira site, and the copies belong to different screens and hold different numbers, so picking one would be wrong in a way the output cannot show. Unknown and ambiguous names both fail before the issue is fetched.

**The field list is fetched only when a token could be a name**, meaning unless every token matches `customfield_<digits>`. That is the only unambiguous id shape: a site can perfectly well have a custom field named "Status".

**Column order needed a change in `crates/output`.** `coerce_rows` unions keys into an alphabetical `BTreeSet`, so `--fields status,summary` would have printed `summary` first. Enabling `serde_json/preserve_order` was rejected: it would change JSON, YAML, CSV and table key order for all ~70 commands and break `--format csv` consumers as a side effect of a Jira feature, and it would not even fix this since `coerce_rows` re-sorts regardless. Added `render_rows_ordered` and `coerce_rows_with(value, Option<&[String]>)`; the no-columns path is byte-identical, pinned by its own test.

**Flattening is a rendering decision only.** Wrapper objects (`{"value":"Internal"}`, `{"displayName":"Ada"}`) become their label in table, CSV and markdown. **JSON and YAML are byte for byte what Jira sent**: the format people pipe into `jq` must not be the lossy one. `value_to_string` in `crates/output` was left alone, since it also serves Bitbucket and Confluence where `{"value":...}` means nothing in particular.

`jira issue get --fields` renders as a two-column vertical table, which sidesteps ordering entirely and reads better than a twelve-column horizontal scroll.

## Verification

775 tests pass; clippy `-D warnings` clean.

- 22 unit tests in `field_selection.rs`, 5 in `crates/output`, 11 command-level wiremock tests in `crates/cli/tests/jira_fields_e2e.rs`.
- Both load-bearing behaviours were verified by reverting them: ignoring the explicit columns turns the CSV header into `Story Points,key,status`, and replacing the ambiguity check with `.find()` makes the site answer silently with one of two different fields.
- Run live against a local mock Jira: only resolved ids reach the wire (`fields=summary%2Ccustomfield_10016%2Ccustomfield_10050`), ADF descriptions extract to text, arrays join, the wrapper object flattens in the table and stays raw in JSON, CSV column order matches what was typed, an absent field warns and renders empty, and the default `get` still sends no `fields` parameter and prints the curated view.

## Limitations, stated in the doc

`--fields all` returns Jira's raw ids as keys; no caching of the field list (one GET per invocation that uses a name); no `--expand`; not added to create/update, JSM or Confluence.

Docs: `docs/26082026_jira_field_selection.md`, plus `docs/index.md`, `docs/c4model.md` and README.