### PR TITLE
fix(config): a /wiki base URL no longer doubles the segment

### DIFF
--- a/crates/cli/src/commands/auth.rs
+++ b/crates/cli/src/commands/auth.rs
@@ -368,6 +368,9 @@ fn login_jira_confluence(
     // should call, and without it they would go back to Jira's and 401. Every
     // request path is built from the site root regardless, via
     // `Profile::site_base_url`.
+    // Both sides trim trailing slashes the same way. Comparing a
+    // single-slash-trimmed string against `site_base_url`, which trims all of
+    // them, made `https://site/wiki//` look normalised when it was not.
     if site_base_url(base_url.as_str()) != base_url.as_str().trim_end_matches('/') {
         println!(
             "Note: /wiki is added automatically for Confluence requests, so it is not needed \
@@ -1109,9 +1112,6 @@ mod tests {
         assert_eq!(product_label(url), "Confluence");
     }
 
-    /// A `/wiki` base is Confluence, but takes the unprefixed path, since the
-    /// base already carries the segment. `wiki_base_url_does_not_double_the_wiki_segment`
-    /// pins what that resolves to.
     /// A `/wiki` base is a Confluence profile. The suffix is the hint, and it is
     /// read here from the base as written, before `site_base_url` strips it for
     /// the client.

--- a/crates/cli/src/commands/auth.rs
+++ b/crates/cli/src/commands/auth.rs
@@ -3,7 +3,7 @@ use std::path::Path;
 
 use anyhow::{anyhow, Context, Result};
 use atlassian_cli_auth::{bitbucket_token_key, token_key, CredentialStore, BITBUCKET_API_URL};
-use atlassian_cli_config::Config;
+use atlassian_cli_config::{site_base_url, Config};
 use atlassian_cli_output::OutputRenderer;
 use clap::{Args, Subcommand};
 use serde::Serialize;
@@ -20,14 +20,6 @@ const JIRA_MYSELF_PATH: &str = "/rest/api/3/myself";
 /// everywhere else. v1 needs no extra scope and returns the same fields.
 const CONFLUENCE_CURRENT_USER_PATH: &str = "/wiki/rest/api/user/current";
 
-/// The same endpoint, for a base URL that already ends in `/wiki`.
-///
-/// `ApiClient` appends to the base rather than replacing its path
-/// (`normalize_base_url` gives the base a trailing slash, `safe_join` strips
-/// the leading slash off the path), so prepending `/wiki` to a base that
-/// carries it already asks for `/wiki/wiki/rest/api/user/current`.
-const CONFLUENCE_CURRENT_USER_PATH_UNPREFIXED: &str = "/rest/api/user/current";
-
 /// Pick the user-info endpoint that matches the profile's product.
 ///
 /// Both Jira and Confluence expose accountId / displayName / email, so callers
@@ -37,18 +29,16 @@ const CONFLUENCE_CURRENT_USER_PATH_UNPREFIXED: &str = "/rest/api/user/current";
 ///
 /// Hardcoding the Jira path made every Confluence profile 401 with a Jira
 /// error, and no token or scope could fix it.
+///
+/// **Takes the base URL as the user wrote it, not the site root.** A trailing
+/// `/wiki` is the only hint a Confluence-only profile on a plain site gives, and
+/// `site_base_url` removes it. Callers pair this with a client built from the
+/// site root, so the returned path's own `/wiki` lands exactly once.
 fn user_info_path(base_url: &str) -> &'static str {
     let lower = base_url.to_lowercase();
     let trimmed = lower.trim_end_matches('/');
 
-    // Checked first, and separately from the gateway form: a gateway base can
-    // itself end in `/wiki` (`/ex/confluence/<cloudId>/wiki`), and that spelling
-    // needs the unprefixed path just as much as a plain site does.
-    if trimmed.ends_with("/wiki") {
-        return CONFLUENCE_CURRENT_USER_PATH_UNPREFIXED;
-    }
-
-    if lower.contains("/ex/confluence/") || lower.contains("/wiki/") {
+    if lower.contains("/ex/confluence/") || lower.contains("/wiki/") || trimmed.ends_with("/wiki") {
         return CONFLUENCE_CURRENT_USER_PATH;
     }
 
@@ -371,6 +361,20 @@ fn login_jira_confluence(
 
     let base_url = atlassian_cli_api::normalize_base_url(base_url);
 
+    // Deliberately stored as typed, `/wiki` and all. Stripping it here would be
+    // tidier to look at and would lose the only signal a Confluence-only
+    // profile carries: `user_info_path` reads that suffix to decide which
+    // product's user endpoint `auth whoami`, `auth test` and `auth status`
+    // should call, and without it they would go back to Jira's and 401. Every
+    // request path is built from the site root regardless, via
+    // `Profile::site_base_url`.
+    if site_base_url(base_url.as_str()) != base_url.as_str().trim_end_matches('/') {
+        println!(
+            "Note: /wiki is added automatically for Confluence requests, so it is not needed \
+             in the base URL. Keeping it is harmless and marks this profile as Confluence."
+        );
+    }
+
     let email = args
         .email
         .as_ref()
@@ -639,7 +643,11 @@ async fn whoami(args: WhoamiArgs, config: &Config, store: &CredentialStore) -> R
         )
     })?;
 
-    let client = atlassian_cli_api::ApiClient::new(base_url)?.with_basic_auth(email, &token);
+    // The client is built from the site root, while the product is detected from
+    // the base URL as written: a trailing `/wiki` is the only hint a
+    // Confluence-only profile gives, and `site_base_url` removes it.
+    let client =
+        atlassian_cli_api::ApiClient::new(site_base_url(base_url))?.with_basic_auth(email, &token);
 
     let path = user_info_path(base_url);
     let product = product_label(base_url);
@@ -726,7 +734,9 @@ async fn test_site_auth(
 
     println!("Testing {product} authentication for profile '{profile_name}'...");
 
-    let client = atlassian_cli_api::ApiClient::new(base_url)?.with_basic_auth(email, &token);
+    // Detection on the base as written, the client on the site root. See `whoami`.
+    let client =
+        atlassian_cli_api::ApiClient::new(site_base_url(base_url))?.with_basic_auth(email, &token);
 
     let result: Result<serde_json::Value> = client
         .get(user_info_path(base_url))
@@ -869,7 +879,8 @@ async fn auth_status(
         let service = product_label(base_url).to_string();
 
         if let Some(token) = get_token(store, profile_name) {
-            let client = atlassian_cli_api::ApiClient::new(base_url)
+            // Detection on the base as written, the client on the site root.
+            let client = atlassian_cli_api::ApiClient::new(site_base_url(base_url))
                 .ok()
                 .map(|c| c.with_basic_auth(email, &token));
 
@@ -1101,15 +1112,18 @@ mod tests {
     /// A `/wiki` base is Confluence, but takes the unprefixed path, since the
     /// base already carries the segment. `wiki_base_url_does_not_double_the_wiki_segment`
     /// pins what that resolves to.
+    /// A `/wiki` base is a Confluence profile. The suffix is the hint, and it is
+    /// read here from the base as written, before `site_base_url` strips it for
+    /// the client.
     #[test]
     fn wiki_base_path_uses_confluence_endpoint() {
         assert_eq!(
             user_info_path("https://example.atlassian.net/wiki"),
-            CONFLUENCE_CURRENT_USER_PATH_UNPREFIXED
+            CONFLUENCE_CURRENT_USER_PATH
         );
         assert_eq!(
             user_info_path("https://example.atlassian.net/wiki/"),
-            CONFLUENCE_CURRENT_USER_PATH_UNPREFIXED
+            CONFLUENCE_CURRENT_USER_PATH
         );
         assert_eq!(
             product_label("https://example.atlassian.net/wiki"),
@@ -1170,7 +1184,9 @@ mod tests {
     /// strips the path's leading one, so the two concatenate. A base that
     /// already ends in `/wiki` therefore produced `/wiki/wiki/...`.
     fn resolved(base_url: &str) -> String {
-        atlassian_cli_api::ApiClient::new(base_url)
+        // Exactly what the commands do: the client on the site root, the
+        // product detected from the base as written.
+        atlassian_cli_api::ApiClient::new(site_base_url(base_url))
             .expect("base URL should parse")
             .resolve_url(user_info_path(base_url))
             .expect("path should join")

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -336,7 +336,13 @@ fn resolve_profile_for_product(
 ) -> Result<ProductProfile> {
     let (base, profile) = resolve_base_profile(config, requested)?;
 
-    let base_url = profile.base_url.clone().ok_or_else(|| {
+    // The site root, so a base URL written as `https://site.atlassian.net/wiki`
+    // works. Every Confluence command spells `/wiki` itself and every Jira
+    // command spells `/rest/api/3`, and the client appends to the base rather
+    // than replacing its path, so leaving the suffix on asked for
+    // `/wiki/wiki/api/v2/pages` and `/wiki/rest/api/3/issue/KEY`. Bamboo has its
+    // own resolver below and keeps its context path.
+    let base_url = profile.site_base_url().map(str::to_string).ok_or_else(|| {
         anyhow!(
             "Profile '{}' is missing a base_url. Run `atlassian-cli auth login --base-url <URL>`",
             base.name

--- a/crates/cli/tests/wiki_base_url_e2e.rs
+++ b/crates/cli/tests/wiki_base_url_e2e.rs
@@ -1,0 +1,221 @@
+//! A profile whose `base_url` ends in `/wiki` must work, for every product.
+//!
+//! `ApiClient` appends request paths to the base rather than replacing the
+//! base's path, and every Confluence command spells `/wiki` itself while every
+//! Jira command spells `/rest/api/3`. So a base written as
+//! `https://site.atlassian.net/wiki` asked for `/wiki/wiki/api/v2/pages` and
+//! `/wiki/rest/api/3/issue/KEY`, and both 404.
+//!
+//! Writing `/wiki` into the base is an easy mistake: it is how the Confluence
+//! REST documentation spells the full URL. Before this suite there was no test
+//! anywhere that used such a base, which is why the fault survived so long.
+//!
+//! Each test mounts the doubled path as well, expecting zero hits, so a
+//! regression fails loudly here instead of turning into a 404 for a user.
+
+use std::path::Path;
+use std::process::Command;
+
+use tempfile::TempDir;
+use wiremock::matchers::{method, path as path_matcher, query_param};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+const BIN: &str = env!("CARGO_BIN_EXE_atlassian-cli");
+
+/// A profile pointed at `<base_url>`, written verbatim so the tests can choose
+/// the shape under test.
+fn write_config(dir: &Path, base_url: &str) -> std::path::PathBuf {
+    let config_path = dir.join("config.yaml");
+    std::fs::write(
+        &config_path,
+        format!(
+            "default_profile: local\nprofiles:\n  local:\n    email: dev@example.com\n    base_url: {base_url}\n"
+        ),
+    )
+    .unwrap();
+    config_path
+}
+
+fn run(config: &Path, args: &[&str]) -> std::process::Output {
+    let dir = config.parent().unwrap_or_else(|| Path::new("."));
+    Command::new(BIN)
+        .arg("--config")
+        .arg(config)
+        .env("HOME", dir)
+        .env("ATLASSIAN_CLI_CONFIG_DIR", dir)
+        .env_remove("XDG_CONFIG_HOME")
+        .env_remove("ATLASSIAN_API_TOKEN")
+        .env_remove("ATLASSIAN_BITBUCKET_TOKEN")
+        .env_remove("BITBUCKET_TOKEN")
+        .env("ATLASSIAN_CLI_TOKEN_LOCAL", "fake-token")
+        .args(args)
+        .output()
+        .expect("failed to run the CLI")
+}
+
+fn assert_ok(out: &std::process::Output) {
+    assert!(
+        out.status.success(),
+        "command failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+/// The doubled path, mounted to catch a regression rather than let it 404.
+async fn trap_doubled(server: &MockServer, doubled: &str) {
+    Mock::given(method("GET"))
+        .and(path_matcher(doubled.to_string()))
+        .respond_with(ResponseTemplate::new(500))
+        .expect(0)
+        .mount(server)
+        .await;
+}
+
+#[tokio::test]
+async fn confluence_page_list_resolves_once_under_a_wiki_base() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path_matcher("/wiki/api/v2/pages"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "results": [{ "id": "1", "title": "Onboarding", "status": "current" }]
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+    trap_doubled(&server, "/wiki/wiki/api/v2/pages").await;
+
+    let dir = TempDir::new().unwrap();
+    let config = write_config(dir.path(), &format!("{}/wiki", server.uri()));
+
+    let out = run(&config, &["confluence", "page", "list"]);
+
+    assert_ok(&out);
+    assert!(String::from_utf8_lossy(&out.stdout).contains("Onboarding"));
+}
+
+/// The space filter takes two requests, so both must resolve correctly.
+#[tokio::test]
+async fn confluence_space_filter_resolves_once_under_a_wiki_base() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path_matcher("/wiki/api/v2/spaces"))
+        .and(query_param("keys", "DOCS"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "results": [{ "id": "786433", "key": "DOCS", "name": "Docs" }]
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path_matcher("/wiki/api/v2/pages"))
+        .and(query_param("space-id", "786433"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "results": [{ "id": "1", "title": "Runbook", "status": "current" }]
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+    trap_doubled(&server, "/wiki/wiki/api/v2/spaces").await;
+
+    let dir = TempDir::new().unwrap();
+    let config = write_config(dir.path(), &format!("{}/wiki", server.uri()));
+
+    let out = run(&config, &["confluence", "page", "list", "--space", "DOCS"]);
+
+    assert_ok(&out);
+    assert!(String::from_utf8_lossy(&out.stdout).contains("Runbook"));
+}
+
+/// Jira was broken by the same base, and more obviously: `/wiki` has no
+/// business in a Jira path at all.
+#[tokio::test]
+async fn jira_is_not_prefixed_with_wiki_under_a_wiki_base() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path_matcher("/rest/api/3/issue/DEV-1"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "key": "DEV-1",
+            "fields": { "summary": "Fix the login error", "status": {"name": "Open"} }
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+    trap_doubled(&server, "/wiki/rest/api/3/issue/DEV-1").await;
+
+    let dir = TempDir::new().unwrap();
+    let config = write_config(dir.path(), &format!("{}/wiki", server.uri()));
+
+    let out = run(&config, &["jira", "issue", "get", "DEV-1"]);
+
+    assert_ok(&out);
+    assert!(String::from_utf8_lossy(&out.stdout).contains("Fix the login error"));
+}
+
+/// The other half of the fix: the `/wiki` suffix is still what tells the CLI
+/// this is a Confluence profile. Strip it everywhere and `auth whoami` would go
+/// back to Jira's endpoint and 401, which is the bug PR #131 fixed.
+#[tokio::test]
+async fn a_wiki_base_is_still_recognised_as_confluence() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path_matcher("/wiki/rest/api/user/current"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "accountId": "abc123",
+            "displayName": "Ada Lovelace",
+            "email": "ada@example.com"
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+    // Where it would go if the suffix were treated as a Jira profile.
+    Mock::given(method("GET"))
+        .and(path_matcher("/rest/api/3/myself"))
+        .respond_with(ResponseTemplate::new(401))
+        .expect(0)
+        .mount(&server)
+        .await;
+    trap_doubled(&server, "/wiki/wiki/rest/api/user/current").await;
+
+    let dir = TempDir::new().unwrap();
+    let config = write_config(dir.path(), &format!("{}/wiki", server.uri()));
+
+    let out = run(&config, &["auth", "whoami"]);
+
+    assert_ok(&out);
+    let text = String::from_utf8_lossy(&out.stdout);
+    assert!(text.contains("Product: Confluence"), "{text}");
+    assert!(text.contains("Ada Lovelace"), "{text}");
+}
+
+/// A plain site is untouched by any of this.
+#[tokio::test]
+async fn a_site_root_base_is_unaffected() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path_matcher("/wiki/api/v2/pages"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "results": [{ "id": "1", "title": "Unchanged", "status": "current" }]
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path_matcher("/rest/api/3/issue/DEV-1"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "key": "DEV-1", "fields": { "summary": "Unchanged" }
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let dir = TempDir::new().unwrap();
+    let config = write_config(dir.path(), &server.uri());
+
+    assert_ok(&run(&config, &["confluence", "page", "list"]));
+    assert_ok(&run(&config, &["jira", "issue", "get", "DEV-1"]));
+}

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -118,6 +118,41 @@ pub struct Profile {
     pub bitbucket_remote: Option<String>,
 }
 
+/// The Confluence prefix, which belongs to the request path and not to the base.
+const WIKI_SUFFIX: &str = "/wiki";
+
+/// A site base URL with a trailing `/wiki` removed.
+///
+/// The API client appends request paths to the base rather than replacing the
+/// base's path, and every Confluence command spells `/wiki` itself while every
+/// Jira command spells `/rest/api/3`. So a profile stored as
+/// `https://site.atlassian.net/wiki` asked for `/wiki/wiki/api/v2/pages` and
+/// `/wiki/rest/api/3/issue/KEY`, and both 404. Writing `/wiki` into the base is
+/// an easy mistake to make, because it is how the Confluence REST documentation
+/// spells the full URL.
+///
+/// `strip_suffix` and not `trim_end_matches`: the latter would eat every
+/// repetition, so a `/wiki/wiki` typo would silently become the site root
+/// instead of losing one segment and staying visibly odd.
+///
+/// Only for Jira, Confluence and JSM. Bamboo is a Server product where a context
+/// path in the base is legitimate, and it resolves its own base URL.
+pub fn site_base_url(base_url: &str) -> &str {
+    let trimmed = base_url.strip_suffix('/').unwrap_or(base_url);
+    trimmed.strip_suffix(WIKI_SUFFIX).unwrap_or(trimmed)
+}
+
+impl Profile {
+    /// `base_url` as the site root, for building a Jira, Confluence or JSM client.
+    ///
+    /// Callers that need to tell the two products apart must read `base_url`
+    /// itself: a trailing `/wiki` is the only hint a Confluence-only profile
+    /// gives, and this strips it.
+    pub fn site_base_url(&self) -> Option<&str> {
+        self.base_url.as_deref().map(site_base_url)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -478,5 +513,88 @@ mod tests {
         assert_eq!(ci_profile.workspace.as_deref(), Some("myteam"));
         // No email required for bearer profiles
         assert!(ci_profile.email.is_none());
+    }
+
+    #[test]
+    fn a_trailing_wiki_is_stripped_from_a_site_base_url() {
+        assert_eq!(
+            site_base_url("https://site.atlassian.net/wiki"),
+            "https://site.atlassian.net"
+        );
+        assert_eq!(
+            site_base_url("https://site.atlassian.net/wiki/"),
+            "https://site.atlassian.net"
+        );
+    }
+
+    #[test]
+    fn a_site_root_is_left_alone() {
+        assert_eq!(
+            site_base_url("https://site.atlassian.net"),
+            "https://site.atlassian.net"
+        );
+        assert_eq!(
+            site_base_url("https://site.atlassian.net/"),
+            "https://site.atlassian.net"
+        );
+    }
+
+    /// The reason for `strip_suffix` over `trim_end_matches`: a word merely
+    /// ending in "wiki" is not the Confluence prefix.
+    #[test]
+    fn a_path_that_merely_ends_in_wiki_is_left_alone() {
+        assert_eq!(
+            site_base_url("https://example.com/mywiki"),
+            "https://example.com/mywiki"
+        );
+        assert_eq!(
+            site_base_url("https://wiki.example.com"),
+            "https://wiki.example.com"
+        );
+    }
+
+    /// One segment, not all of them, so a doubled typo stays visible rather
+    /// than silently resolving to the site root.
+    #[test]
+    fn only_one_wiki_segment_is_removed() {
+        assert_eq!(
+            site_base_url("https://site.atlassian.net/wiki/wiki"),
+            "https://site.atlassian.net/wiki"
+        );
+    }
+
+    /// The OAuth gateway form, which the Confluence REST docs spell with the
+    /// `/wiki` already attached.
+    #[test]
+    fn the_gateway_form_reduces_to_its_cloud_id_root() {
+        assert_eq!(
+            site_base_url("https://api.atlassian.com/ex/confluence/cloud-id/wiki"),
+            "https://api.atlassian.com/ex/confluence/cloud-id"
+        );
+        assert_eq!(
+            site_base_url("https://api.atlassian.com/ex/jira/cloud-id"),
+            "https://api.atlassian.com/ex/jira/cloud-id"
+        );
+    }
+
+    /// Bamboo resolves its own base and never calls this, but a context path
+    /// must survive if it ever does.
+    #[test]
+    fn an_unrelated_context_path_survives() {
+        assert_eq!(
+            site_base_url("https://example.com/bamboo"),
+            "https://example.com/bamboo"
+        );
+    }
+
+    #[test]
+    fn the_profile_accessor_follows_the_same_rule() {
+        let profile = Profile {
+            base_url: Some("https://site.atlassian.net/wiki/".to_string()),
+            ..Default::default()
+        };
+        assert_eq!(profile.site_base_url(), Some("https://site.atlassian.net"));
+
+        assert_eq!(Profile::default().site_base_url(), None);
     }
 }

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -131,15 +131,30 @@ const WIKI_SUFFIX: &str = "/wiki";
 /// an easy mistake to make, because it is how the Confluence REST documentation
 /// spells the full URL.
 ///
-/// `strip_suffix` and not `trim_end_matches`: the latter would eat every
-/// repetition, so a `/wiki/wiki` typo would silently become the site root
-/// instead of losing one segment and staying visibly odd.
+/// One `/wiki` segment is removed, not every repetition: a `/wiki/wiki` typo
+/// should lose one and stay visibly odd rather than silently becoming the site
+/// root. Trailing slashes are all removed first, so `/wiki//` is handled like
+/// `/wiki` instead of slipping through the suffix check.
+///
+/// The comparison ignores case, matching the product detection in
+/// `commands/auth.rs`, which lowercases before looking for the same segment.
+/// The two disagreeing would mean a `/WIKI` base detected as Confluence but not
+/// normalised, which is the doubling all over again.
 ///
 /// Only for Jira, Confluence and JSM. Bamboo is a Server product where a context
 /// path in the base is legitimate, and it resolves its own base URL.
 pub fn site_base_url(base_url: &str) -> &str {
-    let trimmed = base_url.strip_suffix('/').unwrap_or(base_url);
-    trimmed.strip_suffix(WIKI_SUFFIX).unwrap_or(trimmed)
+    let trimmed = base_url.trim_end_matches('/');
+
+    let split = trimmed.len().saturating_sub(WIKI_SUFFIX.len());
+    if trimmed.len() >= WIKI_SUFFIX.len()
+        && trimmed.is_char_boundary(split)
+        && trimmed[split..].eq_ignore_ascii_case(WIKI_SUFFIX)
+    {
+        return &trimmed[..split];
+    }
+
+    trimmed
 }
 
 impl Profile {
@@ -561,6 +576,48 @@ mod tests {
             site_base_url("https://site.atlassian.net/wiki/wiki"),
             "https://site.atlassian.net/wiki"
         );
+    }
+
+    /// Every trailing slash goes before the suffix is looked for. Stripping
+    /// only one left `/wiki//` unnormalised, so it still doubled while
+    /// `auth login` told the user the URL was fine.
+    #[test]
+    fn repeated_trailing_slashes_do_not_hide_the_suffix() {
+        assert_eq!(
+            site_base_url("https://site.atlassian.net/wiki//"),
+            "https://site.atlassian.net"
+        );
+        assert_eq!(
+            site_base_url("https://site.atlassian.net//"),
+            "https://site.atlassian.net"
+        );
+    }
+
+    /// Product detection lowercases before looking for the same segment. If
+    /// this did not, a `/WIKI` base would be called Confluence and left
+    /// unnormalised, which is the doubling again.
+    #[test]
+    fn the_suffix_match_ignores_case() {
+        assert_eq!(
+            site_base_url("https://site.atlassian.net/WIKI"),
+            "https://site.atlassian.net"
+        );
+        assert_eq!(
+            site_base_url("https://site.atlassian.net/Wiki/"),
+            "https://site.atlassian.net"
+        );
+    }
+
+    /// Degenerate input reduces to an empty string rather than panicking on a
+    /// slice boundary; `ApiClient::new` then reports it as an unparseable URL.
+    #[test]
+    fn degenerate_input_does_not_panic() {
+        assert_eq!(site_base_url("/wiki"), "");
+        assert_eq!(site_base_url(""), "");
+        assert_eq!(site_base_url("/"), "");
+        assert_eq!(site_base_url("wiki"), "wiki");
+        // Multi-byte, to prove the boundary guard is doing something.
+        assert_eq!(site_base_url("https://x/päge"), "https://x/päge");
     }
 
     /// The OAuth gateway form, which the Confluence REST docs spell with the

--- a/docs/26082026_auth_product_dispatch.md
+++ b/docs/26082026_auth_product_dispatch.md
@@ -56,10 +56,12 @@ The tests assert on the **resolved URL** rather than on which constant the
 dispatch returned. Asserting the constant proves nothing here, since the whole
 fault lives in how the path and the base combine.
 
-Note that a `base_url` ending in `/wiki` is still wrong for every other
-Confluence command, which build `/wiki/api/v2/...` themselves and hit the same
-doubling. Normalising a trailing `/wiki` off the base at `auth login` time is
-worth doing separately.
+A `base_url` ending in `/wiki` was also wrong for every other Confluence and
+Jira command, which build their own paths and hit the same doubling. That was
+filed as #133 and fixed separately: see
+[28082026_wiki_base_url_normalisation.md](28082026_wiki_base_url_normalisation.md).
+The unprefixed constant described above is gone with it, since the client is now
+built from the site root.
 
 ## `confluence page list --space` was silently ignored
 

--- a/docs/28082026_wiki_base_url_normalisation.md
+++ b/docs/28082026_wiki_base_url_normalisation.md
@@ -1,0 +1,133 @@
+# A `/wiki` base URL no longer doubles the segment
+
+Status: in progress on `fix/wiki-base-url` (issue #133).
+
+## Problem
+
+`ApiClient` appends request paths to the base URL rather than replacing the
+base's path: `normalize_base_url` gives the base a trailing slash and
+`safe_join` strips the leading slash off the path before `Url::join`. Every
+Confluence command spells `/wiki` itself, and every Jira command spells
+`/rest/api/3`.
+
+So a profile stored as `https://site.atlassian.net/wiki` requested:
+
+```
+GET /wiki/wiki/api/v2/pages          confluence page list
+GET /wiki/rest/api/3/issue/DEV-1     jira issue get DEV-1
+```
+
+Both 404. Writing `/wiki` into the base is an easy mistake, because it is how
+the Confluence REST documentation spells the full URL.
+
+PR #131 hit this while fixing Confluence auth dispatch and compensated for the
+three `auth` commands only, by returning an unprefixed user endpoint for such a
+base. Every other command stayed broken, and #133 was filed rather than widening
+that PR. There was also no test anywhere in the repo using a `/wiki` base, which
+is why the fault survived this long.
+
+## The fix
+
+Strip one trailing `/wiki` from the base when building a client, and **read the
+product hint from the base as the user wrote it**.
+
+```rust
+// crates/config/src/lib.rs
+pub fn site_base_url(base_url: &str) -> &str;
+impl Profile { pub fn site_base_url(&self) -> Option<&str>; }
+```
+
+`strip_suffix` rather than `trim_end_matches`, so a `/wiki/wiki` typo loses one
+segment and stays visibly odd instead of silently resolving to the site root,
+and so a path merely ending in the letters "wiki" (`/mywiki`) is untouched.
+
+Applied at four places, which is every site that builds a client from a profile:
+
+| File | Site | Covers |
+| --- | --- | --- |
+| `crates/cli/src/main.rs` | `resolve_profile_for_product` | Jira, Confluence and JSM, which all take their client from `build_product_client` |
+| `crates/cli/src/commands/auth.rs` | `whoami`, `test_site_auth`, `auth_status` | each builds its own client |
+
+**Bamboo is deliberately excluded.** It has its own resolver, and it is a Server
+product where a context path in the base is legitimate and already pinned by
+`test_resolve_url_keeps_a_context_path`. Bitbucket and Opsgenie never read the
+profile's base URL at all.
+
+`crates/api` is untouched. `normalize_base_url` is `pub` in a published crate,
+and teaching a generic HTTP client about one product's path segment would be the
+wrong layer.
+
+### The trap: detection must read the base as written
+
+A trailing `/wiki` is the **only** signal a Confluence-only profile on a plain
+site gives. `user_info_path` reads it to decide whether `auth whoami`,
+`auth test` and `auth status` should call Jira's `/rest/api/3/myself` or
+Confluence's `/wiki/rest/api/user/current`.
+
+Normalising the value that detection sees would therefore have turned every
+Confluence profile back into a Jira one and reintroduced the 401 that PR #131
+existed to fix. So the two are split:
+
+- **detection** reads `profile.base_url`, unchanged;
+- **the client** is built from `site_base_url(...)`.
+
+They compose: the raw base still says Confluence, so the prefixed
+`/wiki/rest/api/user/current` is chosen, and the client's base no longer carries
+`/wiki`, so it resolves exactly once. `a_wiki_base_is_still_recognised_as_confluence`
+in the e2e suite fails if anyone later "tidies" this by normalising before
+detection.
+
+That also makes `CONFLUENCE_CURRENT_USER_PATH_UNPREFIXED` and its branch dead,
+and they are deleted. `user_info_path` returns to a single Confluence constant.
+
+### What `auth login` does, and deliberately does not do
+
+It does **not** rewrite the value. Storing the site root would look tidier and
+would destroy the product hint for exactly the users PR #131 was for. Instead it
+prints a note when the URL carries the suffix, saying `/wiki` is added
+automatically for Confluence requests, that it is not needed, and that keeping it
+marks the profile as Confluence.
+
+Existing configs need no migration: the normalisation happens on read, in memory,
+and the user's file is never rewritten behind their back.
+
+## Verification
+
+The bug was reproduced against a local logging server before anything was
+edited, and each test was confirmed to fail against the pre-fix code.
+
+Every base-URL shape, one run each, showing the path the server actually
+received:
+
+| base_url | `auth whoami` | Confluence | Jira |
+| --- | --- | --- | --- |
+| `<host>` | Jira | `/wiki/api/v2/pages` | `/rest/api/3/issue/DEV-1` |
+| `<host>/wiki` | Confluence | `/wiki/api/v2/pages` | `/rest/api/3/issue/DEV-1` |
+| `<host>/ex/confluence/cid` | Confluence | `/ex/confluence/cid/wiki/api/v2/pages` | `/ex/confluence/cid/rest/api/3/issue/DEV-1` |
+| `<host>/ex/confluence/cid/wiki` | Confluence | `/ex/confluence/cid/wiki/api/v2/pages` | `/ex/confluence/cid/rest/api/3/issue/DEV-1` |
+
+Tests:
+
+- Unit, `crates/config`: `/wiki` and `/wiki/` stripped; a site root untouched;
+  `/mywiki` and a `wiki.` hostname untouched; `/wiki/wiki` loses one segment
+  only; the gateway form reduces to its cloud-id root; an unrelated context path
+  survives; and the `Profile` accessor follows the same rule.
+- Unit, `crates/cli/src/commands/auth.rs`: a `/wiki` base now selects the
+  prefixed Confluence constant, and the `resolved()` helper applies the same
+  normalisation the commands do, so the resolved-URL assertions test the real
+  composition rather than a compensating constant.
+- e2e, `crates/cli/tests/wiki_base_url_e2e.rs`: with a `/wiki` base,
+  `confluence page list` hits `/wiki/api/v2/pages`, the `--space` filter resolves
+  both of its requests, `jira issue get` hits `/rest/api/3/issue/DEV-1` with no
+  prefix, and `auth whoami` still reports `Product: Confluence`. Each test also
+  mounts the doubled path expecting zero hits, so a regression fails loudly here
+  instead of becoming a 404 for a user. Four of the five fail against the pre-fix
+  code.
+
+## Limitations
+
+A self-hosted Confluence whose context path is genuinely `/wiki` would now be
+unreachable. That is not a regression in practice: this CLI targets Atlassian
+Cloud (Jira v3, Confluence v2), Confluence Server is not supported anywhere in
+the codebase, and such an install was already broken by the doubling. Bamboo,
+the one Server product supported, keeps its context path.

--- a/docs/28082026_wiki_base_url_normalisation.md
+++ b/docs/28082026_wiki_base_url_normalisation.md
@@ -37,9 +37,13 @@ pub fn site_base_url(base_url: &str) -> &str;
 impl Profile { pub fn site_base_url(&self) -> Option<&str>; }
 ```
 
-`strip_suffix` rather than `trim_end_matches`, so a `/wiki/wiki` typo loses one
-segment and stays visibly odd instead of silently resolving to the site root,
-and so a path merely ending in the letters "wiki" (`/mywiki`) is untouched.
+One segment is removed, not every repetition, so a `/wiki/wiki` typo loses one
+and stays visibly odd instead of silently resolving to the site root, and a path
+merely ending in the letters "wiki" (`/mywiki`) is untouched. Trailing slashes
+are all trimmed first, and the match ignores case, so `/wiki//` and `/WIKI` are
+normalised too: the case rule matters because product detection lowercases, and
+the two disagreeing would mean a base detected as Confluence but left to
+double.
 
 Applied at four places, which is every site that builds a client from a profile:
 
@@ -94,7 +98,7 @@ and the user's file is never rewritten behind their back.
 ## Verification
 
 The bug was reproduced against a local logging server before anything was
-edited, and each test was confirmed to fail against the pre-fix code.
+edited.
 
 Every base-URL shape, one run each, showing the path the server actually
 received:
@@ -111,7 +115,9 @@ Tests:
 - Unit, `crates/config`: `/wiki` and `/wiki/` stripped; a site root untouched;
   `/mywiki` and a `wiki.` hostname untouched; `/wiki/wiki` loses one segment
   only; the gateway form reduces to its cloud-id root; an unrelated context path
-  survives; and the `Profile` accessor follows the same rule.
+  survives; repeated trailing slashes do not hide the suffix; the match ignores
+  case; degenerate input reduces to an empty string rather than panicking on a
+  slice boundary; and the `Profile` accessor follows the same rule.
 - Unit, `crates/cli/src/commands/auth.rs`: a `/wiki` base now selects the
   prefixed Confluence constant, and the `resolved()` helper applies the same
   normalisation the commands do, so the resolved-URL assertions test the real
@@ -121,8 +127,23 @@ Tests:
   both of its requests, `jira issue get` hits `/rest/api/3/issue/DEV-1` with no
   prefix, and `auth whoami` still reports `Product: Confluence`. Each test also
   mounts the doubled path expecting zero hits, so a regression fails loudly here
-  instead of becoming a 404 for a user. Four of the five fail against the pre-fix
-  code.
+  instead of becoming a 404 for a user.
+
+  **Three of the five fail against the pre-fix code**, checked in a worktree at
+  the parent commit. `a_wiki_base_is_still_recognised_as_confluence` passes both
+  before and after, because PR #131's unprefixed constant produced the same final
+  URL by a different route; it is a guard against the plausible-but-wrong fix of
+  normalising before detection, not a regression test for this bug. It does fail
+  against that variant. `a_site_root_base_is_unaffected` is a no-change guard and
+  passes both ways by design.
+
+## Behaviour change worth knowing
+
+Under a `/wiki` base, `jira api` now resolves from the site root:
+`jira api /rest/api/3/myself` requests `/rest/api/3/myself` where it previously
+requested `/wiki/rest/api/3/myself`. The old composition only ever produced 404s,
+but anyone who had worked around it by omitting a prefix should re-check their
+scripts.
 
 ## Limitations
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -45,6 +45,7 @@ changes made, newest last; `docs/todo.md` is the forward-looking roadmap.
 
 | Document | Date | What it covers |
 | --- | --- | --- |
+| [28082026_wiki_base_url_normalisation.md](28082026_wiki_base_url_normalisation.md) | 2026-08-28 | A `/wiki` base URL no longer doubles the segment: site-root normalisation for Jira, Confluence and JSM clients |
 | [26082026_jira_field_selection.md](26082026_jira_field_selection.md) | 2026-08-26 | `--fields` on `jira issue get` and `search`: ids or display names, ordered columns, and ordered rendering in `crates/output` |
 | [26082026_auth_product_dispatch.md](26082026_auth_product_dispatch.md) | 2026-08-26 | `auth whoami`/`test`/`status` dispatch on the profile's product, the `--space` filter fix, and 401s that keep the server's reason |
 | [16082026_bb_pr_reviewer_status.md](16082026_bb_pr_reviewer_status.md) | 2026-08-16 | `bb pr reviewers` listing with approval status, `--all`, and the `--add` endpoint fix |

--- a/todo.md
+++ b/todo.md
@@ -1785,3 +1785,17 @@ Self-review of the above, by running the binary against a mock Jira and reading 
 - An empty search result printed `[]` under table, CSV, markdown and quiet, where every other list command prints "No issues found" or nothing. That is #110 reintroduced on a new path; the empty case now goes through `render_list_or_empty`.
 
 Each has a test verified to fail against the pre-fix code. A wildcard mixed with named fields now warns, since Jira reads `*all,summary` as everything. 779 tests pass.
+
+### Issue #133: a `/wiki` base URL doubled the segment on every command
+
+Filed while reviewing PR #131, which had compensated for the three `auth` commands only. Reproduced first against a local logging server: a profile with `base_url: <host>/wiki` requested `/wiki/wiki/api/v2/pages` for Confluence and `/wiki/rest/api/3/issue/DEV-1` for Jira, so both 404. The client appends to the base rather than replacing its path, and every command spells its own prefix.
+
+- `site_base_url` in `crates/config`, plus a `Profile` accessor, strips one trailing `/wiki`. `strip_suffix` not `trim_end_matches`, so a `/wiki/wiki` typo loses one segment and stays visibly odd rather than silently becoming the site root, and `/mywiki` is untouched.
+- Applied at the four sites that build a client from a profile: `resolve_profile_for_product` in `main.rs` (which covers Jira, Confluence and JSM at once) and the three in `auth.rs`. Bamboo is excluded deliberately: separate resolver, Server product, and a context path there is legitimate and already pinned by a test.
+- **Deviated from the plan on one point.** The plan said to normalise at `auth login` too. That would have destroyed the only signal a Confluence-only profile carries: `user_info_path` reads the trailing `/wiki` to choose between Jira's and Confluence's user endpoint, so stripping it at save would have reintroduced the 401 PR #131 existed to fix. Detection now reads the base as written, the client is built from the site root, and the two compose. `auth login` keeps the value and prints a note that the prefix is not needed.
+- That split makes `CONFLUENCE_CURRENT_USER_PATH_UNPREFIXED` and its branch dead; both deleted.
+- `crates/api` untouched: `normalize_base_url` is published, and teaching a generic HTTP client about one product's path segment is the wrong layer.
+
+New `crates/cli/tests/wiki_base_url_e2e.rs`, the coverage that never existed: four of its five tests fail against the pre-fix code, and each mounts the doubled path expecting zero hits so a regression fails loudly rather than turning into a user's 404. One test exists purely to catch the plausible-but-wrong fix of normalising before detection, and it does: reverting to that variant fails it.
+
+Verified live for all four base shapes (plain, `/wiki`, `/ex/confluence/<id>`, `/ex/confluence/<id>/wiki`): every path carries exactly one `/wiki` for Confluence and none for Jira, and `auth whoami` reports the right product for each. 791 tests pass. Documented in `docs/28082026_wiki_base_url_normalisation.md`; the #131 doc's open limitation now points at the fix.

--- a/todo.md
+++ b/todo.md
@@ -1796,6 +1796,14 @@ Filed while reviewing PR #131, which had compensated for the three `auth` comman
 - That split makes `CONFLUENCE_CURRENT_USER_PATH_UNPREFIXED` and its branch dead; both deleted.
 - `crates/api` untouched: `normalize_base_url` is published, and teaching a generic HTTP client about one product's path segment is the wrong layer.
 
-New `crates/cli/tests/wiki_base_url_e2e.rs`, the coverage that never existed: four of its five tests fail against the pre-fix code, and each mounts the doubled path expecting zero hits so a regression fails loudly rather than turning into a user's 404. One test exists purely to catch the plausible-but-wrong fix of normalising before detection, and it does: reverting to that variant fails it.
+New `crates/cli/tests/wiki_base_url_e2e.rs`, the coverage that never existed: three of its five tests fail against the pre-fix code, and each mounts the doubled path expecting zero hits so a regression fails loudly rather than turning into a user's 404. One test exists purely to catch the plausible-but-wrong fix of normalising before detection, and it does: reverting to that variant fails it.
 
 Verified live for all four base shapes (plain, `/wiki`, `/ex/confluence/<id>`, `/ex/confluence/<id>/wiki`): every path carries exactly one `/wiki` for Confluence and none for Jira, and `auth whoami` reports the right product for each. 791 tests pass. Documented in `docs/28082026_wiki_base_url_normalisation.md`; the #131 doc's open limitation now points at the fix.
+
+Fable review of the above returned "safe to merge" with three minor findings, all fair and all fixed:
+
+- **The login note lied for `https://site/wiki//`.** My condition compared `site_base_url` (which stripped one trailing slash) against `trim_end_matches('/')` (which strips all of them), so a doubled trailing slash left the base unnormalised while login told the user it was harmless. Verified: it still requested `/wiki/wiki/api/v2/pages`. `site_base_url` now trims all trailing slashes before looking for the suffix.
+- **`/WIKI` was detected as Confluence but not normalised**, because detection lowercases and my strip did not. The two disagreeing is the doubling again, so the suffix match now ignores case. Both cases verified live: each now resolves to a single `/wiki/api/v2/pages`.
+- **My claim that four of the five e2e tests fail pre-fix was wrong; it is three.** I had tested against a hybrid (client normalisation reverted but the new `user_info_path` kept), not the real parent commit. Re-checked in a worktree at `2c830f4`: `a_wiki_base_is_still_recognised_as_confluence` passes both ways, because PR #131's unprefixed constant reached the same URL by another route. It is a guard against normalising before detection, not a regression test for this bug, and the doc now says so.
+
+Also removed a stale doc comment the reviewer spotted, and documented the one user-visible behaviour change: under a `/wiki` base, `jira api` now resolves from the site root. 794 tests pass.


### PR DESCRIPTION
Closes #133.

## Problem

`ApiClient` appends request paths to the base URL rather than replacing the base's path: `normalize_base_url` gives the base a trailing slash and `safe_join` strips the leading slash off the path before `Url::join`. Every Confluence command spells `/wiki` itself and every Jira command spells `/rest/api/3`.

So a profile stored as `https://site.atlassian.net/wiki` requested:

```
GET /wiki/wiki/api/v2/pages          confluence page list
GET /wiki/rest/api/3/issue/DEV-1     jira issue get DEV-1
```

Both 404. Writing `/wiki` into the base is an easy mistake: it is how the Confluence REST docs spell the full URL. PR #131 hit this and compensated for the three `auth` commands only; #133 was filed rather than widening that PR. There was also no test anywhere using a `/wiki` base, which is why it survived.

## The fix

`site_base_url()` in `crates/config` strips one trailing `/wiki`, applied at every site that builds a client from a profile: `resolve_profile_for_product` in `main.rs` (which covers Jira, Confluence **and** JSM through `build_product_client`) and the three in `auth.rs`.

One segment, not every repetition, so a `/wiki/wiki` typo loses one and stays visibly odd rather than silently becoming the site root. Trailing slashes are all trimmed first and the match ignores case.

**Bamboo is deliberately excluded**: separate resolver, Server product, and a context path there is legitimate and already pinned by `test_resolve_url_keeps_a_context_path`. `crates/api` is untouched, since `normalize_base_url` is published and teaching a generic HTTP client about one product's path segment is the wrong layer.

### The trap, and the deviation from the original plan

The plan said to normalise at `auth login` too. **That would have been a regression**, so I did not. A trailing `/wiki` is the only signal a Confluence-only profile on a plain site carries, and `user_info_path` reads it to choose between Jira's and Confluence's user endpoint. Normalising the stored value would have turned every such profile back into a Jira one and reintroduced the exact 401 that PR #131 existed to fix.

So the two are split: **detection reads the base as written, the client is built from the site root.** They compose, and the prefix lands exactly once. `auth login` keeps the value and prints a note that the prefix is not needed. That split also makes `CONFLUENCE_CURRENT_USER_PATH_UNPREFIXED` dead, and it is deleted.

## Verification

Reproduced against a local logging server before any edit. All four base shapes, showing the paths the server actually received:

| base_url | `auth whoami` | Confluence | Jira |
| --- | --- | --- | --- |
| `<host>` | Jira | `/wiki/api/v2/pages` | `/rest/api/3/issue/DEV-1` |
| `<host>/wiki` | Confluence | `/wiki/api/v2/pages` | `/rest/api/3/issue/DEV-1` |
| `<host>/ex/confluence/cid` | Confluence | `/ex/confluence/cid/wiki/api/v2/pages` | `/ex/confluence/cid/rest/api/3/issue/DEV-1` |
| `<host>/ex/confluence/cid/wiki` | Confluence | `/ex/confluence/cid/wiki/api/v2/pages` | `/ex/confluence/cid/rest/api/3/issue/DEV-1` |

New `crates/cli/tests/wiki_base_url_e2e.rs`, the coverage that never existed. **Three of its five tests fail against the parent commit**, checked in a worktree rather than asserted: `a_wiki_base_is_still_recognised_as_confluence` passes both ways, because #131's unprefixed constant reached the same URL by another route. It is a guard against the plausible-but-wrong fix of normalising *before* detection, and it does fail against that variant. Every test also mounts the doubled path expecting zero hits, so a regression fails loudly here instead of becoming a 404 for a user.

794 tests pass; clippy `-D warnings` clean.

## Review round

An independent review returned safe-to-merge with three minor findings, all fixed in a69d0ae:

- **The login note lied for `https://site/wiki//`.** The condition compared `site_base_url` (one trailing slash stripped) against `trim_end_matches` (all of them), so a doubled slash left the base unnormalised while login called it harmless. It still requested `/wiki/wiki/api/v2/pages`.
- **`/WIKI` was detected as Confluence but not normalised**, because detection lowercases and the strip did not. Two rules disagreeing about the same segment is the doubling again.
- **My "four of five tests fail" claim was wrong**, measured against a hybrid rather than the parent commit. It is three, and the doc now says which two do not and why.

## Behaviour change

Under a `/wiki` base, `jira api` now resolves from the site root. The old composition only ever produced 404s.

## Limitation

A self-hosted Confluence whose context path is genuinely `/wiki` would be unreachable. Not a regression in practice: this CLI targets Cloud, Confluence Server is unsupported throughout, and such an install was already broken by the doubling. Bamboo, the one Server product supported, keeps its context path.

Docs: `docs/28082026_wiki_base_url_normalisation.md`, plus `docs/index.md` and the #131 doc's open limitation now points at the fix.